### PR TITLE
Fix some unit tests

### DIFF
--- a/token/src/test/groovy/io/warp10/token/test/TestReadToken.groovy
+++ b/token/src/test/groovy/io/warp10/token/test/TestReadToken.groovy
@@ -144,9 +144,9 @@ class TestReadToken extends TokenTestCase {
         String uuid = UUID.randomUUID().toString()
         String readToken = tokenEncoder.deliverReadToken("app", uuid, uuid, ["app"], 32468, getKeyStore())
 
-        // corrupt the token (pick a random character and increment it)
+        // corrupt the token (pick a random character and decrement it)
         char c1 = readToken.charAt(new Random().nextInt(60))
-        char c2 = c1 + 1
+        char c2 = c1 - 1
         readToken = readToken.replace(c1, c2)
 
         QuasarTokenFilter tokenFilter = new QuasarTokenFilter(getConfig(), getKeyStore())

--- a/token/src/test/groovy/io/warp10/token/test/TestWriteToken.groovy
+++ b/token/src/test/groovy/io/warp10/token/test/TestWriteToken.groovy
@@ -158,9 +158,9 @@ class TestWriteToken extends TokenTestCase {
         String uuid = UUID.randomUUID().toString()
         String writeToken = tokenEncoder.deliverWriteToken("app", uuid, 32478, getKeyStore())
 
-        // corrupt the token (pick a random character and increment it)
+        // corrupt the token (pick a random character and decrement it)
         char c1 = writeToken.charAt(new Random().nextInt(60))
-        char c2 = c1 + 1
+        char c2 = c1 - 1
         writeToken = writeToken.replace(c1, c2)
 
         QuasarTokenFilter tokenFilter = new QuasarTokenFilter(getConfig(), getKeyStore())


### PR DESCRIPTION
64 code indices are encoded by more characters. We replace incrementing by decrementing in the tests since incrementing sometimes provoke a collision