### PR TITLE
Fix check

### DIFF
--- a/warp10/src/main/java/io/warp10/standalone/StandaloneSplitsHandler.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneSplitsHandler.java
@@ -86,6 +86,11 @@ public class StandaloneSplitsHandler extends AbstractHandler {
     //
     
     ReadToken rtoken;
+
+    if (null == token) {
+      response.sendError(HttpServletResponse.SC_FORBIDDEN, "Missing token.");
+      return;
+    }
     
     try {
       rtoken = Tokens.extractReadToken(token);
@@ -95,11 +100,6 @@ public class StandaloneSplitsHandler extends AbstractHandler {
       }
     } catch (WarpScriptException ee) {
       throw new IOException(ee);
-    }
-
-    if (null == rtoken) {
-      response.sendError(HttpServletResponse.SC_FORBIDDEN, "Missing token.");
-      return;
     }
 
     //


### PR DESCRIPTION
`rtoken` cannot be `null` else an exception would be thrown a few line above.
`token` however could be missing from the request, so change the test to check that.