### PR TITLE
Fix for retrocompatibility of FIND signature without LIST or MAP.

### DIFF
--- a/warp10/src/main/java/io/warp10/script/functions/FIND.java
+++ b/warp10/src/main/java/io/warp10/script/functions/FIND.java
@@ -155,8 +155,11 @@ public class FIND extends NamedWarpScriptFunction implements WarpScriptStackFunc
       if (this.metaset) {
         throw new WarpScriptException(getName() + " expects a list of parameters on top of the stack.");
       }
-      mapparams = ((Map)top).containsKey(FETCH.PARAM_TOKEN);
       //syntax error tolerance for older systems : $readtoken 'classselector' { labels selector } FIND
+      mapparams = ((Map)top).containsKey(FETCH.PARAM_TOKEN) &&
+              (((Map)top).containsKey(FETCH.PARAM_SELECTORS) || ((Map)top).containsKey(FETCH.PARAM_SELECTOR) ||
+              (((Map)top).containsKey(FETCH.PARAM_CLASS) && ((Map)top).containsKey(FETCH.PARAM_LABELS)));
+
     } else {
       if (this.metaset) {
         throw new WarpScriptException(getName() + " expects a list of parameters.");

--- a/warp10/src/main/java/io/warp10/script/functions/FIND.java
+++ b/warp10/src/main/java/io/warp10/script/functions/FIND.java
@@ -159,7 +159,6 @@ public class FIND extends NamedWarpScriptFunction implements WarpScriptStackFunc
       mapparams = ((Map)top).containsKey(FETCH.PARAM_TOKEN) &&
               (((Map)top).containsKey(FETCH.PARAM_SELECTORS) || ((Map)top).containsKey(FETCH.PARAM_SELECTOR) ||
               (((Map)top).containsKey(FETCH.PARAM_CLASS) && ((Map)top).containsKey(FETCH.PARAM_LABELS)));
-
     } else {
       if (this.metaset) {
         throw new WarpScriptException(getName() + " expects a list of parameters.");

--- a/warp10/src/main/java/io/warp10/script/functions/FIND.java
+++ b/warp10/src/main/java/io/warp10/script/functions/FIND.java
@@ -155,7 +155,8 @@ public class FIND extends NamedWarpScriptFunction implements WarpScriptStackFunc
       if (this.metaset) {
         throw new WarpScriptException(getName() + " expects a list of parameters on top of the stack.");
       }
-      mapparams = true;
+      mapparams = ((Map)top).containsKey(FETCH.PARAM_TOKEN);
+      //syntax error tolerance for older systems : $readtoken 'classselector' { labels selector } FIND
     } else {
       if (this.metaset) {
         throw new WarpScriptException(getName() + " expects a list of parameters.");


### PR DESCRIPTION
Somewhere in the wild, there is some warpscripts which REXEC "readtoken classname {} FIND", without the LIST nor the MAP syntax. This was working in Warp 10 1.x.