### PR TITLE
Fix pack parsing for booleans, factorize parsing, allow U for PACK.

### DIFF
--- a/warp10/src/main/java/io/warp10/script/functions/PACK.java
+++ b/warp10/src/main/java/io/warp10/script/functions/PACK.java
@@ -16,7 +16,6 @@
 
 package io.warp10.script.functions;
 
-import io.warp10.continuum.gts.UnsafeString;
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptStack;
@@ -62,84 +61,18 @@ public class PACK extends NamedWarpScriptFunction implements WarpScriptStackFunc
     //
     // Parse the format
     //
-    
-    int idx = 0;
 
-    List<String> types = new ArrayList<String>();
+    List<Boolean> bigendians = new ArrayList<Boolean>();
+    List<Character> types = new ArrayList<Character>();
     List<Integer> lengths = new ArrayList<Integer>();
     
-    int totalbits = 0;
-    
-    while(idx < fmt.length()) {
-      
-      String type = new String(UnsafeString.substring(fmt, idx, idx + 2));
-      
-      char prefix = fmt.charAt(idx++);
-      
-      if (idx > fmt.length()) {
-        throw new WarpScriptException(getName() + " encountered an invalid format specification.");
-      }
-      
-      int len = 0;
-      
-      if ('<' == prefix || '>' == prefix) {
-        char t = fmt.charAt(idx++);
-                
-        boolean nolen = false;
-        
-        if ('L' == t) {
-          len = 64;
-        } else if ('D' == t) {
-          len = 64;
-          nolen = true;
-        } else {
-          throw new WarpScriptException(getName() + " encountered an invalid format specification '" + prefix + t + "'.");
-        }
-        
-        // Check if we have a length
-        if (!nolen && idx < fmt.length()) {
-          if (fmt.charAt(idx) <= '9' && fmt.charAt(idx) >= '0') {
-            len = 0;
-            while (idx < fmt.length() && fmt.charAt(idx) <= '9' && fmt.charAt(idx) >= '0') {
-              len *= 10;
-              len += (int) (fmt.charAt(idx++) - '0');
-            }
-          }
-        }
-        
-        if (len > 64) {
-          throw new WarpScriptException(getName() + " encountered an invalid length for 'L', max length is 64.");
-        }
-      } else if ('S' == prefix || 's' == prefix) {
-        type = "" + prefix;
-        if (idx >= fmt.length()) {
-          throw new WarpScriptException(getName() + " encountered an invalid Skip specification.");
-        }
-        if (fmt.charAt(idx) <= '9' && fmt.charAt(idx) >= '0') {
-          len = 0;
-          while (idx < fmt.length() && fmt.charAt(idx) <= '9' && fmt.charAt(idx) >= '0') {
-            len *= 10;
-            len += (int) (fmt.charAt(idx++) - '0');
-          }
-        }
-      } else if ('B' == prefix) {
-        type = "" + prefix;
-        len = 1;
-      } else {
-        throw new WarpScriptException(getName() + " encountered an invalid format specification '" + prefix + "'.");
-      }
-      
-      types.add(type);
-      lengths.add(len);
-      
-      totalbits += len;
-    }
+    int totalbits = PACK.parseFormat(this, fmt, bigendians, types, lengths);
 
     //
     // Now encode the various values
     //
     
-    ByteArrayOutputStream baos = new ByteArrayOutputStream(((totalbits + 7) / 8));
+    ByteArrayOutputStream baos = new ByteArrayOutputStream(((totalbits + 7) / 8)); // Round up to multiple of 8
     
     int nbits = 0;
     int vidx = 0;
@@ -151,14 +84,10 @@ public class PACK extends NamedWarpScriptFunction implements WarpScriptStackFunc
       int len = lengths.get(i);
       long value = 0L;
       
-      boolean bigendian = true;
-
-      if ("s".equals(types.get(i))) {
+      if ('s' == types.get(i)) {
         value = 0L;
-        bigendian = false;
-      } else if ("S".equals(types.get(i))) {
+      } else if ('S' == types.get(i)) {
         value = 0xFFFFFFFFFFFFFFFFL;
-        bigendian = false;
       } else {
         Object v = values.get(vidx++);
         
@@ -170,26 +99,17 @@ public class PACK extends NamedWarpScriptFunction implements WarpScriptStackFunc
           }
         }
 
