### PR TITLE
Fixes to chunks methods and cleaning of WS functions.

### DIFF
--- a/warp10/src/main/java/io/warp10/script/functions/CHUNK.java
+++ b/warp10/src/main/java/io/warp10/script/functions/CHUNK.java
@@ -24,7 +24,7 @@ import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptStack;
 
 /**
- * Apply chunk on GTS instances
+ * Apply chunk on GTS or GTSEncoder instances
  * <p>
  * CHUNK expects the following parameters on the stack:
  * <p>
@@ -103,7 +103,7 @@ public class CHUNK extends ElementOrListStackFunction {
         } else if (element instanceof GTSEncoder) {
           return GTSHelper.chunk((GTSEncoder) element, lastChunk, chunkWidth, chunkCount, chunkLabel, keepEmpty, overlap);
         } else {
-          throw new WarpScriptException(getName() + " expects a Geo Time Series, a GTSEncode or a list thereof under the lastchunk parameter.");
+          throw new WarpScriptException(getName() + " expects a Geo Time Series, a GTSEncoder or a list thereof under the lastchunk parameter.");
         }
       }
     };

--- a/warp10/src/main/java/io/warp10/script/functions/CHUNKENCODER.java
+++ b/warp10/src/main/java/io/warp10/script/functions/CHUNKENCODER.java
@@ -16,23 +16,12 @@
 
 package io.warp10.script.functions;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
-
-import io.warp10.continuum.gts.GTSDecoder;
 import io.warp10.continuum.gts.GTSEncoder;
 import io.warp10.continuum.gts.GTSHelper;
-import io.warp10.continuum.store.thrift.data.Metadata;
 import io.warp10.script.NamedWarpScriptFunction;
-import io.warp10.script.WarpScriptStackFunction;
-import io.warp10.CapacityExtractorOutputStream;
 import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptStack;
+import io.warp10.script.WarpScriptStackFunction;
 
 /**
  * Chunk a GTSEncoder instance into multiple encoders.


### PR DESCRIPTION
- Fix missing overlap for first and last chunk of GTSs.
- Removes useless and buggy code for chunks on GTSs.
- Fix bug with chunks of GTSEncoder when keeping empty chunks.
- Changed from TreeMap to HashMap for chunks(GTSEncoders) because ordering was not needed.
- Imports cleaning, typos fixes, more comments.