### PR TITLE
Fix FILL and fillers

### DIFF
--- a/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
+++ b/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
@@ -3703,8 +3703,6 @@ public class GTSHelper {
     int idxa = 0;
     int idxb = 0;
     
-    int previdxA = -1;
-    int previdxB = -1;
     Long curTickA = null;
     Long curTickB = null;
     
@@ -3764,9 +3762,6 @@ public class GTSHelper {
         continue;
       }
 
-      previdxA = idxa - 1;
-      previdxB = idxb - 1;      
-
       //
       // Determine if we should fill GTS A or GTS B
       //
@@ -3807,22 +3802,28 @@ public class GTSHelper {
         // We should fill GTS A
         
         filled = ga;
-        
+
         for (int i = prewindow - 1; i >= 0; i--) {
-          if (previdxA - i >= 0) {
-            prev[i][0] = gtsa.ticks[previdxA - i];
-            prev[i][1] = locationAtIndex(gtsa, previdxA - i);
-            prev[i][2] = elevationAtIndex(gtsa, previdxA - i);
-            prev[i][3] = valueAtIndex(gtsa, previdxA - i);
+          int ia = idxa - prewindow + i;
+          if (ia >= 0) {
+            prev[i][0] = gtsa.ticks[ia];
+            prev[i][1] = locationAtIndex(gtsa, ia);
+            prev[i][2] = elevationAtIndex(gtsa, ia);
+            prev[i][3] = valueAtIndex(gtsa, ia);
+          } else {
+            break; // No more element to add
           }
         }
 
         for (int i = 0; i < postwindow; i++) {
-          if (idxa + i < gtsa.values) {
-            next[i][0] = gtsa.ticks[idxa + i];
-            next[i][1] = locationAtIndex(gtsa, idxa + i);
-            next[i][2] = elevationAtIndex(gtsa, idxa + i);
-            next[i][3] = valueAtIndex(gtsa, idxa + i);
+          int ia = idxa + i;
+          if (ia < gtsa.values) {
+            next[i][0] = gtsa.ticks[ia];
+            next[i][1] = locationAtIndex(gtsa, ia);
+            next[i][2] = elevationAtIndex(gtsa, ia);
+            next[i][3] = valueAtIndex(gtsa, ia);
+          } else {
+            break; // No more element to add
           }
         }
       
@@ -3844,22 +3845,28 @@ public class GTSHelper {
         // We should fill GTS B
       
         filled = gb;
-        
+
         for (int i = prewindow - 1; i >= 0; i--) {
-          if (previdxB - i >= 0) {
-            prev[i][0] = gtsb.ticks[previdxB - i];
-            prev[i][1] = locationAtIndex(gtsb, previdxB - i);
-            prev[i][2] = elevationAtIndex(gtsb, previdxB - i);
-            prev[i][3] = valueAtIndex(gtsb, previdxB - i);
+          int ib = idxb - prewindow + i;
+          if (ib >= 0) {
+            prev[i][0] = gtsb.ticks[ib];
+            prev[i][1] = locationAtIndex(gtsb, ib);
+            prev[i][2] = elevationAtIndex(gtsb, ib);
+            prev[i][3] = valueAtIndex(gtsb, ib);
+          } else {
+            break; // No more element to add
           }
         }
 
         for (int i = 0; i < postwindow; i++) {
-          if (idxb + i < gtsb.values) {
-            next[i][0] = gtsb.ticks[idxb + i];
-            next[i][1] = locationAtIndex(gtsb, idxb + i);
-            next[i][2] = elevationAtIndex(gtsb, idxb + i);
-            next[i][3] = valueAtIndex(gtsb, idxb + i);
+          int ib = idxb + i;
+          if (ib < gtsb.values) {
+            next[i][0] = gtsb.ticks[ib];
+            next[i][1] = locationAtIndex(gtsb, ib);
+            next[i][2] = elevationAtIndex(gtsb, ib);
+            next[i][3] = valueAtIndex(gtsb, ib);
+          } else {
+            break; // No more element to add
           }
         }
         

--- a/warp10/src/main/java/io/warp10/script/filler/FillerInterpolate.java
+++ b/warp10/src/main/java/io/warp10/script/filler/FillerInterpolate.java
@@ -83,14 +83,14 @@ public class FillerInterpolate extends NamedWarpScriptFunction implements WarpSc
       double[] prevlatlon = GeoXPLib.fromGeoXPPoint(prevloc);
       double[] nextlatlon = GeoXPLib.fromGeoXPPoint(nextloc);
       
-      double lat = prevlatlon[0] + rate * ((nextlatlon[0] - prevlatlon[0]) / span);
-      double lon = prevlatlon[1] + rate * ((nextlatlon[1] - prevlatlon[1]) / span);
+      double lat = prevlatlon[0] + delta * ((nextlatlon[0] - prevlatlon[0]) / span);
+      double lon = prevlatlon[1] + delta * ((nextlatlon[1] - prevlatlon[1]) / span);
       
       location = GeoXPLib.toGeoXPPoint(lat, lon);
     }
     
     if (GeoTimeSerie.NO_ELEVATION != prevelev && GeoTimeSerie.NO_ELEVATION != nextelev) {
-      elevation = (long) Math.round(prevelev + ((nextelev - prevelev) / (double) span) * rate);
+      elevation = (long) Math.round(prevelev + delta * ((nextelev - prevelev) / (double) span));
     }
     
     results[0] = tick;

--- a/warp10/src/main/java/io/warp10/script/filler/FillerTrend.java
+++ b/warp10/src/main/java/io/warp10/script/filler/FillerTrend.java
@@ -102,7 +102,7 @@ public class FillerTrend extends NamedWarpScriptFunction implements WarpScriptFi
       // We will compute the average of the projected previous and next datapoints
       long span = ((Number) next[0]).longValue() - ((Number) prev[0]).longValue();
       long delta = ((Number) other[0]).longValue() - ((Number) prev[0]).longValue();
-      double alpha = (((Number) other[0]).longValue() - ((Number) prev[0]).longValue()) / span;
+      double alpha = (double) delta / span;
       
       double projectedPrevious = ((Number) prev[3]).doubleValue() + delta * prerate;
       double projectedNext = ((Number) next[3]).doubleValue() - (span - delta) * postrate;


### PR DESCRIPTION
- GTSHelper.fill previous array is now in correct order
- FillerTrend uses a floating-point division for alpha
- FillerInterpolate uses delta instead of rate for location and elevation