### PR TITLE
Stop the server when address is already in use.

### DIFF
--- a/warp10/src/main/java/io/warp10/standalone/Warp.java
+++ b/warp10/src/main/java/io/warp10/standalone/Warp.java
@@ -342,14 +342,14 @@ public class Warp extends WarpDist implements Runnable {
       
       if (!"false".equals(properties.getProperty(Configuration.IN_MEMORY_CHUNKED))) {
         scc = new StandaloneChunkedMemoryStore(properties, keystore);
-        ((StandaloneChunkedMemoryStore) scc).setDirectoryClient((StandaloneDirectoryClient) sdc);
+        ((StandaloneChunkedMemoryStore) scc).setDirectoryClient(sdc);
         ((StandaloneChunkedMemoryStore) scc).load();
       } else {
         scc = new StandaloneMemoryStore(keystore,
             Long.valueOf(properties.getProperty(Configuration.IN_MEMORY_DEPTH, Long.toString(60 * 60 * 1000 * Constants.TIME_UNITS_PER_MS))),
             Long.valueOf(properties.getProperty(Configuration.IN_MEMORY_HIGHWATERMARK, "100000")),
             Long.valueOf(properties.getProperty(Configuration.IN_MEMORY_LOWWATERMARK, "80000")));
-        ((StandaloneMemoryStore) scc).setDirectoryClient((StandaloneDirectoryClient) sdc);
+        ((StandaloneMemoryStore) scc).setDirectoryClient(sdc);
         if ("true".equals(properties.getProperty(Configuration.IN_MEMORY_EPHEMERAL))) {
           ((StandaloneMemoryStore) scc).setEphemeral(true);
         }        
@@ -524,6 +524,7 @@ public class Warp extends WarpDist implements Runnable {
       }
       server.start();
     } catch (Exception e) {
+      server.stop();
       throw new RuntimeException(e);
     }
     

--- a/warp10/src/main/sh/warp10-standalone.sh
+++ b/warp10/src/main/sh/warp10-standalone.sh
@@ -164,10 +164,11 @@ isUser() {
 #
 isStarted() {
   # Don't use 'ps -p' for docker compatibility
-  if [ -e ${PID_FILE} ] && ps -Ao pid | grep "^\s*$(cat ${PID_FILE})$" > /dev/null; then
-    return 0
+  if [[ -e ${PID_FILE} ]] && ps -Ao pid | grep "^\s*$(cat ${PID_FILE})$" > /dev/null; then
+    true
+  else
+    false
   fi
-  return 1
 }
 
 CONFIG_FILES=
@@ -416,8 +417,7 @@ start() {
 
   echo $! > ${PID_FILE}
 
-  isStarted
-  if [ $? -eq 1 ]; then
+  if ! isStarted; then
     echo "Start failed! - See ${WARP10_HOME}/logs/warp10.log for more details"
     exit 1
   fi
@@ -466,8 +466,7 @@ start() {
 
   # Check again 5s later (time for plugin load errors)
   sleep 5
-  isStarted
-  if [ $? -eq 1 ]; then
+  if ! isStarted; then
     echo "Start failed! - See ${WARP10_HOME}/logs/warp10.log for more details"
     exit 1
   fi


### PR DESCRIPTION
When the address is already in use (BindExection) the server doesn't stop and there is no error message from the terminal.

Stop the server on BindException
Fix use of isStarted function 