### PR TITLE
boolean, bitwise and comparison operators on GTS

### DIFF
--- a/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
+++ b/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
@@ -10270,4 +10270,8 @@ public class GTSHelper {
   public static double skewness(GeoTimeSerie gts, boolean bessel) throws WarpScriptException {
     return standardizedMoment(3, gts, bessel);
   }
+
+  public static void booleanNot(GeoTimeSerie gts) {
+    gts.booleanValues.flip(0, gts.booleanValues.length());
+  }
 }

--- a/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
+++ b/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
@@ -10271,7 +10271,11 @@ public class GTSHelper {
     return standardizedMoment(3, gts, bessel);
   }
 
-  public static void booleanNot(GeoTimeSerie gts) {
-    gts.booleanValues.flip(0, gts.booleanValues.length());
+  public static void booleanNot(GeoTimeSerie gts) throws WarpScriptException {
+    if (GeoTimeSerie.TYPE.BOOLEAN == gts.getType()) {
+      gts.booleanValues.flip(0, gts.booleanValues.length());
+    } else {
+      throw new WarpScriptException("Non boolean Geo Time Series.");
+    }
   }
 }

--- a/warp10/src/main/java/io/warp10/continuum/gts/GTSOpsHelper.java
+++ b/warp10/src/main/java/io/warp10/continuum/gts/GTSOpsHelper.java
@@ -20,8 +20,10 @@ public class GTSOpsHelper {
   public static interface GTSBinaryOp {
     public Object op(GeoTimeSerie gtsa, GeoTimeSerie gtsb, int idxa, int idxb);
   }
-    
   public static void applyBinaryOp(GeoTimeSerie result, GeoTimeSerie gts1, GeoTimeSerie gts2, GTSBinaryOp op) {
+    applyBinaryOp(result, gts1, gts2, op,false);
+  }
+  public static void applyBinaryOp(GeoTimeSerie result, GeoTimeSerie gts1, GeoTimeSerie gts2, GTSBinaryOp op, boolean copyGts1Location) {
     //
     // Determine if result should be bucketized or not
     //
@@ -49,7 +51,7 @@ public class GTSOpsHelper {
     // Sweeping line over the timestamps
     int idxa = 0;
     int idxb = 0;
-             
+    
     int na = GTSHelper.nvalues(gts1);
     int nb = GTSHelper.nvalues(gts2);
     
@@ -62,7 +64,9 @@ public class GTSOpsHelper {
     if (idxb < na) {
       tsb = GTSHelper.tickAtIndex(gts2, idxb);
     }
-
+  
+    Object value;
+  
     while(idxa < na || idxb < nb) {
       if (idxa >= na) {
         tsa = null;
@@ -74,7 +78,14 @@ public class GTSOpsHelper {
         // We have values at the current index for both GTS
         if (0 == tsa.compareTo(tsb)) {
           // Both indices indicate the same timestamp
-          GTSHelper.setValue(result, tsa, op.op(gts1, gts2, idxa, idxb));
+          if (copyGts1Location) {
+            value = op.op(gts1, gts2, idxa, idxb);
+            if (null != value) {
+              GTSHelper.setValue(result, tsa,GTSHelper.locationAtIndex(gts1,idxa),GTSHelper.elevationAtIndex(gts1,idxa),value,false);
+            }
+          } else {
+            GTSHelper.setValue(result, tsa, op.op(gts1, gts2, idxa, idxb));
+          }
           // Advance both indices
           idxa++;
           idxb++;

--- a/warp10/src/main/java/io/warp10/continuum/gts/GTSOpsHelper.java
+++ b/warp10/src/main/java/io/warp10/continuum/gts/GTSOpsHelper.java
@@ -64,9 +64,7 @@ public class GTSOpsHelper {
     if (idxb < na) {
       tsb = GTSHelper.tickAtIndex(gts2, idxb);
     }
-  
-    Object value;
-  
+    
     while(idxa < na || idxb < nb) {
       if (idxa >= na) {
         tsa = null;

--- a/warp10/src/main/java/io/warp10/continuum/gts/GTSOpsHelper.java
+++ b/warp10/src/main/java/io/warp10/continuum/gts/GTSOpsHelper.java
@@ -79,10 +79,7 @@ public class GTSOpsHelper {
         if (0 == tsa.compareTo(tsb)) {
           // Both indices indicate the same timestamp
           if (copyGts1Location) {
-            value = op.op(gts1, gts2, idxa, idxb);
-            if (null != value) {
-              GTSHelper.setValue(result, tsa,GTSHelper.locationAtIndex(gts1,idxa),GTSHelper.elevationAtIndex(gts1,idxa),value,false);
-            }
+            GTSHelper.setValue(result, tsa,GTSHelper.locationAtIndex(gts1,idxa),GTSHelper.elevationAtIndex(gts1,idxa),op.op(gts1, gts2, idxa, idxb),false);
           } else {
             GTSHelper.setValue(result, tsa, op.op(gts1, gts2, idxa, idxb));
           }

--- a/warp10/src/main/java/io/warp10/script/binary/BitwiseAND.java
+++ b/warp10/src/main/java/io/warp10/script/binary/BitwiseAND.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2019  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.

--- a/warp10/src/main/java/io/warp10/script/binary/BitwiseAND.java
+++ b/warp10/src/main/java/io/warp10/script/binary/BitwiseAND.java
@@ -27,59 +27,15 @@ import io.warp10.script.WarpScriptStack;
 /**
  * Bitwise AND of the two operands on top of the stack
  */
-public class BitwiseAND extends NamedWarpScriptFunction implements WarpScriptStackFunction {
+public class BitwiseAND extends BitwiseOperation {
 
   public BitwiseAND(String name) {
     super(name);
   }
-  
+
   @Override
-  public Object apply(WarpScriptStack stack) throws WarpScriptException {
-    Object op2 = stack.pop();
-    Object op1 = stack.pop();
-    
-    if (op2 instanceof Long && op1 instanceof Long) {
-      stack.push(((Long) op1).longValue() & ((Long) op2).longValue());
-    } else if (op1 instanceof GeoTimeSerie && op2 instanceof GeoTimeSerie) {
-      GeoTimeSerie gts1 = (GeoTimeSerie) op1;
-      GeoTimeSerie gts2 = (GeoTimeSerie) op2;
-      if (GeoTimeSerie.TYPE.LONG == gts1.getType() && GeoTimeSerie.TYPE.LONG == gts2.getType()) {
-        GeoTimeSerie result = new GeoTimeSerie(Math.max(GTSHelper.nvalues(gts1), GTSHelper.nvalues(gts2)));
-        result.setType(GeoTimeSerie.TYPE.LONG);
-        GTSOpsHelper.GTSBinaryOp op = new GTSOpsHelper.GTSBinaryOp() {
-          @Override
-          public Object op(GeoTimeSerie gtsa, GeoTimeSerie gtsb, int idxa, int idxb) {
-            return ((Long) GTSHelper.valueAtIndex(gtsa, idxa)) & ((Long) GTSHelper.valueAtIndex(gtsb, idxb));
-          }
-        };
-        GTSOpsHelper.applyBinaryOp(result, gts1, gts2, op);
-        stack.push(result);
-      } else {
-        throw new WarpScriptException(getName() + " can only operate on long values or long GTS.");
-      }
-    } else if (op1 instanceof GeoTimeSerie || op2 instanceof GeoTimeSerie) {
-      GeoTimeSerie gts;
-      Long mask;
-      if (op1 instanceof GeoTimeSerie && op2 instanceof Long) {
-        gts = (GeoTimeSerie)op1;
-        mask = (Long)op2;
-      } else if (op2 instanceof GeoTimeSerie && op1 instanceof Long) {
-        gts = (GeoTimeSerie)op2;
-        mask = (Long)op1;
-      } else {
-        throw new WarpScriptException(getName() + " can only operate two GTS or one GTS and a long value.");
-      }
-      GeoTimeSerie result = gts.cloneEmpty();
-      result.setType(GeoTimeSerie.TYPE.LONG);
-      for (int i = 0; i < GTSHelper.nvalues(gts); i++) {
-        GTSHelper.setValue(result, GTSHelper.tickAtIndex(gts, i), GTSHelper.locationAtIndex(gts, i), GTSHelper.elevationAtIndex(gts, i),
-                mask & ((Number)GTSHelper.valueAtIndex(gts,i)).longValue() , false);
-      }
-      stack.push(result);
-    } else {
-      throw new WarpScriptException(getName() + " can only operate on long values or boolean GTS.");
-    }
-    
-    return stack;
+  public long operator(long op1, long op2) {
+    return op1 & op2;
   }
+
 }

--- a/warp10/src/main/java/io/warp10/script/binary/BitwiseAND.java
+++ b/warp10/src/main/java/io/warp10/script/binary/BitwiseAND.java
@@ -43,20 +43,39 @@ public class BitwiseAND extends NamedWarpScriptFunction implements WarpScriptSta
     } else if (op1 instanceof GeoTimeSerie && op2 instanceof GeoTimeSerie) {
       GeoTimeSerie gts1 = (GeoTimeSerie) op1;
       GeoTimeSerie gts2 = (GeoTimeSerie) op2;
-      if (GeoTimeSerie.TYPE.BOOLEAN == gts1.getType() && GeoTimeSerie.TYPE.BOOLEAN == gts2.getType()) {
+      if (GeoTimeSerie.TYPE.LONG == gts1.getType() && GeoTimeSerie.TYPE.LONG == gts2.getType()) {
         GeoTimeSerie result = new GeoTimeSerie(Math.max(GTSHelper.nvalues(gts1), GTSHelper.nvalues(gts2)));
-        result.setType(GeoTimeSerie.TYPE.BOOLEAN);
+        result.setType(GeoTimeSerie.TYPE.LONG);
         GTSOpsHelper.GTSBinaryOp op = new GTSOpsHelper.GTSBinaryOp() {
           @Override
           public Object op(GeoTimeSerie gtsa, GeoTimeSerie gtsb, int idxa, int idxb) {
-          return ((Boolean) GTSHelper.valueAtIndex(gtsa, idxa)) && ((Boolean) GTSHelper.valueAtIndex(gtsb, idxb));
+            return ((Long) GTSHelper.valueAtIndex(gtsa, idxa)) & ((Long) GTSHelper.valueAtIndex(gtsb, idxb));
           }
         };
         GTSOpsHelper.applyBinaryOp(result, gts1, gts2, op);
         stack.push(result);
       } else {
-        throw new WarpScriptException(getName() + " can only operate on long values or boolean GTS.");
+        throw new WarpScriptException(getName() + " can only operate on long values or long GTS.");
       }
+    } else if (op1 instanceof GeoTimeSerie || op2 instanceof GeoTimeSerie) {
+      GeoTimeSerie gts;
+      Long mask;
+      if (op1 instanceof GeoTimeSerie && op2 instanceof Long) {
+        gts = (GeoTimeSerie)op1;
+        mask = (Long)op2;
+      } else if (op2 instanceof GeoTimeSerie && op1 instanceof Long) {
+        gts = (GeoTimeSerie)op2;
+        mask = (Long)op1;
+      } else {
+        throw new WarpScriptException(getName() + " can only operate two GTS or one GTS and a long value.");
+      }
+      GeoTimeSerie result = gts.cloneEmpty();
+      result.setType(GeoTimeSerie.TYPE.LONG);
+      for (int i = 0; i < GTSHelper.nvalues(gts); i++) {
+        GTSHelper.setValue(result, GTSHelper.tickAtIndex(gts, i), GTSHelper.locationAtIndex(gts, i), GTSHelper.elevationAtIndex(gts, i),
+                mask & ((Number)GTSHelper.valueAtIndex(gts,i)).longValue() , false);
+      }
+      stack.push(result);
     } else {
       throw new WarpScriptException(getName() + " can only operate on long values or boolean GTS.");
     }

--- a/warp10/src/main/java/io/warp10/script/binary/BitwiseAND.java
+++ b/warp10/src/main/java/io/warp10/script/binary/BitwiseAND.java
@@ -16,6 +16,9 @@
 
 package io.warp10.script.binary;
 
+import io.warp10.continuum.gts.GTSHelper;
+import io.warp10.continuum.gts.GTSOpsHelper;
+import io.warp10.continuum.gts.GeoTimeSerie;
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptStackFunction;
 import io.warp10.script.WarpScriptException;
@@ -37,8 +40,25 @@ public class BitwiseAND extends NamedWarpScriptFunction implements WarpScriptSta
     
     if (op2 instanceof Long && op1 instanceof Long) {
       stack.push(((Long) op1).longValue() & ((Long) op2).longValue());
+    } else if (op1 instanceof GeoTimeSerie && op2 instanceof GeoTimeSerie) {
+      GeoTimeSerie gts1 = (GeoTimeSerie) op1;
+      GeoTimeSerie gts2 = (GeoTimeSerie) op2;
+      if (GeoTimeSerie.TYPE.BOOLEAN == gts1.getType() && GeoTimeSerie.TYPE.BOOLEAN == gts2.getType()) {
+        GeoTimeSerie result = new GeoTimeSerie(Math.max(GTSHelper.nvalues(gts1), GTSHelper.nvalues(gts2)));
+        result.setType(GeoTimeSerie.TYPE.BOOLEAN);
+        GTSOpsHelper.GTSBinaryOp op = new GTSOpsHelper.GTSBinaryOp() {
+          @Override
+          public Object op(GeoTimeSerie gtsa, GeoTimeSerie gtsb, int idxa, int idxb) {
+          return ((Boolean) GTSHelper.valueAtIndex(gtsa, idxa)) && ((Boolean) GTSHelper.valueAtIndex(gtsb, idxb));
+          }
+        };
+        GTSOpsHelper.applyBinaryOp(result, gts1, gts2, op);
+        stack.push(result);
+      } else {
+        throw new WarpScriptException(getName() + " can only operate on long values or boolean GTS.");
+      }
     } else {
-      throw new WarpScriptException(getName() + " can only operate on long values.");
+      throw new WarpScriptException(getName() + " can only operate on long values or boolean GTS.");
     }
     
     return stack;

--- a/warp10/src/main/java/io/warp10/script/binary/BitwiseOR.java
+++ b/warp10/src/main/java/io/warp10/script/binary/BitwiseOR.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2019  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.

--- a/warp10/src/main/java/io/warp10/script/binary/BitwiseOR.java
+++ b/warp10/src/main/java/io/warp10/script/binary/BitwiseOR.java
@@ -43,20 +43,39 @@ public class BitwiseOR extends NamedWarpScriptFunction implements WarpScriptStac
     } else if (op1 instanceof GeoTimeSerie && op2 instanceof GeoTimeSerie) {
       GeoTimeSerie gts1 = (GeoTimeSerie) op1;
       GeoTimeSerie gts2 = (GeoTimeSerie) op2;
-      if (GeoTimeSerie.TYPE.BOOLEAN == gts1.getType() && GeoTimeSerie.TYPE.BOOLEAN == gts2.getType()) {
+      if (GeoTimeSerie.TYPE.LONG == gts1.getType() && GeoTimeSerie.TYPE.LONG == gts2.getType()) {
         GeoTimeSerie result = new GeoTimeSerie(Math.max(GTSHelper.nvalues(gts1), GTSHelper.nvalues(gts2)));
-        result.setType(GeoTimeSerie.TYPE.BOOLEAN);
+        result.setType(GeoTimeSerie.TYPE.LONG);
         GTSOpsHelper.GTSBinaryOp op = new GTSOpsHelper.GTSBinaryOp() {
           @Override
           public Object op(GeoTimeSerie gtsa, GeoTimeSerie gtsb, int idxa, int idxb) {
-            return ((Boolean) GTSHelper.valueAtIndex(gtsa, idxa)) || ((Boolean) GTSHelper.valueAtIndex(gtsb, idxb));
+            return ((Long) GTSHelper.valueAtIndex(gtsa, idxa)) | ((Long) GTSHelper.valueAtIndex(gtsb, idxb));
           }
         };
         GTSOpsHelper.applyBinaryOp(result, gts1, gts2, op);
         stack.push(result);
       } else {
-        throw new WarpScriptException(getName() + " can only operate on long values or boolean GTS.");
+        throw new WarpScriptException(getName() + " can only operate on long values or long GTS.");
       }
+    } else if (op1 instanceof GeoTimeSerie || op2 instanceof GeoTimeSerie) {
+      GeoTimeSerie gts;
+      Long mask;
+      if (op1 instanceof GeoTimeSerie && op2 instanceof Long) {
+        gts = (GeoTimeSerie)op1;
+        mask = (Long)op2;
+      } else if (op2 instanceof GeoTimeSerie && op1 instanceof Long) {
+        gts = (GeoTimeSerie)op2;
+        mask = (Long)op1;
+      } else {
+        throw new WarpScriptException(getName() + " can only operate two GTS or one GTS and a long value.");
+      }
+      GeoTimeSerie result = gts.cloneEmpty();
+      result.setType(GeoTimeSerie.TYPE.LONG);
+      for (int i = 0; i < GTSHelper.nvalues(gts); i++) {
+        GTSHelper.setValue(result, GTSHelper.tickAtIndex(gts, i), GTSHelper.locationAtIndex(gts, i), GTSHelper.elevationAtIndex(gts, i),
+                mask | ((Number)GTSHelper.valueAtIndex(gts,i)).longValue() , false);
+      }
+      stack.push(result);
     } else {
       throw new WarpScriptException(getName() + " can only operate on long values.");
     }

--- a/warp10/src/main/java/io/warp10/script/binary/BitwiseOR.java
+++ b/warp10/src/main/java/io/warp10/script/binary/BitwiseOR.java
@@ -27,59 +27,15 @@ import io.warp10.script.WarpScriptStack;
 /**
  * Bitwise OR of the two operands on top of the stack
  */
-public class BitwiseOR extends NamedWarpScriptFunction implements WarpScriptStackFunction {
+public class BitwiseOR extends BitwiseOperation {
 
   public BitwiseOR(String name) {
     super(name);
   }
-  
+
   @Override
-  public Object apply(WarpScriptStack stack) throws WarpScriptException {
-    Object op2 = stack.pop();
-    Object op1 = stack.pop();
-    
-    if (op2 instanceof Long && op1 instanceof Long) {
-      stack.push(((Long) op1).longValue() | ((Long) op2).longValue());
-    } else if (op1 instanceof GeoTimeSerie && op2 instanceof GeoTimeSerie) {
-      GeoTimeSerie gts1 = (GeoTimeSerie) op1;
-      GeoTimeSerie gts2 = (GeoTimeSerie) op2;
-      if (GeoTimeSerie.TYPE.LONG == gts1.getType() && GeoTimeSerie.TYPE.LONG == gts2.getType()) {
-        GeoTimeSerie result = new GeoTimeSerie(Math.max(GTSHelper.nvalues(gts1), GTSHelper.nvalues(gts2)));
-        result.setType(GeoTimeSerie.TYPE.LONG);
-        GTSOpsHelper.GTSBinaryOp op = new GTSOpsHelper.GTSBinaryOp() {
-          @Override
-          public Object op(GeoTimeSerie gtsa, GeoTimeSerie gtsb, int idxa, int idxb) {
-            return ((Long) GTSHelper.valueAtIndex(gtsa, idxa)) | ((Long) GTSHelper.valueAtIndex(gtsb, idxb));
-          }
-        };
-        GTSOpsHelper.applyBinaryOp(result, gts1, gts2, op);
-        stack.push(result);
-      } else {
-        throw new WarpScriptException(getName() + " can only operate on long values or long GTS.");
-      }
-    } else if (op1 instanceof GeoTimeSerie || op2 instanceof GeoTimeSerie) {
-      GeoTimeSerie gts;
-      Long mask;
-      if (op1 instanceof GeoTimeSerie && op2 instanceof Long) {
-        gts = (GeoTimeSerie)op1;
-        mask = (Long)op2;
-      } else if (op2 instanceof GeoTimeSerie && op1 instanceof Long) {
-        gts = (GeoTimeSerie)op2;
-        mask = (Long)op1;
-      } else {
-        throw new WarpScriptException(getName() + " can only operate two GTS or one GTS and a long value.");
-      }
-      GeoTimeSerie result = gts.cloneEmpty();
-      result.setType(GeoTimeSerie.TYPE.LONG);
-      for (int i = 0; i < GTSHelper.nvalues(gts); i++) {
-        GTSHelper.setValue(result, GTSHelper.tickAtIndex(gts, i), GTSHelper.locationAtIndex(gts, i), GTSHelper.elevationAtIndex(gts, i),
-                mask | ((Number)GTSHelper.valueAtIndex(gts,i)).longValue() , false);
-      }
-      stack.push(result);
-    } else {
-      throw new WarpScriptException(getName() + " can only operate on long values.");
-    }
-    
-    return stack;
+  public long operator(long op1, long op2) {
+    return op1 | op2;
   }
+
 }

--- a/warp10/src/main/java/io/warp10/script/binary/BitwiseOR.java
+++ b/warp10/src/main/java/io/warp10/script/binary/BitwiseOR.java
@@ -16,6 +16,9 @@
 
 package io.warp10.script.binary;
 
+import io.warp10.continuum.gts.GTSHelper;
+import io.warp10.continuum.gts.GTSOpsHelper;
+import io.warp10.continuum.gts.GeoTimeSerie;
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptStackFunction;
 import io.warp10.script.WarpScriptException;
@@ -37,6 +40,23 @@ public class BitwiseOR extends NamedWarpScriptFunction implements WarpScriptStac
     
     if (op2 instanceof Long && op1 instanceof Long) {
       stack.push(((Long) op1).longValue() | ((Long) op2).longValue());
+    } else if (op1 instanceof GeoTimeSerie && op2 instanceof GeoTimeSerie) {
+      GeoTimeSerie gts1 = (GeoTimeSerie) op1;
+      GeoTimeSerie gts2 = (GeoTimeSerie) op2;
+      if (GeoTimeSerie.TYPE.BOOLEAN == gts1.getType() && GeoTimeSerie.TYPE.BOOLEAN == gts2.getType()) {
+        GeoTimeSerie result = new GeoTimeSerie(Math.max(GTSHelper.nvalues(gts1), GTSHelper.nvalues(gts2)));
+        result.setType(GeoTimeSerie.TYPE.BOOLEAN);
+        GTSOpsHelper.GTSBinaryOp op = new GTSOpsHelper.GTSBinaryOp() {
+          @Override
+          public Object op(GeoTimeSerie gtsa, GeoTimeSerie gtsb, int idxa, int idxb) {
+            return ((Boolean) GTSHelper.valueAtIndex(gtsa, idxa)) || ((Boolean) GTSHelper.valueAtIndex(gtsb, idxb));
+          }
+        };
+        GTSOpsHelper.applyBinaryOp(result, gts1, gts2, op);
+        stack.push(result);
+      } else {
+        throw new WarpScriptException(getName() + " can only operate on long values or boolean GTS.");
+      }
     } else {
       throw new WarpScriptException(getName() + " can only operate on long values.");
     }

--- a/warp10/src/main/java/io/warp10/script/binary/BitwiseOperation.java
+++ b/warp10/src/main/java/io/warp10/script/binary/BitwiseOperation.java
@@ -76,7 +76,7 @@ public abstract class BitwiseOperation extends NamedWarpScriptFunction implement
         stack.push(result);
       } else if (GeoTimeSerie.TYPE.UNDEFINED == gts.getType()) {
         // gts is empty return gts
-        stack.push(gts);
+        stack.push(gts.cloneEmpty());
       } else {
         throw new WarpScriptException(exceptionMessage);
       }

--- a/warp10/src/main/java/io/warp10/script/binary/BitwiseOperation.java
+++ b/warp10/src/main/java/io/warp10/script/binary/BitwiseOperation.java
@@ -23,6 +23,7 @@ import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptStack;
 import io.warp10.script.WarpScriptStackFunction;
+import io.warp10.standalone.Warp;
 
 public abstract class BitwiseOperation extends NamedWarpScriptFunction implements WarpScriptStackFunction {
 
@@ -60,25 +61,20 @@ public abstract class BitwiseOperation extends NamedWarpScriptFunction implement
       } else {
         throw new WarpScriptException(exceptionMessage);
       }
-    } else if (op1 instanceof GeoTimeSerie || op2 instanceof GeoTimeSerie) {
-      GeoTimeSerie gts;
-      long mask;
-      if (op1 instanceof GeoTimeSerie && op2 instanceof Long) {
-        gts = (GeoTimeSerie)op1;
-        mask = ((Number)op2).longValue();
-      } else if (op2 instanceof GeoTimeSerie && op1 instanceof Long) {
-        gts = (GeoTimeSerie)op2;
-        mask = ((Number)op1).longValue();
+    } else if (op1 instanceof GeoTimeSerie && op2 instanceof Long) {
+      GeoTimeSerie  gts = (GeoTimeSerie)op1;
+      long mask = ((Number)op2).longValue();
+      if (GeoTimeSerie.TYPE.LONG == gts.getType()){
+        GeoTimeSerie result = gts.cloneEmpty();
+        result.setType(GeoTimeSerie.TYPE.LONG);
+        for (int i = 0; i < GTSHelper.nvalues(gts); i++) {
+          GTSHelper.setValue(result, GTSHelper.tickAtIndex(gts, i), GTSHelper.locationAtIndex(gts, i), GTSHelper.elevationAtIndex(gts, i),
+                  operator(((Number)GTSHelper.valueAtIndex(gts,i)).longValue(), mask) , false);
+        }
+        stack.push(result);
       } else {
         throw new WarpScriptException(exceptionMessage);
       }
-      GeoTimeSerie result = gts.cloneEmpty();
-      result.setType(GeoTimeSerie.TYPE.LONG);
-      for (int i = 0; i < GTSHelper.nvalues(gts); i++) {
-        GTSHelper.setValue(result, GTSHelper.tickAtIndex(gts, i), GTSHelper.locationAtIndex(gts, i), GTSHelper.elevationAtIndex(gts, i),
-                operator(mask, ((Number)GTSHelper.valueAtIndex(gts,i)).longValue()) , false);
-      }
-      stack.push(result);
     } else {
       throw new WarpScriptException(exceptionMessage);
     }

--- a/warp10/src/main/java/io/warp10/script/binary/BitwiseOperation.java
+++ b/warp10/src/main/java/io/warp10/script/binary/BitwiseOperation.java
@@ -35,12 +35,11 @@ public abstract class BitwiseOperation extends NamedWarpScriptFunction implement
     this.op = new GTSOpsHelper.GTSBinaryOp() {
       @Override
       public Object op(GeoTimeSerie gtsa, GeoTimeSerie gtsb, int idxa, int idxb) {
-        return operator(((Long) GTSHelper.valueAtIndex(gtsa, idxa)) , ((Long) GTSHelper.valueAtIndex(gtsb, idxb)));
+        return operator(((Number) GTSHelper.valueAtIndex(gtsa, idxa)).longValue(), ((Number) GTSHelper.valueAtIndex(gtsb, idxb)).longValue());
       }
     };
   }
-
-
+  
   @Override
   public Object apply(WarpScriptStack stack) throws WarpScriptException {
     String exceptionMessage = getName() + " can only operate on two long, or two long GTS, or one long GTS and a long.";

--- a/warp10/src/main/java/io/warp10/script/binary/BitwiseOperation.java
+++ b/warp10/src/main/java/io/warp10/script/binary/BitwiseOperation.java
@@ -23,19 +23,18 @@ import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptStack;
 import io.warp10.script.WarpScriptStackFunction;
-import io.warp10.standalone.Warp;
 
 public abstract class BitwiseOperation extends NamedWarpScriptFunction implements WarpScriptStackFunction {
-
+  
   private final GTSOpsHelper.GTSBinaryOp op = new GTSOpsHelper.GTSBinaryOp() {
     @Override
     public Object op(GeoTimeSerie gtsa, GeoTimeSerie gtsb, int idxa, int idxb) {
       return operator(((Number) GTSHelper.valueAtIndex(gtsa, idxa)).longValue(), ((Number) GTSHelper.valueAtIndex(gtsb, idxb)).longValue());
     }
   };
-
+  
   public abstract long operator(long op1, long op2);
-
+  
   public BitwiseOperation(String name) {
     super(name);
   }
@@ -43,10 +42,10 @@ public abstract class BitwiseOperation extends NamedWarpScriptFunction implement
   @Override
   public Object apply(WarpScriptStack stack) throws WarpScriptException {
     String exceptionMessage = getName() + " can only operate on two long, or two long GTS, or one long GTS and a long.";
-
+    
     Object op2 = stack.pop();
     Object op1 = stack.pop();
-
+    
     if (op2 instanceof Long && op1 instanceof Long) {
       stack.push(operator(((Long) op1).longValue(), ((Long) op2).longValue()));
     } else if (op1 instanceof GeoTimeSerie && op2 instanceof GeoTimeSerie) {
@@ -58,21 +57,21 @@ public abstract class BitwiseOperation extends NamedWarpScriptFunction implement
         GTSOpsHelper.applyBinaryOp(result, gts1, gts2, op);
         stack.push(result);
       } else if ((GeoTimeSerie.TYPE.UNDEFINED == gts1.getType() && GeoTimeSerie.TYPE.LONG == gts2.getType())
-              || (GeoTimeSerie.TYPE.UNDEFINED == gts2.getType() && GeoTimeSerie.TYPE.LONG == gts1.getType())) {
+          || (GeoTimeSerie.TYPE.UNDEFINED == gts2.getType() && GeoTimeSerie.TYPE.LONG == gts1.getType())) {
         // gts1 or gts2 empty, return an empty gts
         stack.push(new GeoTimeSerie());
       } else {
         throw new WarpScriptException(exceptionMessage);
       }
     } else if (op1 instanceof GeoTimeSerie && op2 instanceof Long) {
-      GeoTimeSerie  gts = (GeoTimeSerie)op1;
-      long mask = ((Number)op2).longValue();
-      if (GeoTimeSerie.TYPE.LONG == gts.getType()){
+      GeoTimeSerie gts = (GeoTimeSerie) op1;
+      long mask = ((Number) op2).longValue();
+      if (GeoTimeSerie.TYPE.LONG == gts.getType()) {
         GeoTimeSerie result = gts.cloneEmpty();
         result.setType(GeoTimeSerie.TYPE.LONG);
         for (int i = 0; i < GTSHelper.nvalues(gts); i++) {
           GTSHelper.setValue(result, GTSHelper.tickAtIndex(gts, i), GTSHelper.locationAtIndex(gts, i), GTSHelper.elevationAtIndex(gts, i),
-                  operator(((Number)GTSHelper.valueAtIndex(gts,i)).longValue(), mask) , false);
+              operator(((Number) GTSHelper.valueAtIndex(gts, i)).longValue(), mask), false);
         }
         stack.push(result);
       } else if (GeoTimeSerie.TYPE.UNDEFINED == gts.getType()) {
@@ -84,7 +83,7 @@ public abstract class BitwiseOperation extends NamedWarpScriptFunction implement
     } else {
       throw new WarpScriptException(exceptionMessage);
     }
-
+    
     return stack;
   }
 }

--- a/warp10/src/main/java/io/warp10/script/binary/BitwiseOperation.java
+++ b/warp10/src/main/java/io/warp10/script/binary/BitwiseOperation.java
@@ -1,0 +1,89 @@
+//
+//   Copyright 2019  SenX S.A.S.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+package io.warp10.script.binary;
+
+import io.warp10.continuum.gts.GTSHelper;
+import io.warp10.continuum.gts.GTSOpsHelper;
+import io.warp10.continuum.gts.GeoTimeSerie;
+import io.warp10.script.NamedWarpScriptFunction;
+import io.warp10.script.WarpScriptException;
+import io.warp10.script.WarpScriptStack;
+import io.warp10.script.WarpScriptStackFunction;
+
+public abstract class BitwiseOperation extends NamedWarpScriptFunction implements WarpScriptStackFunction {
+
+  private GTSOpsHelper.GTSBinaryOp op;
+
+  public abstract long operator(long op1, long op2);
+
+  public BitwiseOperation(String name) {
+    super(name);
+    this.op = new GTSOpsHelper.GTSBinaryOp() {
+      @Override
+      public Object op(GeoTimeSerie gtsa, GeoTimeSerie gtsb, int idxa, int idxb) {
+        return operator(((Long) GTSHelper.valueAtIndex(gtsa, idxa)) , ((Long) GTSHelper.valueAtIndex(gtsb, idxb)));
+      }
+    };
+  }
+
+
+  @Override
+  public Object apply(WarpScriptStack stack) throws WarpScriptException {
+    String exceptionMessage = getName() + " can only operate on two long, or two long GTS, or one long GTS and a long.";
+
+    Object op2 = stack.pop();
+    Object op1 = stack.pop();
+
+    if (op2 instanceof Long && op1 instanceof Long) {
+      stack.push(operator(((Long) op1).longValue(), ((Long) op2).longValue()));
+    } else if (op1 instanceof GeoTimeSerie && op2 instanceof GeoTimeSerie) {
+      GeoTimeSerie gts1 = (GeoTimeSerie) op1;
+      GeoTimeSerie gts2 = (GeoTimeSerie) op2;
+      if (GeoTimeSerie.TYPE.LONG == gts1.getType() && GeoTimeSerie.TYPE.LONG == gts2.getType()) {
+        GeoTimeSerie result = new GeoTimeSerie(Math.max(GTSHelper.nvalues(gts1), GTSHelper.nvalues(gts2)));
+        result.setType(GeoTimeSerie.TYPE.LONG);
+        GTSOpsHelper.applyBinaryOp(result, gts1, gts2, op);
+        stack.push(result);
+      } else {
+        throw new WarpScriptException(exceptionMessage);
+      }
+    } else if (op1 instanceof GeoTimeSerie || op2 instanceof GeoTimeSerie) {
+      GeoTimeSerie gts;
+      long mask;
+      if (op1 instanceof GeoTimeSerie && op2 instanceof Long) {
+        gts = (GeoTimeSerie)op1;
+        mask = ((Number)op2).longValue();
+      } else if (op2 instanceof GeoTimeSerie && op1 instanceof Long) {
+        gts = (GeoTimeSerie)op2;
+        mask = ((Number)op1).longValue();
+      } else {
+        throw new WarpScriptException(exceptionMessage);
+      }
+      GeoTimeSerie result = gts.cloneEmpty();
+      result.setType(GeoTimeSerie.TYPE.LONG);
+      for (int i = 0; i < GTSHelper.nvalues(gts); i++) {
+        GTSHelper.setValue(result, GTSHelper.tickAtIndex(gts, i), GTSHelper.locationAtIndex(gts, i), GTSHelper.elevationAtIndex(gts, i),
+                operator(mask, ((Number)GTSHelper.valueAtIndex(gts,i)).longValue()) , false);
+      }
+      stack.push(result);
+    } else {
+      throw new WarpScriptException(exceptionMessage);
+    }
+
+    return stack;
+  }
+}

--- a/warp10/src/main/java/io/warp10/script/binary/BitwiseXOR.java
+++ b/warp10/src/main/java/io/warp10/script/binary/BitwiseXOR.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2019  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.

--- a/warp10/src/main/java/io/warp10/script/binary/BitwiseXOR.java
+++ b/warp10/src/main/java/io/warp10/script/binary/BitwiseXOR.java
@@ -27,59 +27,15 @@ import io.warp10.script.WarpScriptStack;
 /**
  * Bitwise XOR of the two operands on top of the stack
  */
-public class BitwiseXOR extends NamedWarpScriptFunction implements WarpScriptStackFunction {
+public class BitwiseXOR extends BitwiseOperation {
 
   public BitwiseXOR(String name) {
     super(name);
   }
-  
+
   @Override
-  public Object apply(WarpScriptStack stack) throws WarpScriptException {
-    Object op2 = stack.pop();
-    Object op1 = stack.pop();
-    
-    if (op2 instanceof Long && op1 instanceof Long) {
-      stack.push(((Long) op1).longValue() ^ ((Long) op2).longValue());
-    } else if (op1 instanceof GeoTimeSerie && op2 instanceof GeoTimeSerie) {
-      GeoTimeSerie gts1 = (GeoTimeSerie) op1;
-      GeoTimeSerie gts2 = (GeoTimeSerie) op2;
-      if (GeoTimeSerie.TYPE.LONG == gts1.getType() && GeoTimeSerie.TYPE.LONG == gts2.getType()) {
-        GeoTimeSerie result = new GeoTimeSerie(Math.max(GTSHelper.nvalues(gts1), GTSHelper.nvalues(gts2)));
-        result.setType(GeoTimeSerie.TYPE.LONG);
-        GTSOpsHelper.GTSBinaryOp op = new GTSOpsHelper.GTSBinaryOp() {
-          @Override
-          public Object op(GeoTimeSerie gtsa, GeoTimeSerie gtsb, int idxa, int idxb) {
-            return ((Long) GTSHelper.valueAtIndex(gtsa, idxa)) ^ ((Long) GTSHelper.valueAtIndex(gtsb, idxb));
-          }
-        };
-        GTSOpsHelper.applyBinaryOp(result, gts1, gts2, op);
-        stack.push(result);
-      } else {
-        throw new WarpScriptException(getName() + " can only operate on long values or long GTS.");
-      }
-    } else if (op1 instanceof GeoTimeSerie || op2 instanceof GeoTimeSerie) {
-      GeoTimeSerie gts;
-      Long mask;
-      if (op1 instanceof GeoTimeSerie && op2 instanceof Long) {
-        gts = (GeoTimeSerie)op1;
-        mask = (Long)op2;
-      } else if (op2 instanceof GeoTimeSerie && op1 instanceof Long) {
-        gts = (GeoTimeSerie)op2;
-        mask = (Long)op1;
-      } else {
-        throw new WarpScriptException(getName() + " can only operate two GTS or one GTS and a long value.");
-      }
-      GeoTimeSerie result = gts.cloneEmpty();
-      result.setType(GeoTimeSerie.TYPE.LONG);
-      for (int i = 0; i < GTSHelper.nvalues(gts); i++) {
-        GTSHelper.setValue(result, GTSHelper.tickAtIndex(gts, i), GTSHelper.locationAtIndex(gts, i), GTSHelper.elevationAtIndex(gts, i),
-                mask ^ ((Number)GTSHelper.valueAtIndex(gts,i)).longValue() , false);
-      }
-      stack.push(result);
-    } else {
-      throw new WarpScriptException(getName() + " can only operate on long values.");
-    }
-    
-    return stack;
+  public long operator(long op1, long op2) {
+    return op1 ^ op2;
   }
+
 }

--- a/warp10/src/main/java/io/warp10/script/binary/BitwiseXOR.java
+++ b/warp10/src/main/java/io/warp10/script/binary/BitwiseXOR.java
@@ -43,20 +43,39 @@ public class BitwiseXOR extends NamedWarpScriptFunction implements WarpScriptSta
     } else if (op1 instanceof GeoTimeSerie && op2 instanceof GeoTimeSerie) {
       GeoTimeSerie gts1 = (GeoTimeSerie) op1;
       GeoTimeSerie gts2 = (GeoTimeSerie) op2;
-      if (GeoTimeSerie.TYPE.BOOLEAN == gts1.getType() && GeoTimeSerie.TYPE.BOOLEAN == gts2.getType()) {
+      if (GeoTimeSerie.TYPE.LONG == gts1.getType() && GeoTimeSerie.TYPE.LONG == gts2.getType()) {
         GeoTimeSerie result = new GeoTimeSerie(Math.max(GTSHelper.nvalues(gts1), GTSHelper.nvalues(gts2)));
-        result.setType(GeoTimeSerie.TYPE.BOOLEAN);
+        result.setType(GeoTimeSerie.TYPE.LONG);
         GTSOpsHelper.GTSBinaryOp op = new GTSOpsHelper.GTSBinaryOp() {
           @Override
           public Object op(GeoTimeSerie gtsa, GeoTimeSerie gtsb, int idxa, int idxb) {
-            return ((Boolean) GTSHelper.valueAtIndex(gtsa, idxa)) ^ ((Boolean) GTSHelper.valueAtIndex(gtsb, idxb));
+            return ((Long) GTSHelper.valueAtIndex(gtsa, idxa)) ^ ((Long) GTSHelper.valueAtIndex(gtsb, idxb));
           }
         };
         GTSOpsHelper.applyBinaryOp(result, gts1, gts2, op);
         stack.push(result);
       } else {
-        throw new WarpScriptException(getName() + " can only operate on long values or boolean GTS.");
+        throw new WarpScriptException(getName() + " can only operate on long values or long GTS.");
       }
+    } else if (op1 instanceof GeoTimeSerie || op2 instanceof GeoTimeSerie) {
+      GeoTimeSerie gts;
+      Long mask;
+      if (op1 instanceof GeoTimeSerie && op2 instanceof Long) {
+        gts = (GeoTimeSerie)op1;
+        mask = (Long)op2;
+      } else if (op2 instanceof GeoTimeSerie && op1 instanceof Long) {
+        gts = (GeoTimeSerie)op2;
+        mask = (Long)op1;
+      } else {
+        throw new WarpScriptException(getName() + " can only operate two GTS or one GTS and a long value.");
+      }
+      GeoTimeSerie result = gts.cloneEmpty();
+      result.setType(GeoTimeSerie.TYPE.LONG);
+      for (int i = 0; i < GTSHelper.nvalues(gts); i++) {
+        GTSHelper.setValue(result, GTSHelper.tickAtIndex(gts, i), GTSHelper.locationAtIndex(gts, i), GTSHelper.elevationAtIndex(gts, i),
+                mask ^ ((Number)GTSHelper.valueAtIndex(gts,i)).longValue() , false);
+      }
+      stack.push(result);
     } else {
       throw new WarpScriptException(getName() + " can only operate on long values.");
     }

--- a/warp10/src/main/java/io/warp10/script/binary/ComparisonOperation.java
+++ b/warp10/src/main/java/io/warp10/script/binary/ComparisonOperation.java
@@ -57,12 +57,17 @@ public abstract class ComparisonOperation extends NamedWarpScriptFunction implem
     }
   };
   
+  // Default apply function for > < >= =<
+  // It only supports number and strings.
   @Override
   public Object apply(WarpScriptStack stack) throws WarpScriptException {
-    String exceptionMessage = getName() + "  can only operate on homogeneous numeric or string types.";
-    
     Object op2 = stack.pop();
     Object op1 = stack.pop();
+    return comparison(stack, op1, op2);
+  }
+  
+  public Object comparison(WarpScriptStack stack, Object op1, Object op2) throws WarpScriptException {
+    String exceptionMessage = getName() + "  can only operate on homogeneous numeric or string types.";
     
     if (op1 instanceof Double && Double.isNaN((Double) op1) && !(op2 instanceof GeoTimeSerie)) { // Do we have only one NaN ?
       stack.push(false);
@@ -70,6 +75,8 @@ public abstract class ComparisonOperation extends NamedWarpScriptFunction implem
       stack.push(false);
     } else if (op2 instanceof Number && op1 instanceof Number) {
       stack.push(operator(EQ.compare((Number) op1, (Number) op2), 0));
+    } else if (op1 instanceof Boolean && op1 instanceof Boolean) {
+    
     } else if (op2 instanceof String && op1 instanceof String) {
       stack.push(operator(op1.toString().compareTo(op2.toString()), 0));
     } else if (op1 instanceof GeoTimeSerie && op2 instanceof GeoTimeSerie) {
@@ -82,7 +89,7 @@ public abstract class ComparisonOperation extends NamedWarpScriptFunction implem
         // both strings, compare lexicographically
         GeoTimeSerie result = new GeoTimeSerie(Math.max(GTSHelper.nvalues(gts1), GTSHelper.nvalues(gts2)));
         result.setType(GeoTimeSerie.TYPE.STRING);
-        GTSOpsHelper.applyBinaryOp(result, gts1, gts2, stringOp);
+        GTSOpsHelper.applyBinaryOp(result, gts1, gts2, stringOp, true);
         stack.push(result);
       } else if ((GeoTimeSerie.TYPE.LONG == gts1.getType() || GeoTimeSerie.TYPE.DOUBLE == gts1.getType())
           && (GeoTimeSerie.TYPE.LONG == gts2.getType() || GeoTimeSerie.TYPE.DOUBLE == gts2.getType())) {
@@ -94,7 +101,7 @@ public abstract class ComparisonOperation extends NamedWarpScriptFunction implem
         } else {
           result.setType(GeoTimeSerie.TYPE.LONG);
         }
-        GTSOpsHelper.applyBinaryOp(result, gts1, gts2, numberOp);
+        GTSOpsHelper.applyBinaryOp(result, gts1, gts2, numberOp, true);
         stack.push(result);
       } else {
         throw new WarpScriptException(exceptionMessage);

--- a/warp10/src/main/java/io/warp10/script/binary/ComparisonOperation.java
+++ b/warp10/src/main/java/io/warp10/script/binary/ComparisonOperation.java
@@ -61,10 +61,10 @@ public abstract class ComparisonOperation extends NamedWarpScriptFunction implem
     // both input GTS are doubles, we need to deal with NaN special cases.
     @Override
     public Object op(GeoTimeSerie gtsa, GeoTimeSerie gtsb, int idxa, int idxb) {
-      if (ifTwoNaNOperands && Double.isNaN((Double) GTSHelper.valueAtIndex(gtsa, idxa)) && Double.isNaN((Double) GTSHelper.valueAtIndex(gtsb, idxb))) {
-        return GTSHelper.valueAtIndex(gtsa, idxa);
-      } else if (ifOneNaNOperand && (Double.isNaN((Double) GTSHelper.valueAtIndex(gtsa, idxa)) || Double.isNaN((Double) GTSHelper.valueAtIndex(gtsb, idxb)))) {
-        return GTSHelper.valueAtIndex(gtsa, idxa);
+      if (Double.isNaN((Double) GTSHelper.valueAtIndex(gtsa, idxa)) && Double.isNaN((Double) GTSHelper.valueAtIndex(gtsb, idxb))) {
+        return ifTwoNaNOperands ? GTSHelper.valueAtIndex(gtsa, idxa) : null;
+      } else if ((Double.isNaN((Double) GTSHelper.valueAtIndex(gtsa, idxa)) || Double.isNaN((Double) GTSHelper.valueAtIndex(gtsb, idxb)))) {
+        return ifOneNaNOperand ? GTSHelper.valueAtIndex(gtsa, idxa) : null;
       } else {
         return operator(EQ.compare((Number) (GTSHelper.valueAtIndex(gtsa, idxa)), (Number) (GTSHelper.valueAtIndex(gtsb, idxb))), 0) ? GTSHelper.valueAtIndex(gtsa, idxa) : null;
       }
@@ -74,8 +74,8 @@ public abstract class ComparisonOperation extends NamedWarpScriptFunction implem
   private final GTSOpsHelper.GTSBinaryOp gtsaIsDoubleOp = new GTSOpsHelper.GTSBinaryOp() {
     @Override
     public Object op(GeoTimeSerie gtsa, GeoTimeSerie gtsb, int idxa, int idxb) {
-      if (ifOneNaNOperand && (Double.isNaN((Double) GTSHelper.valueAtIndex(gtsa, idxa)))) {
-        return GTSHelper.valueAtIndex(gtsa, idxa);
+      if (Double.isNaN((Double) GTSHelper.valueAtIndex(gtsa, idxa))) {
+        return ifOneNaNOperand ? GTSHelper.valueAtIndex(gtsa, idxa) : null;
       } else {
         return operator(EQ.compare((Number) (GTSHelper.valueAtIndex(gtsa, idxa)), (Number) (GTSHelper.valueAtIndex(gtsb, idxb))), 0) ? GTSHelper.valueAtIndex(gtsa, idxa) : null;
       }
@@ -85,8 +85,8 @@ public abstract class ComparisonOperation extends NamedWarpScriptFunction implem
   private final GTSOpsHelper.GTSBinaryOp gtsbIsDoubleOp = new GTSOpsHelper.GTSBinaryOp() {
     @Override
     public Object op(GeoTimeSerie gtsa, GeoTimeSerie gtsb, int idxa, int idxb) {
-      if (ifOneNaNOperand && (Double.isNaN((Double) GTSHelper.valueAtIndex(gtsb, idxb)))) {
-        return GTSHelper.valueAtIndex(gtsa, idxa);
+      if (Double.isNaN((Double) GTSHelper.valueAtIndex(gtsb, idxb))) {
+        return ifOneNaNOperand ? GTSHelper.valueAtIndex(gtsa, idxa) : null;
       } else {
         return operator(EQ.compare((Number) (GTSHelper.valueAtIndex(gtsa, idxa)), (Number) (GTSHelper.valueAtIndex(gtsb, idxb))), 0) ? GTSHelper.valueAtIndex(gtsa, idxa) : null;
       }
@@ -173,7 +173,7 @@ public abstract class ComparisonOperation extends NamedWarpScriptFunction implem
       if (op2 instanceof Double && Double.isNaN((Double) op2)) {
         // op2 is NaN, must test if both are NaN
         for (int i = 0; i < GTSHelper.nvalues(gts); i++) {
-          if ((Double.isNaN((Double) GTSHelper.valueAtIndex(gts, i)) && ifTwoNaNOperands) || ifOneNaNOperand) {
+          if ((Double.isNaN((Double) GTSHelper.valueAtIndex(gts, i)) && ifTwoNaNOperands) || (!Double.isNaN((Double) GTSHelper.valueAtIndex(gts, i)) && ifOneNaNOperand)) {
             GTSHelper.setValue(result, GTSHelper.tickAtIndex(gts, i), GTSHelper.locationAtIndex(gts, i), GTSHelper.elevationAtIndex(gts, i),
                 GTSHelper.valueAtIndex(gts, i), false);
           }
@@ -181,9 +181,9 @@ public abstract class ComparisonOperation extends NamedWarpScriptFunction implem
       } else {
         // op2 is not NaN, must only test if gts content for NaN
         for (int i = 0; i < GTSHelper.nvalues(gts); i++) {
-          if (Double.isNaN((Double) GTSHelper.valueAtIndex(gts, i)) && ifOneNaNOperand) {
+          if (Double.isNaN((Double) GTSHelper.valueAtIndex(gts, i))) {
             GTSHelper.setValue(result, GTSHelper.tickAtIndex(gts, i), GTSHelper.locationAtIndex(gts, i), GTSHelper.elevationAtIndex(gts, i),
-                GTSHelper.valueAtIndex(gts, i), false);
+                ifOneNaNOperand ? GTSHelper.valueAtIndex(gts, i) : null, false);
           } else {
             GTSHelper.setValue(result, GTSHelper.tickAtIndex(gts, i), GTSHelper.locationAtIndex(gts, i), GTSHelper.elevationAtIndex(gts, i),
                 operator(EQ.compare((Number) GTSHelper.valueAtIndex(gts, i), (Number) op2), 0) ? GTSHelper.valueAtIndex(gts, i) : null, false);

--- a/warp10/src/main/java/io/warp10/script/binary/ComparisonOperation.java
+++ b/warp10/src/main/java/io/warp10/script/binary/ComparisonOperation.java
@@ -1,0 +1,152 @@
+//
+//   Copyright 2019  SenX S.A.S.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+package io.warp10.script.binary;
+
+import io.warp10.continuum.gts.GTSHelper;
+import io.warp10.continuum.gts.GTSOpsHelper;
+import io.warp10.continuum.gts.GeoTimeSerie;
+import io.warp10.script.NamedWarpScriptFunction;
+import io.warp10.script.WarpScriptException;
+import io.warp10.script.WarpScriptStack;
+import io.warp10.script.WarpScriptStackFunction;
+
+public abstract class ComparisonOperation extends NamedWarpScriptFunction implements WarpScriptStackFunction {
+  
+  public abstract boolean operator(int op1, int op2);
+  
+  public ComparisonOperation(String name) {
+    super(name);
+  }
+  
+  @Override
+  public Object apply(WarpScriptStack stack) throws WarpScriptException {
+    String exceptionMessage = getName() + "  can only operate on homogeneous numeric or string types.";
+    
+    Object op2 = stack.pop();
+    Object op1 = stack.pop();
+    
+    if (op1 instanceof Double && Double.isNaN((Double) op1) && !(op2 instanceof GeoTimeSerie)) { // Do we have only one NaN ?
+      stack.push(false);
+    } else if (op2 instanceof Double && Double.isNaN((Double) op2) && !(op1 instanceof GeoTimeSerie)) { // Do we have only one NaN ?
+      stack.push(false);
+    } else if (op2 instanceof Number && op1 instanceof Number) {
+      stack.push(operator(EQ.compare((Number) op1, (Number) op2), 0));
+    } else if (op2 instanceof String && op1 instanceof String) {
+      stack.push(operator(op1.toString().compareTo(op2.toString()), 0));
+    } else if (op1 instanceof GeoTimeSerie && op2 instanceof GeoTimeSerie) {
+      GeoTimeSerie gts1 = (GeoTimeSerie) op1;
+      GeoTimeSerie gts2 = (GeoTimeSerie) op2;
+      if (GeoTimeSerie.TYPE.UNDEFINED == gts1.getType() || GeoTimeSerie.TYPE.UNDEFINED == gts2.getType()) {
+        // gts1 or gts2 empty, return an empty gts
+        stack.push(new GeoTimeSerie());
+      } else if (GeoTimeSerie.TYPE.STRING == gts1.getType() && GeoTimeSerie.TYPE.STRING == gts2.getType()) {
+        // both strings, compare lexicographically
+        GeoTimeSerie result = new GeoTimeSerie(Math.max(GTSHelper.nvalues(gts1), GTSHelper.nvalues(gts2)));
+        result.setType(GeoTimeSerie.TYPE.STRING);
+        GTSOpsHelper.GTSBinaryOp op = new GTSOpsHelper.GTSBinaryOp() {
+          @Override
+          public Object op(GeoTimeSerie gtsa, GeoTimeSerie gtsb, int idxa, int idxb) {
+            boolean ComparisonResult = operator((GTSHelper.valueAtIndex(gtsa, idxa)).toString().compareTo((GTSHelper.valueAtIndex(gtsb, idxb)).toString()), 0);
+            return ComparisonResult ? GTSHelper.valueAtIndex(gtsa, idxa) : null;
+          }
+        };
+        GTSOpsHelper.applyBinaryOp(result, gts1, gts2, op);
+        stack.push(result);
+      } else if ((GeoTimeSerie.TYPE.LONG == gts1.getType() || GeoTimeSerie.TYPE.DOUBLE == gts1.getType())
+          && (GeoTimeSerie.TYPE.LONG == gts2.getType() || GeoTimeSerie.TYPE.DOUBLE == gts2.getType())) {
+        // both are numbers
+        GeoTimeSerie result = new GeoTimeSerie(Math.max(GTSHelper.nvalues(gts1), GTSHelper.nvalues(gts2)));
+        if (GeoTimeSerie.TYPE.DOUBLE == gts1.getType() || GeoTimeSerie.TYPE.DOUBLE == gts2.getType()) {
+          //one input gts is double
+          result.setType(GeoTimeSerie.TYPE.DOUBLE);
+        } else {
+          result.setType(GeoTimeSerie.TYPE.LONG);
+        }
+        GTSOpsHelper.GTSBinaryOp op = new GTSOpsHelper.GTSBinaryOp() {
+          @Override
+          public Object op(GeoTimeSerie gtsa, GeoTimeSerie gtsb, int idxa, int idxb) {
+            if (GTSHelper.valueAtIndex(gtsa, idxa) instanceof Double && Double.isNaN((Double) GTSHelper.valueAtIndex(gtsa, idxa))) {
+              // if one is NaN, result of comparison is always false, return null.
+              return null;
+            } else if (GTSHelper.valueAtIndex(gtsb, idxb) instanceof Double && Double.isNaN((Double) GTSHelper.valueAtIndex(gtsb, idxb))) {
+              // if one is NaN, result of comparison is always false, return null.
+              return null;
+            } else {
+              // both inputs are numbers
+              boolean ComparisonResult = operator(EQ.compare((Number) (GTSHelper.valueAtIndex(gtsa, idxa)), (Number) (GTSHelper.valueAtIndex(gtsb, idxb))), 0);
+              return ComparisonResult ? GTSHelper.valueAtIndex(gtsa, idxa) : null;
+            }
+          }
+        };
+        GTSOpsHelper.applyBinaryOp(result, gts1, gts2, op);
+        stack.push(result);
+      } else {
+        throw new WarpScriptException(exceptionMessage);
+      }
+    } else if (op1 instanceof GeoTimeSerie && GeoTimeSerie.TYPE.UNDEFINED == ((GeoTimeSerie) op1).getType() && (op2 instanceof String || op1 instanceof Number)) {
+      // empty string compared to a string or a number
+      stack.push(op1);
+    } else if (op1 instanceof GeoTimeSerie && op2 instanceof String && GeoTimeSerie.TYPE.STRING == ((GeoTimeSerie) op1).getType()) {
+      // one string gts compared to a string
+      GeoTimeSerie gts = (GeoTimeSerie) op1;
+      GeoTimeSerie result = gts.cloneEmpty();
+      result.setType(GeoTimeSerie.TYPE.STRING);
+      for (int i = 0; i < GTSHelper.nvalues(gts); i++) {
+        GTSHelper.setValue(result, GTSHelper.tickAtIndex(gts, i), GTSHelper.locationAtIndex(gts, i), GTSHelper.elevationAtIndex(gts, i),
+            operator((GTSHelper.valueAtIndex(gts, i)).toString().compareTo(op2.toString()), 0) ? GTSHelper.valueAtIndex(gts, i) : null, false);
+      }
+      stack.push(result);
+    } else if (op1 instanceof GeoTimeSerie && op2 instanceof Number && GeoTimeSerie.TYPE.DOUBLE == ((GeoTimeSerie) op1).getType()) {
+      // one double gts compared to number
+      GeoTimeSerie gts = (GeoTimeSerie) op1;
+      GeoTimeSerie result = gts.cloneEmpty();
+      result.setType(GeoTimeSerie.TYPE.DOUBLE);
+      if (op2 instanceof Double && Double.isNaN((Double) op2)) {
+        // nothing is comparable to NaN
+        stack.push(result);
+      } else {
+        for (int i = 0; i < GTSHelper.nvalues(gts); i++) {
+          if (!Double.isNaN((Double) GTSHelper.valueAtIndex(gts, i))) {
+            //exclude NaN inputs
+            GTSHelper.setValue(result, GTSHelper.tickAtIndex(gts, i), GTSHelper.locationAtIndex(gts, i), GTSHelper.elevationAtIndex(gts, i),
+                operator(EQ.compare((Number) GTSHelper.valueAtIndex(gts, i), (Number) op2), 0) ? GTSHelper.valueAtIndex(gts, i) : null, false);
+          }
+        }
+        stack.push(result);
+      }
+    } else if (op1 instanceof GeoTimeSerie && op2 instanceof Number && GeoTimeSerie.TYPE.LONG == ((GeoTimeSerie) op1).getType()) {
+      // one long gts compared to number
+      GeoTimeSerie gts = (GeoTimeSerie) op1;
+      GeoTimeSerie result = gts.cloneEmpty();
+      result.setType(GeoTimeSerie.TYPE.LONG);
+      if (op2 instanceof Double && Double.isNaN((Double) op2)) {
+        // nothing is comparable to NaN
+        stack.push(result);
+      } else {
+        for (int i = 0; i < GTSHelper.nvalues(gts); i++) {
+          GTSHelper.setValue(result, GTSHelper.tickAtIndex(gts, i), GTSHelper.locationAtIndex(gts, i), GTSHelper.elevationAtIndex(gts, i),
+              operator(EQ.compare((Number) GTSHelper.valueAtIndex(gts, i), (Number) op2), 0) ? GTSHelper.valueAtIndex(gts, i) : null, false);
+        }
+        stack.push(result);
+      }
+    } else {
+      throw new WarpScriptException(exceptionMessage);
+    }
+    
+    return stack;
+  }
+}

--- a/warp10/src/main/java/io/warp10/script/binary/ComparisonOperation.java
+++ b/warp10/src/main/java/io/warp10/script/binary/ComparisonOperation.java
@@ -29,11 +29,29 @@ public abstract class ComparisonOperation extends NamedWarpScriptFunction implem
   public abstract boolean operator(int op1, int op2);
   
   //default behavior for > < operators. For >= <= == or !=, you need to set these.
-  public boolean ifOneNaNOperand = false;
-  public boolean ifTwoNaNOperands = false;
+  private final boolean ifOneNaNOperand;
+  private final boolean ifTwoNaNOperands;
   
+  /**
+   * Default constructor with default behavior for > < operators. For >= <= == or !=, you need to set ifOneNaNOperand and ifTwoNaNOperands.
+   *
+   * @param name WarpScript function name
+   */
   public ComparisonOperation(String name) {
     super(name);
+    ifOneNaNOperand = false;
+    ifTwoNaNOperands = false;
+  }
+  
+  /**
+   * @param name                 WarpsScript function name
+   * @param trueIfOneNaNOperand  set it for != comparison
+   * @param trueIfTwoNaNOperands set it for == or <= or >= comparison
+   */
+  public ComparisonOperation(String name, boolean trueIfOneNaNOperand, boolean trueIfTwoNaNOperands) {
+    super(name);
+    ifOneNaNOperand = trueIfOneNaNOperand;
+    ifTwoNaNOperands = trueIfTwoNaNOperands;
   }
   
   private final GTSOpsHelper.GTSBinaryOp stringOp = new GTSOpsHelper.GTSBinaryOp() {

--- a/warp10/src/main/java/io/warp10/script/binary/CondShortCircuit.java
+++ b/warp10/src/main/java/io/warp10/script/binary/CondShortCircuit.java
@@ -37,11 +37,19 @@ public abstract class CondShortCircuit extends NamedWarpScriptFunction implement
 
   protected final boolean triggerValue;
 
+  private GTSOpsHelper.GTSBinaryOp op;
+
   public abstract boolean operator(boolean bool1, boolean bool2);
 
   public CondShortCircuit(String name, boolean triggerValue) {
     super(name);
     this.triggerValue = triggerValue;
+    this.op = new GTSOpsHelper.GTSBinaryOp() {
+      @Override
+      public Object op(GeoTimeSerie gtsa, GeoTimeSerie gtsb, int idxa, int idxb) {
+        return operator(((boolean) GTSHelper.valueAtIndex(gtsa, idxa)) , ((boolean) GTSHelper.valueAtIndex(gtsb, idxb)));
+      }
+    };
   }
 
   @Override
@@ -89,13 +97,7 @@ public abstract class CondShortCircuit extends NamedWarpScriptFunction implement
         if (GeoTimeSerie.TYPE.BOOLEAN == gts1.getType() && GeoTimeSerie.TYPE.BOOLEAN == gts2.getType()) {
           GeoTimeSerie result = new GeoTimeSerie(Math.max(GTSHelper.nvalues(gts1), GTSHelper.nvalues(gts2)));
           result.setType(GeoTimeSerie.TYPE.BOOLEAN);
-          GTSOpsHelper.GTSBinaryOp op = new GTSOpsHelper.GTSBinaryOp() {
-            @Override
-            public Object op(GeoTimeSerie gtsa, GeoTimeSerie gtsb, int idxa, int idxb) {
-              return operator(((Boolean) GTSHelper.valueAtIndex(gtsa, idxa)), ((Boolean) GTSHelper.valueAtIndex(gtsb, idxb)));
-            }
-          };
-          GTSOpsHelper.applyBinaryOp(result, gts1, gts2, op);
+          GTSOpsHelper.applyBinaryOp(result, gts1, gts2, this.op);
           stack.push(result);
           return stack;
         } else {

--- a/warp10/src/main/java/io/warp10/script/binary/CondShortCircuit.java
+++ b/warp10/src/main/java/io/warp10/script/binary/CondShortCircuit.java
@@ -37,19 +37,18 @@ public abstract class CondShortCircuit extends NamedWarpScriptFunction implement
 
   protected final boolean triggerValue;
 
-  private GTSOpsHelper.GTSBinaryOp op;
+  private final GTSOpsHelper.GTSBinaryOp op = new GTSOpsHelper.GTSBinaryOp() {
+    @Override
+    public Object op(GeoTimeSerie gtsa, GeoTimeSerie gtsb, int idxa, int idxb) {
+      return operator(((boolean) GTSHelper.valueAtIndex(gtsa, idxa)) , ((boolean) GTSHelper.valueAtIndex(gtsb, idxb)));
+    }
+  };
 
   public abstract boolean operator(boolean bool1, boolean bool2);
 
   public CondShortCircuit(String name, boolean triggerValue) {
     super(name);
     this.triggerValue = triggerValue;
-    this.op = new GTSOpsHelper.GTSBinaryOp() {
-      @Override
-      public Object op(GeoTimeSerie gtsa, GeoTimeSerie gtsb, int idxa, int idxb) {
-        return operator(((boolean) GTSHelper.valueAtIndex(gtsa, idxa)) , ((boolean) GTSHelper.valueAtIndex(gtsb, idxb)));
-      }
-    };
   }
 
   @Override
@@ -99,6 +98,11 @@ public abstract class CondShortCircuit extends NamedWarpScriptFunction implement
           result.setType(GeoTimeSerie.TYPE.BOOLEAN);
           GTSOpsHelper.applyBinaryOp(result, gts1, gts2, this.op);
           stack.push(result);
+          return stack;
+        } else if ((GeoTimeSerie.TYPE.UNDEFINED == gts1.getType() && GeoTimeSerie.TYPE.BOOLEAN == gts2.getType())
+                || (GeoTimeSerie.TYPE.UNDEFINED == gts2.getType() && GeoTimeSerie.TYPE.BOOLEAN == gts1.getType())) {
+          // gts1 or gts2 empty, return an empty gts
+          stack.push(new GeoTimeSerie());
           return stack;
         } else {
           throw new WarpScriptException(getName() + " can only operate on long values or long GTS.");

--- a/warp10/src/main/java/io/warp10/script/binary/CondShortCircuit.java
+++ b/warp10/src/main/java/io/warp10/script/binary/CondShortCircuit.java
@@ -46,7 +46,7 @@ public abstract class CondShortCircuit extends NamedWarpScriptFunction implement
 
   @Override
   public Object apply(WarpScriptStack stack) throws WarpScriptException {
-    String exceptionMessage = getName() + " can only operate on two boolean values, or two GTS, or a GTS and a boolean, or a list of booleans or macros, each macro putting a single boolean on top of the stack.";
+    String exceptionMessage = getName() + " can only operate on two boolean values, or two boolean GTS, or a list of booleans or macros, each macro putting a single boolean on top of the stack.";
 
     Object top = stack.pop();
 
@@ -101,27 +101,6 @@ public abstract class CondShortCircuit extends NamedWarpScriptFunction implement
         } else {
           throw new WarpScriptException(getName() + " can only operate on long values or long GTS.");
         }
-      } else if (op1 instanceof GeoTimeSerie || op2 instanceof GeoTimeSerie) {
-        // logical operator between a boolean GTS value and a constant (might be usefull to set values to true or false)
-        GeoTimeSerie gts;
-        boolean mask;
-        if (op1 instanceof GeoTimeSerie && op2 instanceof Boolean) {
-          gts = (GeoTimeSerie) op1;
-          mask = (boolean) op2;
-        } else if (op2 instanceof GeoTimeSerie && op1 instanceof Boolean) {
-          gts = (GeoTimeSerie) op2;
-          mask = (boolean) op1;
-        } else {
-          throw new WarpScriptException(getName() + " can only operate two GTS or one GTS and a long value.");
-        }
-        GeoTimeSerie result = gts.cloneEmpty();
-        result.setType(GeoTimeSerie.TYPE.BOOLEAN);
-        for (int i = 0; i < GTSHelper.nvalues(gts); i++) {
-          GTSHelper.setValue(result, GTSHelper.tickAtIndex(gts, i), GTSHelper.locationAtIndex(gts, i), GTSHelper.elevationAtIndex(gts, i),
-                  operator(mask, (boolean) GTSHelper.valueAtIndex(gts, i)), false);
-        }
-        stack.push(result);
-        return stack;
       } else {
         throw new WarpScriptException(exceptionMessage);
       }

--- a/warp10/src/main/java/io/warp10/script/binary/EQ.java
+++ b/warp10/src/main/java/io/warp10/script/binary/EQ.java
@@ -30,6 +30,7 @@ public class EQ extends ComparisonOperation {
   
   public EQ(String name) {
     super(name);
+    ifTwoNaNOperands = true; // NaN NaN == must return true in WarpScript
   }
   
   @Override
@@ -42,15 +43,7 @@ public class EQ extends ComparisonOperation {
     Object op2 = stack.pop();
     Object op1 = stack.pop();
     
-    if (op2 instanceof Double && op1 instanceof Double) {
-      // Special case if the 2 parameters are NaN value : we want 'NaN NaN ==' to be true
-      // NaN is not convertible to BigDecimal, so we cannot use the compare method
-      if (Double.isNaN((Double) op1) || Double.isNaN((Double) op2)) {
-        stack.push(Double.isNaN((Double) op1) && Double.isNaN((Double) op2));
-      } else {
-        stack.push(0 == EQ.compare((Number) op1, (Number) op2));
-      }
-    } else if (op1 instanceof Boolean || op1 instanceof String
+    if (op1 instanceof Boolean || op1 instanceof String
         || op1 instanceof RealVector || op1 instanceof RealMatrix) {
       stack.push(op1.equals(op2));
     } else {

--- a/warp10/src/main/java/io/warp10/script/binary/EQ.java
+++ b/warp10/src/main/java/io/warp10/script/binary/EQ.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2019  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -16,30 +16,32 @@
 
 package io.warp10.script.binary;
 
-import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptStack;
-import io.warp10.script.WarpScriptStackFunction;
 import org.apache.commons.math3.linear.RealMatrix;
 import org.apache.commons.math3.linear.RealVector;
 
 import java.math.BigDecimal;
 
-
 /**
  * Checks the two operands on top of the stack for equality
  */
-public class EQ extends NamedWarpScriptFunction implements WarpScriptStackFunction {
-
+public class EQ extends ComparisonOperation {
+  
   public EQ(String name) {
     super(name);
   }
-
+  
+  @Override
+  public boolean operator(int op1, int op2) {
+    return op1 == op2;
+  }
+  
   @Override
   public Object apply(WarpScriptStack stack) throws WarpScriptException {
     Object op2 = stack.pop();
     Object op1 = stack.pop();
-
+    
     if (op2 instanceof Double && op1 instanceof Double) {
       // Special case if the 2 parameters are NaN value : we want 'NaN NaN ==' to be true
       // NaN is not convertible to BigDecimal, so we cannot use the compare method
@@ -48,28 +50,21 @@ public class EQ extends NamedWarpScriptFunction implements WarpScriptStackFuncti
       } else {
         stack.push(0 == EQ.compare((Number) op1, (Number) op2));
       }
-    } else if (op1 instanceof Double && Double.isNaN((Double) op1)) { // Do we have only one NaN ?
-      stack.push(false);
-    } else if (op2 instanceof Double && Double.isNaN((Double) op2)) { // Do we have only one NaN ?
-      stack.push(false);
-    } else if (op2 instanceof Number && op1 instanceof Number) {
-      stack.push(0 == compare((Number) op1, (Number) op2));
     } else if (op1 instanceof Boolean || op1 instanceof String
         || op1 instanceof RealVector || op1 instanceof RealMatrix) {
       stack.push(op1.equals(op2));
     } else {
-      throw new WarpScriptException(getName()
-          + " can only operate on homogeneous numeric, string, boolean, vector or matrix types.");
+      // gts and numbers
+      comparison(stack, op1, op2);
     }
-
     return stack;
   }
-
+  
   public static int compare(Number a, Number b) {
     if (a.equals(b)) {
       return 0;
     }
-
+    
     if (a instanceof Double && b instanceof Double) {
       return ((Double) a).compareTo((Double) b);
     } else if ((a instanceof Long && b instanceof Long) || ((a instanceof Long || a instanceof Integer || a instanceof Short || a instanceof Byte)
@@ -81,7 +76,7 @@ public class EQ extends NamedWarpScriptFunction implements WarpScriptStackFuncti
       } else {
         return 0;
       }
-    } else {    
+    } else {
       // If the equals function fails and the types do not permit direct number comparison,
       // we test again with BigDecimal comparison for type abstraction
       // We want '10 10.0 ==' or '10 10.0 >=' to be true
@@ -107,7 +102,7 @@ public class EQ extends NamedWarpScriptFunction implements WarpScriptStackFuncti
       } else {
         bdb = new BigDecimal(b.toString());
       }
-
+      
       return bda.compareTo(bdb);
     }
   }

--- a/warp10/src/main/java/io/warp10/script/binary/EQ.java
+++ b/warp10/src/main/java/io/warp10/script/binary/EQ.java
@@ -29,8 +29,7 @@ import java.math.BigDecimal;
 public class EQ extends ComparisonOperation {
   
   public EQ(String name) {
-    super(name);
-    ifTwoNaNOperands = true; // NaN NaN == must return true in WarpScript
+    super(name, false, true); // NaN NaN == must return true in WarpScript
   }
   
   @Override

--- a/warp10/src/main/java/io/warp10/script/binary/GE.java
+++ b/warp10/src/main/java/io/warp10/script/binary/GE.java
@@ -16,45 +16,19 @@
 
 package io.warp10.script.binary;
 
-import io.warp10.script.NamedWarpScriptFunction;
-import io.warp10.script.WarpScriptException;
-import io.warp10.script.WarpScriptStack;
-import io.warp10.script.WarpScriptStackFunction;
-
 /**
  * Checks the two operands on top of the stack for greater or equal
  */
-public class GE extends NamedWarpScriptFunction implements WarpScriptStackFunction {
-
+public class GE extends ComparisonOperation {
+  
   public GE(String name) {
     super(name);
   }
-
+  
   @Override
-  public Object apply(WarpScriptStack stack) throws WarpScriptException {
-    Object op2 = stack.pop();
-    Object op1 = stack.pop();
-
-    if (op2 instanceof Double && op1 instanceof Double) {
-      // Special case if the 2 parameters are NaN value : we want 'NaN NaN >=' to be true
-      // NaN is not convertible to BigDecimal, so we cannot use the compare method
-      if (Double.isNaN((Double) op1) || Double.isNaN((Double) op2)) {
-        stack.push(Double.isNaN((Double) op1) && Double.isNaN((Double) op2));
-      } else {
-        stack.push(EQ.compare((Number) op1, (Number) op2) >= 0);
-      }
-    } else if (op1 instanceof Double && Double.isNaN((Double) op1)) { // Do we have only one NaN ?
-      stack.push(false);
-    } else if (op2 instanceof Double && Double.isNaN((Double) op2)) { // Do we have only one NaN ?
-      stack.push(false);
-    } else if (op2 instanceof Number && op1 instanceof Number) {
-      stack.push(EQ.compare((Number) op1, (Number) op2) >= 0);
-    } else if (op2 instanceof String && op1 instanceof String) {
-      stack.push(op1.toString().compareTo(op2.toString()) >= 0);
-    } else {
-      throw new WarpScriptException(getName() + " can only operate on homogeneous numeric or string types.");
-    }
-
-    return stack;
+  public boolean operator(int op1, int op2) {
+    return op1 >= op2;
   }
+  
 }
+

--- a/warp10/src/main/java/io/warp10/script/binary/GE.java
+++ b/warp10/src/main/java/io/warp10/script/binary/GE.java
@@ -22,8 +22,7 @@ package io.warp10.script.binary;
 public class GE extends ComparisonOperation {
   
   public GE(String name) {
-    super(name);
-    ifTwoNaNOperands = true; // NaN NaN >= must return true in WarpScript
+    super(name, false, true); // NaN NaN >= must return true in WarpScript
   }
   
   @Override

--- a/warp10/src/main/java/io/warp10/script/binary/GE.java
+++ b/warp10/src/main/java/io/warp10/script/binary/GE.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2019  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ public class GE extends ComparisonOperation {
   
   public GE(String name) {
     super(name);
+    ifTwoNaNOperands = true; // NaN NaN >= must return true in WarpScript
   }
   
   @Override

--- a/warp10/src/main/java/io/warp10/script/binary/GT.java
+++ b/warp10/src/main/java/io/warp10/script/binary/GT.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2019  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.

--- a/warp10/src/main/java/io/warp10/script/binary/GT.java
+++ b/warp10/src/main/java/io/warp10/script/binary/GT.java
@@ -16,37 +16,18 @@
 
 package io.warp10.script.binary;
 
-import io.warp10.script.NamedWarpScriptFunction;
-import io.warp10.script.WarpScriptException;
-import io.warp10.script.WarpScriptStack;
-import io.warp10.script.WarpScriptStackFunction;
-
 /**
  * Checks the two operands on top of the stack for greater than
  */
-public class GT extends NamedWarpScriptFunction implements WarpScriptStackFunction {
-
+public class GT extends ComparisonOperation {
+  
   public GT(String name) {
     super(name);
   }
-
+  
   @Override
-  public Object apply(WarpScriptStack stack) throws WarpScriptException {
-    Object op2 = stack.pop();
-    Object op1 = stack.pop();
-
-    if (op1 instanceof Double && Double.isNaN((Double) op1)) { // Do we have only one NaN ?
-      stack.push(false);
-    } else if (op2 instanceof Double && Double.isNaN((Double) op2)) { // Do we have only one NaN ?
-      stack.push(false);
-    } else if (op2 instanceof Number && op1 instanceof Number) {
-      stack.push(EQ.compare((Number) op1, (Number) op2) > 0);
-    } else if (op2 instanceof String && op1 instanceof String) {
-      stack.push(op1.toString().compareTo(op2.toString()) > 0);
-    } else {
-      throw new WarpScriptException(getName() + " can only operate on homogeneous numeric or string types.");
-    }
-
-    return stack;
+  public boolean operator(int op1, int op2) {
+    return op1 > op2;
   }
+  
 }

--- a/warp10/src/main/java/io/warp10/script/binary/LE.java
+++ b/warp10/src/main/java/io/warp10/script/binary/LE.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2019  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ public class LE extends ComparisonOperation {
   
   public LE(String name) {
     super(name);
+    ifTwoNaNOperands = true; // NaN NaN <= must return true in WarpScript
   }
   
   @Override

--- a/warp10/src/main/java/io/warp10/script/binary/LE.java
+++ b/warp10/src/main/java/io/warp10/script/binary/LE.java
@@ -22,8 +22,7 @@ package io.warp10.script.binary;
 public class LE extends ComparisonOperation {
   
   public LE(String name) {
-    super(name);
-    ifTwoNaNOperands = true; // NaN NaN <= must return true in WarpScript
+    super(name, false, true); // NaN NaN <= must return true in WarpScript
   }
   
   @Override

--- a/warp10/src/main/java/io/warp10/script/binary/LE.java
+++ b/warp10/src/main/java/io/warp10/script/binary/LE.java
@@ -16,45 +16,18 @@
 
 package io.warp10.script.binary;
 
-import io.warp10.script.NamedWarpScriptFunction;
-import io.warp10.script.WarpScriptException;
-import io.warp10.script.WarpScriptStack;
-import io.warp10.script.WarpScriptStackFunction;
-
 /**
  * Checks the two operands on top of the stack for less or equal
  */
-public class LE extends NamedWarpScriptFunction implements WarpScriptStackFunction {
-
+public class LE extends ComparisonOperation {
+  
   public LE(String name) {
     super(name);
   }
-
+  
   @Override
-  public Object apply(WarpScriptStack stack) throws WarpScriptException {
-    Object op2 = stack.pop();
-    Object op1 = stack.pop();
-
-    if (op2 instanceof Double && op1 instanceof Double) {
-      // Special case if the 2 parameters are NaN value : we want 'NaN NaN <=' to be true
-      // NaN is not convertible to BigDecimal, so we cannot use the compare method
-      if (Double.isNaN((Double) op1) || Double.isNaN((Double) op2)) {
-        stack.push(Double.isNaN((Double) op1) && Double.isNaN((Double) op2));
-      } else {
-        stack.push(EQ.compare((Number) op1, (Number) op2) <= 0);
-      }
-    } else if (op1 instanceof Double && Double.isNaN((Double) op1)) { // Do we have only one NaN ?
-      stack.push(false);
-    } else if (op2 instanceof Double && Double.isNaN((Double) op2)) { // Do we have only one NaN ?
-      stack.push(false);
-    } else if (op2 instanceof Number && op1 instanceof Number) {
-      stack.push(EQ.compare((Number) op1, (Number) op2) <= 0);
-    } else if (op2 instanceof String && op1 instanceof String) {
-      stack.push(op1.toString().compareTo(op2.toString()) <= 0);
-    } else {
-      throw new WarpScriptException(getName() + " can only operate on homogeneous numeric or string types.");
-    }
-
-    return stack;
+  public boolean operator(int op1, int op2) {
+    return op1 <= op2;
   }
+  
 }

--- a/warp10/src/main/java/io/warp10/script/binary/LT.java
+++ b/warp10/src/main/java/io/warp10/script/binary/LT.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2019  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.

--- a/warp10/src/main/java/io/warp10/script/binary/LT.java
+++ b/warp10/src/main/java/io/warp10/script/binary/LT.java
@@ -16,37 +16,18 @@
 
 package io.warp10.script.binary;
 
-import io.warp10.script.NamedWarpScriptFunction;
-import io.warp10.script.WarpScriptException;
-import io.warp10.script.WarpScriptStack;
-import io.warp10.script.WarpScriptStackFunction;
-
 /**
  * Checks the two operands on top of the stack for less than
  */
-public class LT extends NamedWarpScriptFunction implements WarpScriptStackFunction {
-
+public class LT extends ComparisonOperation {
+  
   public LT(String name) {
     super(name);
   }
-
+  
   @Override
-  public Object apply(WarpScriptStack stack) throws WarpScriptException {
-    Object op2 = stack.pop();
-    Object op1 = stack.pop();
-
-    if (op1 instanceof Double && Double.isNaN((Double) op1)) { // Do we have only one NaN ?
-      stack.push(false);
-    } else if (op2 instanceof Double && Double.isNaN((Double) op2)) { // Do we have only one NaN ?
-      stack.push(false);
-    } else if (op2 instanceof Number && op1 instanceof Number) {
-      stack.push(EQ.compare((Number) op1, (Number) op2) < 0);
-    } else if (op2 instanceof String && op1 instanceof String) {
-      stack.push(op1.toString().compareTo(op2.toString()) < 0);
-    } else {
-      throw new WarpScriptException(getName() + " can only operate on homogeneous numeric or string types.");
-    }
-
-    return stack;
+  public boolean operator(int op1, int op2) {
+    return op1 < op2;
   }
+  
 }

--- a/warp10/src/main/java/io/warp10/script/binary/NE.java
+++ b/warp10/src/main/java/io/warp10/script/binary/NE.java
@@ -16,27 +16,30 @@
 
 package io.warp10.script.binary;
 
-import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptStack;
-import io.warp10.script.WarpScriptStackFunction;
 import org.apache.commons.math3.linear.RealMatrix;
 import org.apache.commons.math3.linear.RealVector;
 
 /**
  * Checks the two operands on top of the stack for inequality
  */
-public class NE extends NamedWarpScriptFunction implements WarpScriptStackFunction {
-
+public class NE extends ComparisonOperation {
+  
   public NE(String name) {
     super(name);
   }
-
+  
+  @Override
+  public boolean operator(int op1, int op2) {
+    return op1 != op2;
+  }
+  
   @Override
   public Object apply(WarpScriptStack stack) throws WarpScriptException {
     Object op2 = stack.pop();
     Object op1 = stack.pop();
-
+    
     if (op2 instanceof Double && op1 instanceof Double) {
       // Special case if the 2 parameters are NaN value : we want 'NaN NaN !=' to be true
       // NaN is not convertible to BigDecimal, so we cannot use the compare method
@@ -45,20 +48,13 @@ public class NE extends NamedWarpScriptFunction implements WarpScriptStackFuncti
       } else {
         stack.push(0 != EQ.compare((Number) op1, (Number) op2));
       }
-    } else if (op1 instanceof Double && Double.isNaN((Double) op1)) { // Do we have only one NaN ?
-      stack.push(true);
-    } else if (op2 instanceof Double && Double.isNaN((Double) op2)) { // Do we have only one NaN ?
-      stack.push(true);
-    } else if (op2 instanceof Number && op1 instanceof Number) {
-      stack.push(0 != EQ.compare((Number) op1, (Number) op2));
     } else if (op1 instanceof Boolean || op1 instanceof String
         || op1 instanceof RealVector || op1 instanceof RealMatrix) {
       stack.push(!op1.equals(op2));
     } else {
-      throw new WarpScriptException(getName()
-          + " can only operate on homogeneous numeric, string, boolean, vector or matrix types.");
+      comparison(stack, op1, op2);
     }
-
+    
     return stack;
   }
 }

--- a/warp10/src/main/java/io/warp10/script/binary/NE.java
+++ b/warp10/src/main/java/io/warp10/script/binary/NE.java
@@ -27,8 +27,7 @@ import org.apache.commons.math3.linear.RealVector;
 public class NE extends ComparisonOperation {
   
   public NE(String name) {
-    super(name);
-    ifOneNaNOperand = true; // 0.0 NaN != must return true
+    super(name, true, false); // 0.0 NaN != must return true
   }
   
   @Override

--- a/warp10/src/main/java/io/warp10/script/binary/NE.java
+++ b/warp10/src/main/java/io/warp10/script/binary/NE.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2019  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ public class NE extends ComparisonOperation {
   
   public NE(String name) {
     super(name);
+    ifOneNaNOperand = true; // 0.0 NaN != must return true
   }
   
   @Override
@@ -40,18 +41,11 @@ public class NE extends ComparisonOperation {
     Object op2 = stack.pop();
     Object op1 = stack.pop();
     
-    if (op2 instanceof Double && op1 instanceof Double) {
-      // Special case if the 2 parameters are NaN value : we want 'NaN NaN !=' to be true
-      // NaN is not convertible to BigDecimal, so we cannot use the compare method
-      if (Double.isNaN((Double) op1) || Double.isNaN((Double) op2)) {
-        stack.push(!(Double.isNaN((Double) op1) && Double.isNaN((Double) op2)));
-      } else {
-        stack.push(0 != EQ.compare((Number) op1, (Number) op2));
-      }
-    } else if (op1 instanceof Boolean || op1 instanceof String
+    if (op1 instanceof Boolean || op1 instanceof String
         || op1 instanceof RealVector || op1 instanceof RealMatrix) {
       stack.push(!op1.equals(op2));
     } else {
+      // gts and numbers
       comparison(stack, op1, op2);
     }
     

--- a/warp10/src/main/java/io/warp10/script/binary/SHIFTLEFT.java
+++ b/warp10/src/main/java/io/warp10/script/binary/SHIFTLEFT.java
@@ -24,34 +24,15 @@ import io.warp10.script.WarpScriptStack;
 /**
  * Shift left the long below the top of the stack by the number of bits on top of the stack
  */
-public class SHIFTLEFT extends NamedWarpScriptFunction implements WarpScriptStackFunction {
+public class SHIFTLEFT extends BitwiseOperation {
 
   public SHIFTLEFT(String name) {
     super(name);
   }
-  
-  @Override
-  public Object apply(WarpScriptStack stack) throws WarpScriptException {
-    Object top = stack.pop();
-    
-    if (!(top instanceof Long)) {
-      throw new WarpScriptException(getName() + " expects a number of bits on top of the stack.");
-    }
-    
-    int nbits = ((Number) top).intValue();
-    
-    top = stack.pop();
-    
-    if (!(top instanceof Long)) {
-      throw new WarpScriptException(getName() + " operates on a LONG.");
-    }
-    
-    long v = ((Number) top).longValue();
 
-    v = v << nbits;
-    
-    stack.push(v);
-    
-    return stack;
+  @Override
+  public long operator(long op1, long op2) {
+    return op1 << op2;
   }
+
 }

--- a/warp10/src/main/java/io/warp10/script/binary/SHIFTRIGHT.java
+++ b/warp10/src/main/java/io/warp10/script/binary/SHIFTRIGHT.java
@@ -24,40 +24,21 @@ import io.warp10.script.WarpScriptStack;
 /**
  * Shift right the long below the top of the stack by the number of bits on top of the stack
  */
-public class SHIFTRIGHT extends NamedWarpScriptFunction implements WarpScriptStackFunction {
+public class SHIFTRIGHT extends BitwiseOperation {
 
   private final boolean signed;
   public SHIFTRIGHT(String name, boolean signed) {
     super(name);
     this.signed = signed;
   }
-  
+
   @Override
-  public Object apply(WarpScriptStack stack) throws WarpScriptException {
-    Object top = stack.pop();
-    
-    if (!(top instanceof Long)) {
-      throw new WarpScriptException(getName() + " expects a number of bits on top of the stack.");
-    }
-    
-    int nbits = ((Number) top).intValue();
-    
-    top = stack.pop();
-    
-    if (!(top instanceof Long)) {
-      throw new WarpScriptException(getName() + " operates on a LONG.");
-    }
-    
-    long v = ((Number) top).longValue();
-    
+  public long operator(long op1, long op2) {
     if (this.signed) {
-      v = v >> nbits;
+      return op1 >> op2;
     } else {
-      v = v >>> nbits;
+      return op1 >>> op2;
     }
-    
-    stack.push(v);
-    
-    return stack;
   }
+
 }

--- a/warp10/src/main/java/io/warp10/script/unary/NOT.java
+++ b/warp10/src/main/java/io/warp10/script/unary/NOT.java
@@ -27,7 +27,7 @@ import io.warp10.script.WarpScriptStack;
  * Unary NOT of the operand on top of the stack
  */
 public class NOT extends NamedWarpScriptFunction implements WarpScriptStackFunction {
-
+  
   public NOT(String name) {
     super(name);
   }
@@ -50,8 +50,7 @@ public class NOT extends NamedWarpScriptFunction implements WarpScriptStackFunct
       } else {
         throw new WarpScriptException(getName() + " can only operate on a boolean value or a boolean GTS.");
       }
-    }
-    else {
+    } else {
       throw new WarpScriptException(getName() + " can only operate on a boolean value or a boolean GTS.");
     }
     

--- a/warp10/src/main/java/io/warp10/script/unary/NOT.java
+++ b/warp10/src/main/java/io/warp10/script/unary/NOT.java
@@ -46,7 +46,7 @@ public class NOT extends NamedWarpScriptFunction implements WarpScriptStackFunct
         stack.push(result);
       } else if (GeoTimeSerie.TYPE.UNDEFINED == gts.getType()) {
         // empty gts
-        stack.push(gts);
+        stack.push(gts.cloneEmpty());
       } else {
         throw new WarpScriptException(getName() + " can only operate on a boolean value or a boolean GTS.");
       }

--- a/warp10/src/main/java/io/warp10/script/unary/NOT.java
+++ b/warp10/src/main/java/io/warp10/script/unary/NOT.java
@@ -44,6 +44,9 @@ public class NOT extends NamedWarpScriptFunction implements WarpScriptStackFunct
         GeoTimeSerie result = gts.clone();
         GTSHelper.booleanNot(result);
         stack.push(result);
+      } else if (GeoTimeSerie.TYPE.UNDEFINED == gts.getType()) {
+        // empty gts
+        stack.push(gts);
       } else {
         throw new WarpScriptException(getName() + " can only operate on a boolean value or a boolean GTS.");
       }

--- a/warp10/src/main/java/io/warp10/script/unary/NOT.java
+++ b/warp10/src/main/java/io/warp10/script/unary/NOT.java
@@ -19,9 +19,9 @@ package io.warp10.script.unary;
 import io.warp10.continuum.gts.GTSHelper;
 import io.warp10.continuum.gts.GeoTimeSerie;
 import io.warp10.script.NamedWarpScriptFunction;
-import io.warp10.script.WarpScriptStackFunction;
 import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptStack;
+import io.warp10.script.WarpScriptStackFunction;
 
 /**
  * Unary NOT of the operand on top of the stack

--- a/warp10/src/main/java/io/warp10/script/unary/NOT.java
+++ b/warp10/src/main/java/io/warp10/script/unary/NOT.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2019  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package io.warp10.script.unary;
 
+import io.warp10.continuum.gts.GTSHelper;
+import io.warp10.continuum.gts.GeoTimeSerie;
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptStackFunction;
 import io.warp10.script.WarpScriptException;
@@ -36,8 +38,18 @@ public class NOT extends NamedWarpScriptFunction implements WarpScriptStackFunct
     
     if (op instanceof Boolean) {
       stack.push(!((Boolean) op).booleanValue());
-    } else {
-      throw new WarpScriptException(getName() + " can only operate on a boolean value.");
+    } else if (op instanceof GeoTimeSerie) {
+      GeoTimeSerie gts = (GeoTimeSerie) op;
+      if (GeoTimeSerie.TYPE.BOOLEAN == gts.getType()) {
+        GeoTimeSerie result = gts.clone();
+        GTSHelper.booleanNot(result);
+        stack.push(result);
+      } else {
+        throw new WarpScriptException(getName() + " can only operate on a boolean value or a boolean GTS.");
+      }
+    }
+    else {
+      throw new WarpScriptException(getName() + " can only operate on a boolean value or a boolean GTS.");
     }
     
     return stack;


### PR DESCRIPTION
Fix the fate of boolean GTS operation in Warp 10 2.0 : allow not, and, or, xor on boolean GTS.
Tried to optimize NOT with flip operation, but I didn't test performances.

I choose to implement and or xor bitwise operators, not condition ones... I can change.