-        if ("<D".equals(types.get(i))) {
-          bigendian = false;
+        if ('D' == types.get(i)) {
           value = Double.doubleToRawLongBits(((Number) v).doubleValue());
-        } else if (">D".equals(types.get(i))) {
-          bigendian = true;
-          value = Double.doubleToRawLongBits(((Number) v).doubleValue());        
-        } else if ("<L".equals(types.get(i))) {
-          bigendian = false;
+        } else if ('L' == types.get(i) || 'U' == types.get(i)) {
           value = ((Number) v).longValue();
-        } else if (">L".equals(types.get(i))) {
-          bigendian = true;          
-          value = ((Number) v).longValue();
-        } else if ("B".equals(types.get(i))) {
-          bigendian = false;
+        } else if ('B' == types.get(i)) {
           value = 0 != ((Number) v).longValue() ? 1L : 0L;
         }
       }
-      
-      if (bigendian) {
-        
+
+      // Reverse bits for big endians
+      if (bigendians.get(i)) {
         value = Long.reverse(value);
         
         if (len < 64) {
@@ -210,6 +130,7 @@ public class PACK extends NamedWarpScriptFunction implements WarpScriptStackFunc
       }
     }
 
+    // Right-pad with zeros
     if (0 != nbits % 8) {
       curbyte <<= 8 - (nbits % 8);
       baos.write((int) (curbyte & 0xFFL));
@@ -219,4 +140,71 @@ public class PACK extends NamedWarpScriptFunction implements WarpScriptStackFunc
     
     return stack;
   }
+
+  public static int parseFormat(NamedWarpScriptFunction function, String format, List<Boolean> bigendians, List<Character> types, List<Integer> lengths) throws WarpScriptException {
+    int idx = 0;
+    int totalbits = 0;
+
+    while (idx < format.length()) {
+
+      boolean isBigendian = false;
+
+      char type = format.charAt(idx++);
+
+      int len = 0;
+
+      if ('<' == type || '>' == type) {
+        if (idx >= format.length()) {
+          throw new WarpScriptException(function.getName() + " encountered an invalid format specification.");
+        }
+
+        isBigendian = '>' == type;
+
+        type = format.charAt(idx++);
+
+        if ('L' == type || 'U' == type) {
+          // Parse length
+          while (idx < format.length() && format.charAt(idx) <= '9' && format.charAt(idx) >= '0') {
+            len *= 10;
+            len += (int) (format.charAt(idx++) - '0');
+          }
+
+          if (0 == len) {
+            // If no specified length, fall back to 64
+            len = 64;
+          } else if (len > 64) {
+            throw new WarpScriptException(function.getName() + " encountered an invalid length for 'L', max length is 64.");
+          }
+        } else if ('D' == type) {
+          len = 64;
+        } else {
+          throw new WarpScriptException(function.getName() + " encountered an invalid format specification '" + type + "'.");
+        }
+      } else if ('S' == type || 's' == type) {
+        // Parse length
+        while (idx < format.length() && format.charAt(idx) <= '9' && format.charAt(idx) >= '0') {
+          len *= 10;
+          len += (int) (format.charAt(idx++) - '0');
+        }
+
+        // If no specified length, error.
+        if (0 == len) {
+          throw new WarpScriptException(function.getName() + " encountered an invalid Skip specification, length must be a strictly positive number.");
+        }
+      } else if ('B' == type) {
+        len = 1;
+      } else {
+        throw new WarpScriptException(function.getName() + " encountered an invalid format specification '" + type + "'.");
+      }
+
+      bigendians.add(isBigendian);
+      types.add(type);
+      lengths.add(len);
+
+      totalbits += len;
+    }
+
+    return totalbits;
+  }
+
 }

--- a/warp10/src/main/java/io/warp10/script/functions/PACK.java
+++ b/warp10/src/main/java/io/warp10/script/functions/PACK.java
@@ -159,7 +159,7 @@ public class PACK extends NamedWarpScriptFunction implements WarpScriptStackFunc
           throw new WarpScriptException(function.getName() + " encountered an invalid format specification.");
         }
 
-        isBigendian = '>' == type;
+        isBigendian = ('>' == type);
 
         type = format.charAt(idx++);
 

--- a/warp10/src/main/java/io/warp10/script/functions/PACK.java
+++ b/warp10/src/main/java/io/warp10/script/functions/PACK.java
@@ -23,6 +23,7 @@ import io.warp10.script.WarpScriptStackFunction;
 
 import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
