### PR TITLE
Fix mapper output

### DIFF
--- a/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
+++ b/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
@@ -4697,8 +4697,8 @@ public class GTSHelper {
       }
 
       if (mapResult instanceof Map) {
+        hasSingleResult = false;
         for (Entry<Object, Object> entry : ((Map<Object, Object>) mapResult).entrySet()) {
-          hasSingleResult = false;
           GeoTimeSerie mgts = multipleMapped.get(entry.getKey().toString());
           if (null == mgts) {
             mgts = mapped.cloneEmpty();

--- a/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
+++ b/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
@@ -4462,7 +4462,7 @@ public class GTSHelper {
 
     Map<String, GeoTimeSerie> multipleMapped = new TreeMap<String, GeoTimeSerie>();
 
-    boolean hasSingleResult = false;
+    boolean hasSingleResult = true;
 
     while (idx < nticks) {
 
@@ -4698,6 +4698,7 @@ public class GTSHelper {
 
       if (mapResult instanceof Map) {
         for (Entry<Object, Object> entry : ((Map<Object, Object>) mapResult).entrySet()) {
+          hasSingleResult = false;
           GeoTimeSerie mgts = multipleMapped.get(entry.getKey().toString());
           if (null == mgts) {
             mgts = mapped.cloneEmpty();
@@ -4721,7 +4722,7 @@ public class GTSHelper {
         // Set value if it was not null. Don't overwrite, we scan ticks only once
         //
 
-        hasSingleResult = true;
+
 
         if (null != result[3]) {
           GTSHelper.setValue(mapped, overrideTick ? (long) result[0] : tick, (long) result[1], (long) result[2], result[3], false);


### PR DESCRIPTION
Fix the output when applying a multiple output macromapper on a bucketized serie. The empty original serie is not returned anymore among the results.
It does not change the default behavior of classic mappers (list output). 

new unit tests ready if accepted.
