### PR TITLE
Do not check nullity when instanceof already does

### DIFF
--- a/warp10/src/main/java/io/warp10/continuum/egress/EgressExecHandler.java
+++ b/warp10/src/main/java/io/warp10/continuum/egress/EgressExecHandler.java
@@ -325,7 +325,7 @@ public class EgressExecHandler extends AbstractHandler {
       
       Object exported = stack.getAttribute(WarpScriptStack.ATTRIBUTE_EXPORTED_SYMBOLS);
       
-      if (null != exported && exported instanceof Set && !((Set) exported).isEmpty()) {
+      if (exported instanceof Set && !((Set) exported).isEmpty()) {
         Map<String,Object> exports = new HashMap<String,Object>();
         Map<String,Object> symtable = stack.getSymbolTable();
         for (Object symbol: (Set) exported) {
@@ -382,7 +382,7 @@ public class EgressExecHandler extends AbstractHandler {
       
       Object exported = stack.getAttribute(WarpScriptStack.ATTRIBUTE_EXPORTED_SYMBOLS);
       
-      if (null != exported && exported instanceof Set && !((Set) exported).isEmpty()) {
+      if (exported instanceof Set && !((Set) exported).isEmpty()) {
         Map<String,Object> exports = new HashMap<String,Object>();
         Map<String,Object> symtable = stack.getSymbolTable();
         for (Object symbol: (Set) exported) {

--- a/warp10/src/main/java/io/warp10/script/WarpScriptLib.java
+++ b/warp10/src/main/java/io/warp10/script/WarpScriptLib.java
@@ -1749,20 +1749,6 @@ public class WarpScriptLib {
   public static List<String> extensions() {
     return new ArrayList<String>(extloaded);
   }
-  
-  /**
-   * Check whether or not an object is castable to a macro
-   * @param o
-   * @return
-   */
-  public static boolean isMacro(Object o) {
-    
-    if (null == o) {
-      return false;
-    }
-    
-    return o instanceof Macro;
-  }
 
   public static ArrayList getFunctionNames() {
 

--- a/warp10/src/main/java/io/warp10/script/aggregator/StandardDeviation.java
+++ b/warp10/src/main/java/io/warp10/script/aggregator/StandardDeviation.java
@@ -64,7 +64,7 @@ public class StandardDeviation extends NamedWarpScriptFunction implements WarpSc
   public Object apply(Object[] args) throws io.warp10.script.WarpScriptException {
     Object[] var = (Object[]) variance.apply(args); 
     
-    if (4 != var.length || null == var[3] || !(var[3] instanceof Number)) {
+    if (4 != var.length || !(var[3] instanceof Number)) {
       return new Object[] { Long.MAX_VALUE, GeoTimeSerie.NO_LOCATION, GeoTimeSerie.NO_ELEVATION, null };
     }
     

--- a/warp10/src/main/java/io/warp10/script/binary/CondShortCircuit.java
+++ b/warp10/src/main/java/io/warp10/script/binary/CondShortCircuit.java
@@ -23,7 +23,7 @@ import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptStackFunction;
 import io.warp10.script.WarpScriptStack;
 import io.warp10.script.WarpScriptException;
-import io.warp10.script.WarpScriptLib;
+import io.warp10.script.WarpScriptStack.Macro;
 
 import java.util.List;
 
@@ -62,8 +62,8 @@ public abstract class CondShortCircuit extends NamedWarpScriptFunction implement
       // exiting, triggerValue() is putted on top of the stack.
       for (Object operand : (List) top) {
         // If a macro is found, execute it and use the result as the operand.
-        if (WarpScriptLib.isMacro(operand)) {
-          stack.exec((WarpScriptStack.Macro) operand);
+        if (operand instanceof Macro) {
+          stack.exec((Macro) operand);
           operand = stack.pop();
         }
 

--- a/warp10/src/main/java/io/warp10/script/ext/token/TOKENSECRET.java
+++ b/warp10/src/main/java/io/warp10/script/ext/token/TOKENSECRET.java
@@ -44,7 +44,7 @@ public class TOKENSECRET extends NamedWarpScriptFunction implements WarpScriptSt
     // pop the new secret to use
     top = stack.pop();
     
-    if (null == top || !(top instanceof String)) {
+    if (!(top instanceof String)) {
       throw new WarpScriptException(getName() + " expects a new secret which is a non null string.");
     }
     

--- a/warp10/src/main/java/io/warp10/script/functions/EXPORT.java
+++ b/warp10/src/main/java/io/warp10/script/functions/EXPORT.java
@@ -42,7 +42,7 @@ public class EXPORT extends NamedWarpScriptFunction implements WarpScriptStackFu
     
     Set symbols = null;
     
-    if (null != osymbols && osymbols instanceof Set) {
+    if (osymbols instanceof Set) {
       symbols = (Set) osymbols;
     }
     

--- a/warp10/src/main/java/io/warp10/script/functions/FOR.java
+++ b/warp10/src/main/java/io/warp10/script/functions/FOR.java
@@ -19,7 +19,6 @@ package io.warp10.script.functions;
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptStackFunction;
 import io.warp10.script.WarpScriptException;
-import io.warp10.script.WarpScriptLib;
 import io.warp10.script.WarpScriptLoopBreakException;
 import io.warp10.script.WarpScriptLoopContinueException;
 import io.warp10.script.WarpScriptStack;
@@ -65,7 +64,7 @@ public class FOR extends NamedWarpScriptFunction implements WarpScriptStackFunct
     Object to = stack.pop(); // TO
     Object from = stack.pop(); // FROM
     
-    if (!WarpScriptLib.isMacro(macro)) {
+    if (!(macro instanceof Macro)) {
       throw new WarpScriptException(getName() + " expects a macro on top of the stack.");
     }
     

--- a/warp10/src/main/java/io/warp10/script/functions/FOREACH.java
+++ b/warp10/src/main/java/io/warp10/script/functions/FOREACH.java
@@ -23,7 +23,6 @@ import io.warp10.continuum.gts.GeoTimeSerie;
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptStackFunction;
 import io.warp10.script.WarpScriptException;
-import io.warp10.script.WarpScriptLib;
 import io.warp10.script.WarpScriptLoopBreakException;
 import io.warp10.script.WarpScriptLoopContinueException;
 import io.warp10.script.WarpScriptStack;
@@ -57,7 +56,7 @@ public class FOREACH extends NamedWarpScriptFunction implements WarpScriptStackF
     Object macro = stack.pop(); // RUN-macro
     Object obj = stack.pop(); // LIST or MAP
     
-    if (!WarpScriptLib.isMacro(macro)) {
+    if (!(macro instanceof Macro)) {
       throw new WarpScriptException(getName() + " expects a macro on top of the stack.");
     }
     

--- a/warp10/src/main/java/io/warp10/script/functions/FORSTEP.java
+++ b/warp10/src/main/java/io/warp10/script/functions/FORSTEP.java
@@ -19,7 +19,6 @@ package io.warp10.script.functions;
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptStackFunction;
 import io.warp10.script.WarpScriptException;
-import io.warp10.script.WarpScriptLib;
 import io.warp10.script.WarpScriptLoopBreakException;
 import io.warp10.script.WarpScriptLoopContinueException;
 import io.warp10.script.WarpScriptStack;
@@ -68,7 +67,7 @@ public class FORSTEP extends NamedWarpScriptFunction implements WarpScriptStackF
     Object to = stack.pop(); // TO
     Object from = stack.pop(); // FROM
     
-    if (!WarpScriptLib.isMacro(macroRun) || !WarpScriptLib.isMacro(macroStep)) {
+    if (!(macroRun instanceof Macro) || !(macroStep instanceof Macro)) {
       throw new WarpScriptException(getName() + " expects two macros on top of the stack.");
     }
     

--- a/warp10/src/main/java/io/warp10/script/functions/IFT.java
+++ b/warp10/src/main/java/io/warp10/script/functions/IFT.java
@@ -19,7 +19,6 @@ package io.warp10.script.functions;
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptStackFunction;
 import io.warp10.script.WarpScriptException;
-import io.warp10.script.WarpScriptLib;
 import io.warp10.script.WarpScriptStack;
 import io.warp10.script.WarpScriptStack.Macro;
 
@@ -50,7 +49,7 @@ public class IFT extends NamedWarpScriptFunction implements WarpScriptStackFunct
     // Check than thenMacro is a macro, ifMacro will be checked later.
     //
     
-    if (!WarpScriptLib.isMacro(thenMacro)) {
+    if (!(thenMacro instanceof Macro)) {
       throw new WarpScriptException(getName() + " expects a *THEN* macro on top of the stack.");
     }
     
@@ -60,7 +59,7 @@ public class IFT extends NamedWarpScriptFunction implements WarpScriptStackFunct
 
     boolean ifResult;
 
-    if (WarpScriptLib.isMacro(ifMacro)) {
+    if (ifMacro instanceof Macro) {
       stack.exec((Macro) ifMacro);
 
       // Check that the top of the stack is a boolean

--- a/warp10/src/main/java/io/warp10/script/functions/IFTE.java
+++ b/warp10/src/main/java/io/warp10/script/functions/IFTE.java
@@ -19,7 +19,6 @@ package io.warp10.script.functions;
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptStackFunction;
 import io.warp10.script.WarpScriptException;
-import io.warp10.script.WarpScriptLib;
 import io.warp10.script.WarpScriptStack;
 import io.warp10.script.WarpScriptStack.Macro;
 
@@ -52,7 +51,7 @@ public class IFTE extends NamedWarpScriptFunction implements WarpScriptStackFunc
     // Check that thenMacro and elseMacro are macros, ifMacro will be checked later
     //
 
-    if (!WarpScriptLib.isMacro(elseMacro) && !WarpScriptLib.isMacro(thenMacro)) {
+    if (!(elseMacro instanceof Macro) || !(thenMacro instanceof Macro)) {
       throw new WarpScriptException(getName() + " expects three macros or two macros and a boolean on top of the stack.");
     }
 
@@ -62,7 +61,7 @@ public class IFTE extends NamedWarpScriptFunction implements WarpScriptStackFunc
 
     boolean ifResult;
 
-    if (WarpScriptLib.isMacro(ifMacro)) {
+    if (ifMacro instanceof Macro) {
       // Execute the IF macro
       stack.exec((Macro) ifMacro);
 

--- a/warp10/src/main/java/io/warp10/script/functions/LFLATMAP.java
+++ b/warp10/src/main/java/io/warp10/script/functions/LFLATMAP.java
@@ -19,7 +19,6 @@ package io.warp10.script.functions;
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptStackFunction;
 import io.warp10.script.WarpScriptException;
-import io.warp10.script.WarpScriptLib;
 import io.warp10.script.WarpScriptStack;
 import io.warp10.script.WarpScriptStack.Macro;
 
@@ -48,7 +47,7 @@ public class LFLATMAP extends NamedWarpScriptFunction implements WarpScriptStack
 
     Object macro = stack.pop();
     
-    if (!WarpScriptLib.isMacro(macro)) {
+    if (!(macro instanceof Macro)) {
       throw new WarpScriptException(getName() + " expects a macro on top of the stack.");
     }
     

--- a/warp10/src/main/java/io/warp10/script/functions/LMAP.java
+++ b/warp10/src/main/java/io/warp10/script/functions/LMAP.java
@@ -19,7 +19,6 @@ package io.warp10.script.functions;
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptStackFunction;
 import io.warp10.script.WarpScriptException;
-import io.warp10.script.WarpScriptLib;
 import io.warp10.script.WarpScriptStack;
 import io.warp10.script.WarpScriptStack.Macro;
 
@@ -47,7 +46,7 @@ public class LMAP extends NamedWarpScriptFunction implements WarpScriptStackFunc
     
     Object macro = stack.pop();
     
-    if (!WarpScriptLib.isMacro(macro)) {
+    if (!(macro instanceof Macro)) {
       throw new WarpScriptException(getName() + " expects a macro on top of the stack.");
     }
     

--- a/warp10/src/main/java/io/warp10/script/functions/MACROCONFIGSECRET.java
+++ b/warp10/src/main/java/io/warp10/script/functions/MACROCONFIGSECRET.java
@@ -52,7 +52,7 @@ public class MACROCONFIGSECRET extends NamedWarpScriptFunction implements WarpSc
     // pop the new secret to use
     top = stack.pop();
     
-    if (null == top || !(top instanceof String)) {
+    if (!(top instanceof String)) {
       throw new WarpScriptException(getName() + " expects a new secret which is a non null string.");
     }
     

--- a/warp10/src/main/java/io/warp10/script/functions/SETMACROCONFIG.java
+++ b/warp10/src/main/java/io/warp10/script/functions/SETMACROCONFIG.java
@@ -40,7 +40,7 @@ public class SETMACROCONFIG extends NamedWarpScriptFunction implements WarpScrip
     
     Object top = stack.pop();
     
-    if (null == top || !(top instanceof String)) {
+    if (!(top instanceof String)) {
       throw new WarpScriptException(getName() + " expects the macroconfig secret on top of the stack.");
     }
     

--- a/warp10/src/main/java/io/warp10/script/functions/SWITCH.java
+++ b/warp10/src/main/java/io/warp10/script/functions/SWITCH.java
@@ -19,7 +19,6 @@ package io.warp10.script.functions;
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptStackFunction;
 import io.warp10.script.WarpScriptException;
-import io.warp10.script.WarpScriptLib;
 import io.warp10.script.WarpScriptStack;
 import io.warp10.script.WarpScriptStack.Macro;
 
@@ -66,7 +65,7 @@ public class SWITCH extends NamedWarpScriptFunction implements WarpScriptStackFu
     
     Object defaultMacro = stack.pop();
     
-    if (!WarpScriptLib.isMacro(defaultMacro)) {
+    if (!(defaultMacro instanceof Macro)) {
       throw new WarpScriptException(getName() + " expects a default macro after the number of cases.");
     }
     
@@ -76,7 +75,7 @@ public class SWITCH extends NamedWarpScriptFunction implements WarpScriptStackFu
       cases[i * 2 + 1] = stack.pop();
       cases[i * 2] = stack.pop();
       
-      if (!WarpScriptLib.isMacro(cases[i * 2 + 1]) || !WarpScriptLib.isMacro(cases[i * 2])) {
+      if (!(cases[i * 2 + 1] instanceof Macro) || !(cases[i * 2] instanceof Macro)) {
         throw new WarpScriptException(getName() + " expects each case to be a set of two macros, a conditional macro with an 'exec' macro on top of it.");
       }
     }

--- a/warp10/src/main/java/io/warp10/script/functions/UNTIL.java
+++ b/warp10/src/main/java/io/warp10/script/functions/UNTIL.java
@@ -19,7 +19,6 @@ package io.warp10.script.functions;
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptStackFunction;
 import io.warp10.script.WarpScriptException;
-import io.warp10.script.WarpScriptLib;
 import io.warp10.script.WarpScriptLoopBreakException;
 import io.warp10.script.WarpScriptLoopContinueException;
 import io.warp10.script.WarpScriptStack;
@@ -68,7 +67,7 @@ public class UNTIL extends NamedWarpScriptFunction implements WarpScriptStackFun
     //
     
     for (Object macro: macros) {
-      if (!WarpScriptLib.isMacro(macro)) {
+      if (!(macro instanceof Macro)) {
         throw new WarpScriptException(getName() + " expects two macros on top of the stack.");
       }
     }

--- a/warp10/src/main/java/io/warp10/script/functions/WHILE.java
+++ b/warp10/src/main/java/io/warp10/script/functions/WHILE.java
@@ -19,7 +19,6 @@ package io.warp10.script.functions;
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptStackFunction;
 import io.warp10.script.WarpScriptException;
-import io.warp10.script.WarpScriptLib;
 import io.warp10.script.WarpScriptLoopBreakException;
 import io.warp10.script.WarpScriptLoopContinueException;
 import io.warp10.script.WarpScriptStack;
@@ -68,7 +67,7 @@ public class WHILE extends NamedWarpScriptFunction implements WarpScriptStackFun
     //
     
     for (Object macro: macros) {
-      if (!WarpScriptLib.isMacro(macro)) {
+      if (!(macro instanceof Macro)) {
         throw new WarpScriptException(getName() + " expects two macros on top of the stack.");
       }
     }

--- a/warp10/src/main/java/io/warp10/script/mapper/MapperKernelSmoother.java
+++ b/warp10/src/main/java/io/warp10/script/mapper/MapperKernelSmoother.java
@@ -62,7 +62,7 @@ public class MapperKernelSmoother extends NamedWarpScriptFunction implements War
     for (int i = 0; i < ticks.length; i++) {
       int idx = (int) (Math.abs(ticks[i] - tick) / step);
       
-      if (idx < this.weights.length && null != values[i] && values[i] instanceof Number) {
+      if (idx < this.weights.length && values[i] instanceof Number) {
         weightedValue += this.weights[idx] * ((Number) values[i]).doubleValue();
         valueDividend += this.weights[idx];
         


### PR DESCRIPTION
`o instanceof SomeClass` returns `false` when `o` is `null` so there is no need to test for nullity before `instanceof`.
This will stay that way as it is in the specs of Java: https://docs.oracle.com/javase/specs/jls/se11/html/jls-15.html#jls-15.20.2

Also fixes the testing of the types in IFTE.