+import java.util.BitSet;
 import java.util.List;
 
 /**
@@ -62,7 +63,7 @@ public class PACK extends NamedWarpScriptFunction implements WarpScriptStackFunc
     // Parse the format
     //
 
-    List<Boolean> bigendians = new ArrayList<Boolean>();
+    BitSet bigendians = new BitSet();
     List<Character> types = new ArrayList<Character>();
     List<Integer> lengths = new ArrayList<Integer>();
     
@@ -141,7 +142,7 @@ public class PACK extends NamedWarpScriptFunction implements WarpScriptStackFunc
     return stack;
   }
 
-  public static int parseFormat(NamedWarpScriptFunction function, String format, List<Boolean> bigendians, List<Character> types, List<Integer> lengths) throws WarpScriptException {
+  public static int parseFormat(NamedWarpScriptFunction function, String format, BitSet bigendians, List<Character> types, List<Integer> lengths) throws WarpScriptException {
     int idx = 0;
     int totalbits = 0;
 
@@ -197,7 +198,9 @@ public class PACK extends NamedWarpScriptFunction implements WarpScriptStackFunc
         throw new WarpScriptException(function.getName() + " encountered an invalid format specification '" + type + "'.");
       }
 
-      bigendians.add(isBigendian);
+      // Can't use bigendians.size() nor bigendians.length() because they don't give the number of defined bits (set or cleared).
+      // bigendians, types and lengths contains the same number of elements, so we can use either types.size() or lengths.size().
+      bigendians.set(types.size(), isBigendian);
       types.add(type);
       lengths.add(len);
 

--- a/warp10/src/main/java/io/warp10/script/functions/UNPACK.java
+++ b/warp10/src/main/java/io/warp10/script/functions/UNPACK.java
@@ -16,7 +16,6 @@
 
 package io.warp10.script.functions;
 
-import io.warp10.continuum.gts.UnsafeString;
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptStack;
@@ -52,92 +51,22 @@ public class UNPACK extends NamedWarpScriptFunction implements WarpScriptStackFu
     }
     
     byte[] data = (byte[]) o;
-    
+
     //
     // Parse the format
     //
-    
-    int idx = 0;
 
-    List<String> types = new ArrayList<String>();
+    List<Boolean> bigendians = new ArrayList<Boolean>();
+    List<Character> types = new ArrayList<Character>();
     List<Integer> lengths = new ArrayList<Integer>();
-    
-    while(idx < fmt.length()) {
-      
-      String type = new String(UnsafeString.substring(fmt, idx, idx + 2));
-      
-      char prefix = fmt.charAt(idx++);
-      
-      if (idx > fmt.length()) {
-        throw new WarpScriptException(getName() + " encountered an invalid format specification.");
-      }
-      
-      int len = 0;
-      
-      if ('<' == prefix || '>' == prefix) {
-        char t = fmt.charAt(idx++);
-                
-        boolean nolen = false;
-        
-        if ('L' == t || 'U' == t) {
-          len = 64;
-        } else if ('D' == t) {
-          len = 64;
-          nolen = true;
-        } else {
-          throw new WarpScriptException(getName() + " encountered an invalid format specification '" + prefix + t + "'.");
-        }
-        
-        // Check if we have a length
-        if (!nolen && idx < fmt.length()) {
-          if (fmt.charAt(idx) <= '9' && fmt.charAt(idx) >= '0') {
-            len = 0;
-            while (idx < fmt.length() && fmt.charAt(idx) <= '9' && fmt.charAt(idx) >= '0') {
-              len *= 10;
-              len += (int) (fmt.charAt(idx++) - '0');
-            }
-          }
-        }
-        
-        if (len > 64) {
-          throw new WarpScriptException(getName() + " encountered an invalid length for 'L', max length is 64.");
-        }
-      } else if ('S' == prefix || 's' == prefix) {
-        type = "" + prefix;
-        if (idx >= fmt.length()) {
-          throw new WarpScriptException(getName() + " encountered an invalid Skip specification.");
-        }
-        if (fmt.charAt(idx) <= '9' && fmt.charAt(idx) >= '0') {
-          len = 0;
-          while (idx < fmt.length() && fmt.charAt(idx) <= '9' && fmt.charAt(idx) >= '0') {
-            len *= 10;
-            len += (int) (fmt.charAt(idx++) - '0');
-          }
-        }
-      } else if ('B' == prefix) {
-        type = "" + prefix;
-        len = 1;
-      } else {
-        throw new WarpScriptException(getName() + " encountered an invalid format specification '" + prefix + "'.");
-      }
-      
-      types.add(type);
-      lengths.add(len);      
-    }
+
+    PACK.parseFormat(this, fmt, bigendians, types, lengths);
 
     //
     // Now decode the various values
     //
     
     int bitno = 0;
-    
-//    BitSet bits = new BitSet(data.length * 8);
-//    
-//    for (int i = 0; i < data.length * 8; i++) {
-//      if ((data[i/8] & (1 << (7 - (i % 8)))) != 0) {
-//        bits.set(i);
-//      }
-//    }
 
     //
     // Invert the bits of the input data
@@ -154,26 +83,21 @@ public class UNPACK extends NamedWarpScriptFunction implements WarpScriptStackFu
     List<Object> values = new ArrayList<Object>();
     
     for (int i = 0; i < types.size(); i++) {
-      
+
+      char type = types.get(i);
       int len = lengths.get(i);
       
-      if ("s".equals(types.get(i)) || "S".equals(types.get(i))) {
+      if ('s' == type || 'S' == type) {
         bitno += len;
         continue;
       }
       
-      if ("B".equals(types.get(i))) {
+      if ('B' == type) {
         values.add(bits.get(bitno++));
         continue;
       }
       
-      boolean bigendian = true;
-      
-      if (types.get(i).startsWith("<")) {
-        bigendian = false;
-      } else {
-        bigendian = true;
-      }
+      boolean bigendian = bigendians.get(i);
       
       //
       // Extract bits
@@ -193,14 +117,14 @@ public class UNPACK extends NamedWarpScriptFunction implements WarpScriptStackFu
 
       bitno += len;
 
-      switch (types.get(i).charAt(1)) {
-        case 'D':
+      switch (type) {
+        case 'D': // double
           values.add(Double.longBitsToDouble(value));
           break;
-        case 'L':
+        case 'L': // long
           values.add((value << (64 - len)) >> (64 - len));
           break;
-        case 'U':
+        case 'U': // Unsigned long
           values.add(value);
           break;
       }

--- a/warp10/src/main/java/io/warp10/script/functions/UNPACK.java
+++ b/warp10/src/main/java/io/warp10/script/functions/UNPACK.java
@@ -75,6 +75,7 @@ public class UNPACK extends NamedWarpScriptFunction implements WarpScriptStackFu
     byte[] atad = new byte[data.length];
     
     for (int i = 0; i < data.length; i++) {
+      // see http://graphics.stanford.edu/~seander/bithacks.html#ReverseByteWith64BitsDiv
       atad[i] = (byte) ((((((long) data[i]) & 0xFFL) * 0x0202020202L & 0x010884422010L) % 1023L) & 0xFFL);
     }
     

--- a/warp10/src/main/java/io/warp10/script/functions/UNPACK.java
+++ b/warp10/src/main/java/io/warp10/script/functions/UNPACK.java
@@ -56,7 +56,7 @@ public class UNPACK extends NamedWarpScriptFunction implements WarpScriptStackFu
     // Parse the format
     //
 
-    List<Boolean> bigendians = new ArrayList<Boolean>();
+    BitSet bigendians = new BitSet();
     List<Character> types = new ArrayList<Character>();
     List<Integer> lengths = new ArrayList<Integer>();
 


### PR DESCRIPTION
Parsing when using B could fail, like this script `[ T ] 'B' PACK`
U for PACK is equivalent to L but it makes it easier to use the same format for PACK and UNPACK.

Tested using:
```
[
  RAND
  RAND
  RAND 1e6 *
  RAND 1e6 *
  RAND 1e60 *
  RAND 1e60 *
  RAND 1e6000 *
  RAND 1e6000 *
  Infinity
  Infinity
  NaN
  NaN
  15
  15
  MAXLONG
  MINLONG
  MAXLONG
  MINLONG
  MAXLONG
  MAXLONG
  -15
  -15
  31
  31
  42
  F
  42
  T
  42
  F
  42
  T
  T
]
'data' STORE
'<D>D<D>D<D>D<D>D<D>D<D>D<U4s7>U4<L<LS9>L>L>U<U>L5s1<L5<U5>U5<LBS77>LB<LB>LBB' 'format' STORE

$data $format PACK $format UNPACK

$data 2 ->LIST ZIP
<%
  DROP
  LIST-> DROP
  ==
%>
LMAP

AND ASSERT
```