### PR TITLE
Add type check to */- operations involving a GTS and a value.

### DIFF
--- a/warp10/src/main/java/io/warp10/script/binary/DIV.java
+++ b/warp10/src/main/java/io/warp10/script/binary/DIV.java
@@ -143,7 +143,7 @@ public class DIV extends NamedWarpScriptFunction implements WarpScriptStackFunct
       }
 
       stack.push(result);
-    } else if (op1 instanceof GeoTimeSerie || op2 instanceof GeoTimeSerie) {
+    } else if ((op1 instanceof GeoTimeSerie && op2 instanceof Number )|| (op1 instanceof Number && op2 instanceof GeoTimeSerie)) {
       boolean op1gts = op1 instanceof GeoTimeSerie;
       
       int n = op1gts ? GTSHelper.nvalues((GeoTimeSerie) op1) : GTSHelper.nvalues((GeoTimeSerie) op2);

--- a/warp10/src/main/java/io/warp10/script/binary/DIV.java
+++ b/warp10/src/main/java/io/warp10/script/binary/DIV.java
@@ -143,7 +143,7 @@ public class DIV extends NamedWarpScriptFunction implements WarpScriptStackFunct
       }
 
       stack.push(result);
-    } else if ((op1 instanceof GeoTimeSerie && op2 instanceof Number )|| (op1 instanceof Number && op2 instanceof GeoTimeSerie)) {
+    } else if ((op1 instanceof GeoTimeSerie && op2 instanceof Number) || (op1 instanceof Number && op2 instanceof GeoTimeSerie)) {
       boolean op1gts = op1 instanceof GeoTimeSerie;
       
       int n = op1gts ? GTSHelper.nvalues((GeoTimeSerie) op1) : GTSHelper.nvalues((GeoTimeSerie) op2);

--- a/warp10/src/main/java/io/warp10/script/binary/MUL.java
+++ b/warp10/src/main/java/io/warp10/script/binary/MUL.java
@@ -146,7 +146,7 @@ public class MUL extends NamedWarpScriptFunction implements WarpScriptStackFunct
       }
 
       stack.push(result);
-    } else if ((op1 instanceof GeoTimeSerie && op2 instanceof Number )|| (op1 instanceof Number && op2 instanceof GeoTimeSerie)) {
+    } else if ((op1 instanceof GeoTimeSerie && op2 instanceof Number) || (op1 instanceof Number && op2 instanceof GeoTimeSerie)) {
       boolean op1gts = op1 instanceof GeoTimeSerie;
       
       int n = op1gts ? GTSHelper.nvalues((GeoTimeSerie) op1) : GTSHelper.nvalues((GeoTimeSerie) op2);

--- a/warp10/src/main/java/io/warp10/script/binary/MUL.java
+++ b/warp10/src/main/java/io/warp10/script/binary/MUL.java
@@ -146,7 +146,7 @@ public class MUL extends NamedWarpScriptFunction implements WarpScriptStackFunct
       }
 
       stack.push(result);
-    } else if (op1 instanceof GeoTimeSerie || op2 instanceof GeoTimeSerie) {
+    } else if ((op1 instanceof GeoTimeSerie && op2 instanceof Number )|| (op1 instanceof Number && op2 instanceof GeoTimeSerie)) {
       boolean op1gts = op1 instanceof GeoTimeSerie;
       
       int n = op1gts ? GTSHelper.nvalues((GeoTimeSerie) op1) : GTSHelper.nvalues((GeoTimeSerie) op2);

--- a/warp10/src/main/java/io/warp10/script/binary/SUB.java
+++ b/warp10/src/main/java/io/warp10/script/binary/SUB.java
@@ -146,7 +146,7 @@ public class SUB extends NamedWarpScriptFunction implements WarpScriptStackFunct
       }
 
       stack.push(result);
-    } else if ((op1 instanceof GeoTimeSerie && op2 instanceof Number )|| (op1 instanceof Number && op2 instanceof GeoTimeSerie)) {
+    } else if ((op1 instanceof GeoTimeSerie && op2 instanceof Number) || (op1 instanceof Number && op2 instanceof GeoTimeSerie)) {
       boolean op1gts = op1 instanceof GeoTimeSerie;
       
       int n = op1gts ? GTSHelper.nvalues((GeoTimeSerie) op1) : GTSHelper.nvalues((GeoTimeSerie) op2);

--- a/warp10/src/main/java/io/warp10/script/binary/SUB.java
+++ b/warp10/src/main/java/io/warp10/script/binary/SUB.java
@@ -146,7 +146,7 @@ public class SUB extends NamedWarpScriptFunction implements WarpScriptStackFunct
       }
 
       stack.push(result);
-    } else if (op1 instanceof GeoTimeSerie || op2 instanceof GeoTimeSerie) {
+    } else if ((op1 instanceof GeoTimeSerie && op2 instanceof Number )|| (op1 instanceof Number && op2 instanceof GeoTimeSerie)) {
       boolean op1gts = op1 instanceof GeoTimeSerie;
       
       int n = op1gts ? GTSHelper.nvalues((GeoTimeSerie) op1) : GTSHelper.nvalues((GeoTimeSerie) op2);


### PR DESCRIPTION
Makes error message clearer.

Example:
```NEWGTS 'a' /```

- without PR returns:
`java.lang.String cannot be cast to java.lang.Number`
- with this PR returns:
`/ can only operate on numeric values or Geo Time Series .`