### PR TITLE
Add support for attributes via UPDATE endpoint

### DIFF
--- a/etc/conf-distributed.template
+++ b/etc/conf-distributed.template
@@ -663,6 +663,14 @@ ingress.delete.shuffle = true
 //
 ingress.delete.reject = false
 
+
+//
+// Accept attributes via update endpoint with the "class{labels}{attributes} value" form.
+// It's a convenient way to update some meta without having to call /meta.
+// Note that cache entries have to expire to update a metadata so this method has to be considered as "best effort"
+//
+ingress.update.accept.attributes = false
+
 //
 // Path where the metadata cache should be dumped
 //

--- a/warp10/src/main/java/io/warp10/continuum/Configuration.java
+++ b/warp10/src/main/java/io/warp10/continuum/Configuration.java
@@ -496,7 +496,12 @@ public class Configuration {
    * to have ingress endpoints which only honor meta and update.
    */
   public static final String INGRESS_DELETE_REJECT = "ingress.delete.reject";
-  
+
+  /**
+   * Accept attributes via update endpoint
+   */
+  public static final String INGRESS_UPDATE_ACCEPT_ATTRIBUTES = "ingress.update.accept.attributes";
+
   /**
    * Path where the metadata cache should be dumped
    */
@@ -541,7 +546,7 @@ public class Configuration {
    * Size of metadata cache in number of entries
    */
   public static final String INGRESS_METADATA_CACHE_SIZE = "ingress.metadata.cache.size";
-  
+
   /**
    * Number of acceptors
    */

--- a/warp10/src/main/java/io/warp10/continuum/ingress/Ingress.java
+++ b/warp10/src/main/java/io/warp10/continuum/ingress/Ingress.java
@@ -269,8 +269,7 @@ public class Ingress extends AbstractHandler implements Runnable {
    */
   private final boolean rejectDelete;
 
-
-  private final boolean acceptAttributes;
+  final boolean acceptAttributes;
 
   public Ingress(KeyStore keystore, Properties props) {
 

--- a/warp10/src/main/java/io/warp10/continuum/ingress/IngressStreamUpdateHandler.java
+++ b/warp10/src/main/java/io/warp10/continuum/ingress/IngressStreamUpdateHandler.java
@@ -65,7 +65,7 @@ import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
 public class IngressStreamUpdateHandler extends WebSocketHandler.Simple {
     
   private final Ingress ingress;
-  
+
   @WebSocket(maxTextMessageSize=1024 * 1024, maxBinaryMessageSize=1024 * 1024)
   public static class StandaloneStreamUpdateWebSocket {
     
@@ -163,7 +163,7 @@ public class IngressStreamUpdateHandler extends WebSocketHandler.Simple {
               }
 
               try {
-                encoder = GTSHelper.parse(lastencoder, line, extraLabels, now, this.handler.ingress.maxValueSize, false);
+                encoder = GTSHelper.parse(lastencoder, line, extraLabels, now, this.handler.ingress.maxValueSize, this.handler.ingress.acceptAttributes);
               } catch (ParseException pe) {
                 Sensision.update(SensisionConstants.SENSISION_CLASS_CONTINUUM_STREAM_UPDATE_PARSEERRORS, sensisionLabels, 1);
                 throw new IOException("Parse error at '" + line + "'", pe);
@@ -344,7 +344,7 @@ public class IngressStreamUpdateHandler extends WebSocketHandler.Simple {
     super(StandaloneStreamUpdateWebSocket.class);
 
     this.ingress = ingress;
-  }      
+  }
     
   @Override
   public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneIngressHandler.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneIngressHandler.java
@@ -109,8 +109,10 @@ public class StandaloneIngressHandler extends AbstractHandler {
   private final boolean logforwarded;
   
   private final DateTimeFormatter dtf = DateTimeFormat.forPattern("yyyyMMdd'T'HHmmss.SSS").withZoneUTC();
-  
+
   private final long maxValueSize;
+
+  private final boolean acceptAttributes;
   
   public StandaloneIngressHandler(KeyStore keystore, StandaloneDirectoryClient directoryClient, StoreClient storeClient) {
     this.keyStore = keystore;
@@ -159,6 +161,9 @@ public class StandaloneIngressHandler extends AbstractHandler {
     this.logforwarded = "true".equals(props.getProperty(Configuration.DATALOG_LOGFORWARDED));
     
     this.maxValueSize = Long.parseLong(props.getProperty(Configuration.STANDALONE_VALUE_MAXSIZE, DEFAULT_VALUE_MAXSIZE));
+
+    this.acceptAttributes = "true".equals(props.getProperty(Configuration.INGRESS_UPDATE_ACCEPT_ATTRIBUTES));
+
   }
   
   @Override
@@ -479,7 +484,7 @@ public class StandaloneIngressHandler extends AbstractHandler {
           count++;
 
           try {
-            encoder = GTSHelper.parse(lastencoder, line, extraLabels, now, maxValueSize, false);
+            encoder = GTSHelper.parse(lastencoder, line, extraLabels, now, maxValueSize, acceptAttributes);
             //nano2 += System.nanoTime() - nano0;
           } catch (ParseException pe) {
             Sensision.update(SensisionConstants.SENSISION_CLASS_CONTINUUM_STANDALONE_UPDATE_PARSEERRORS, sensisionLabels, 1);            

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneStreamUpdateHandler.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneStreamUpdateHandler.java
@@ -94,7 +94,9 @@ public class StandaloneStreamUpdateHandler extends WebSocketHandler.Simple {
   private final String datalogId;
   private final byte[] datalogPSK;
   private final File loggingDir;
-  
+
+  private final boolean acceptAttributes;
+
   private final DateTimeFormatter dtf = DateTimeFormat.forPattern("yyyyMMdd'T'HHmmss.SSS").withZoneUTC();
 
   @WebSocket(maxTextMessageSize=1024 * 1024, maxBinaryMessageSize=1024 * 1024)
@@ -111,7 +113,8 @@ public class StandaloneStreamUpdateHandler extends WebSocketHandler.Simple {
     private WriteToken wtoken;
 
     private String encodedToken;
-    
+
+
     /**
      * Cache used to determine if we should push metadata into Kafka or if it was previously seen.
      * Key is a BigInteger constructed from a byte array of classId+labelsId (we cannot use byte[] as map key)
@@ -290,7 +293,7 @@ public class StandaloneStreamUpdateHandler extends WebSocketHandler.Simple {
               }
 
               try {
-                encoder = GTSHelper.parse(lastencoder, line, extraLabels, now);
+                encoder = GTSHelper.parse(lastencoder, line, extraLabels, now, Long.MAX_VALUE, handler.acceptAttributes);
               } catch (ParseException pe) {
                 Sensision.update(SensisionConstants.SENSISION_CLASS_CONTINUUM_STANDALONE_STREAM_UPDATE_PARSEERRORS, sensisionLabels, 1);
                 throw new IOException("Parse error at '" + line + "'", pe);
@@ -479,7 +482,9 @@ public class StandaloneStreamUpdateHandler extends WebSocketHandler.Simple {
     this.storeClient = storeClient;
     this.directoryClient = directoryClient;
     this.properties = properties;
-    
+
+    this.acceptAttributes = "true".equals(properties.getProperty(Configuration.INGRESS_UPDATE_ACCEPT_ATTRIBUTES));
+
     if (properties.containsKey(Configuration.DATALOG_DIR)) {
       File dir = new File(properties.getProperty(Configuration.DATALOG_DIR));
       


### PR DESCRIPTION
This PR allows for pushing attributes directly from a update endpoint.

This way, a source push metrics with the form "class{labels}{atttibutes} value"  and at cache expiration, the new meta will be taken into account.

This has to be considered as a best effort meta update in contrast to what /meta provides.