### PR TITLE
Handler now handles only REQUEST to avoid being called twice when there is an error.

### DIFF
--- a/warp10/src/main/java/io/warp10/plugins/http/WarpScriptHandler.java
+++ b/warp10/src/main/java/io/warp10/plugins/http/WarpScriptHandler.java
@@ -24,6 +24,7 @@ import org.eclipse.jetty.http.MimeTypes;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 
+import javax.servlet.DispatcherType;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -50,6 +51,12 @@ public class WarpScriptHandler extends AbstractHandler {
 
   @Override
   public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException {
+    // Only handle REQUEST
+    if(DispatcherType.REQUEST != baseRequest.getDispatcherType()){
+      baseRequest.setHandled(true);
+      return;
+    }
+
     String prefix = this.plugin.getPrefix(target);
     Macro macro = this.plugin.getMacro(prefix);
 


### PR DESCRIPTION
When a macro creates an exception on the initial REQUEST, the handler is called again to handle the ERROR, thus calling the macro twice.
This PR avoid the call of the macro for the ERROR handling.