### PR TITLE
Convert some GTSStackFunctions to ElementOrListStackFunction

### DIFF
--- a/warp10/src/main/java/io/warp10/continuum/gts/GTSEncoder.java
+++ b/warp10/src/main/java/io/warp10/continuum/gts/GTSEncoder.java
@@ -1294,6 +1294,8 @@ public class GTSEncoder {
     if (null != this.wrappingKey) {
       encoder.setWrappingKey(Arrays.copyOf(this.wrappingKey, this.wrappingKey.length));
     }
+
+    encoder.setMetadata(this.getMetadata());
     
     return encoder;
   }

--- a/warp10/src/main/java/io/warp10/script/functions/CLIP.java
+++ b/warp10/src/main/java/io/warp10/script/functions/CLIP.java
@@ -16,76 +16,90 @@
 
 package io.warp10.script.functions;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import io.warp10.continuum.gts.GTSEncoder;
 import io.warp10.continuum.gts.GTSHelper;
 import io.warp10.continuum.gts.GeoTimeSerie;
-import io.warp10.script.NamedWarpScriptFunction;
-import io.warp10.script.WarpScriptStackFunction;
+import io.warp10.script.ElementOrListStackFunction;
 import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptStack;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 /**
- * Clip a Geo Time Series according to a series of limits
+ * Clip Geo Time Series, GTSEncoder or a list thereof according to a series of limits
  */
-public class CLIP extends NamedWarpScriptFunction implements WarpScriptStackFunction {
-  
+public class CLIP extends ElementOrListStackFunction {
+
   public CLIP(String name) {
     super(name);
   }
-  
+
   @Override
-  public Object apply(WarpScriptStack stack) throws WarpScriptException {
+  public ElementStackFunction generateFunction(WarpScriptStack stack) throws WarpScriptException {
     Object top = stack.pop();
-    
+
     if (!(top instanceof List)) {
       throw new WarpScriptException(getName() + " expects a list of limit pairs on top of the stack.");
     }
-    
-    List<Object> limits = (List<Object>) top;
-    
-    top = stack.pop();
-    
-    if (!(top instanceof GeoTimeSerie) && !(top instanceof GTSEncoder)) {
-      throw new WarpScriptException(getName() + " operates on a Geo Time Series or encoder.");
-    }
-     
-    GeoTimeSerie gts = top instanceof GeoTimeSerie ? (GeoTimeSerie) top : null;
-    GTSEncoder encoder = top instanceof GTSEncoder ? (GTSEncoder) top: null;
 
-    List<Object> clipped = new ArrayList<Object>();
-    
+    final List<Object> limits = (List<Object>) top;
+
+    // Check that limits contains pair of ordered numeric bounds
     for (Object o: limits) {
       if (!(o instanceof List)) {
         throw new WarpScriptException(getName() + " expects a list of limit pairs on top of the stack.");
       }
-      
+
       List<Object> pair = (List<Object>) o;
-      
+
       if (2 != pair.size()) {
         throw new WarpScriptException(getName() + " expects a list of limit pairs on top of the stack.");
       }
-      
+
+      if (!(pair.get(0) instanceof Number) || !(pair.get(1) instanceof Number)) {
+        throw new WarpScriptException(getName() + " expects the limits to be numeric.");
+      }
+
       long lower = ((Number) pair.get(0)).longValue();
       long upper = ((Number) pair.get(1)).longValue();
-      
+
       if (lower > upper) {
-        long tmp = lower;
-        lower = upper;
-        upper = tmp;
-      }
-      
-      if (null != gts) {
-        clipped.add(GTSHelper.timeclip(gts, lower, upper));
-      } else {
-        clipped.add(GTSHelper.timeclip(encoder, lower, upper));
+        Collections.swap(pair, 0, 1);
       }
     }
-    
-    stack.push(clipped);
-    
-    return stack;
+
+    return new ElementStackFunction() {
+      @Override
+      public Object applyOnElement(Object element) throws WarpScriptException {
+
+        List<Object> clipped = new ArrayList<Object>();
+
+        if (element instanceof GeoTimeSerie) {
+          for (Object o: limits) {
+            List<Object> pair = (List<Object>) o;
+
+            long lower = ((Number) pair.get(0)).longValue();
+            long upper = ((Number) pair.get(1)).longValue();
+
+            clipped.add(GTSHelper.timeclip((GeoTimeSerie) element, lower, upper));
+          }
+        } else if (element instanceof GTSEncoder) {
+          for (Object o: limits) {
+            List<Object> pair = (List<Object>) o;
+
+            long lower = ((Number) pair.get(0)).longValue();
+            long upper = ((Number) pair.get(1)).longValue();
+
+            clipped.add(GTSHelper.timeclip((GTSEncoder) element, lower, upper));
+          }
+        } else {
+          throw new WarpScriptException(getName() + " expects a GeoTimeSeries, a GTSEncoder or a list thereof under the list of limit.");
+        }
+
+        return clipped;
+      }
+    };
   }
 }

--- a/warp10/src/main/java/io/warp10/script/functions/CLONEEMPTY.java
+++ b/warp10/src/main/java/io/warp10/script/functions/CLONEEMPTY.java
@@ -16,46 +16,39 @@
 
 package io.warp10.script.functions;
 
-import java.util.Map;
-
 import io.warp10.continuum.gts.GTSEncoder;
 import io.warp10.continuum.gts.GeoTimeSerie;
-import io.warp10.continuum.store.thrift.data.Metadata;
-import io.warp10.script.GTSStackFunction;
+import io.warp10.script.ElementOrListStackFunction;
 import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptStack;
 
 /**
- * Produce an empty clone of the parameter GTS instances 
- * 
+ * Produce an empty clone of the parameter GTS or Encoder instance or list thereof.
+ * <p>
  * CLONEEMPTY expects no other parameter on the stack than the GTS instances
  */
-public class CLONEEMPTY extends GTSStackFunction {
+public class CLONEEMPTY extends ElementOrListStackFunction {
+
+  private final ElementStackFunction cloneemptyFunction = new ElementStackFunction() {
+    @Override
+    public Object applyOnElement(Object element) throws WarpScriptException {
+      if (element instanceof GeoTimeSerie) {
+        return ((GeoTimeSerie) element).cloneEmpty();
+      } else if (element instanceof GTSEncoder) {
+        return ((GTSEncoder) element).cloneEmpty();
+      } else {
+        throw new WarpScriptException(getName() + " expects a GeoTimeSeries, a GTSEncoder or a list thereof on top of the stack.");
+      }
+    }
+  };
 
   public CLONEEMPTY(String name) {
     super(name);
   }
 
   @Override
-  public Object apply(WarpScriptStack stack) throws WarpScriptException {
-    if (!(stack.peek() instanceof GTSEncoder)) {
-      return super.apply(stack);      
-    }
-    
-    GTSEncoder encoder = (GTSEncoder) stack.pop();
-    
-    stack.push(encoder.cloneEmpty());
-    
-    return stack;
+  public ElementStackFunction generateFunction(WarpScriptStack stack) throws WarpScriptException {
+    return cloneemptyFunction;
   }
 
-  @Override
-  protected Map<String, Object> retrieveParameters(WarpScriptStack stack) throws WarpScriptException {
-    return null;
-  }
-
-   @Override
-  protected Object gtsOp(Map<String, Object> params, GeoTimeSerie gts) throws WarpScriptException {
-    return gts.cloneEmpty();  
-  }  
 }

--- a/warp10/src/main/java/io/warp10/script/functions/TICKLIST.java
+++ b/warp10/src/main/java/io/warp10/script/functions/TICKLIST.java
@@ -20,52 +20,49 @@ import io.warp10.continuum.gts.GTSDecoder;
 import io.warp10.continuum.gts.GTSEncoder;
 import io.warp10.continuum.gts.GTSHelper;
 import io.warp10.continuum.gts.GeoTimeSerie;
-import io.warp10.script.GTSStackFunction;
+import io.warp10.script.ElementOrListStackFunction;
 import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptStack;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 /**
- * Extract the ticks from the parameter GTS instances, in the order they are stored in the GTS, and push them onto the stack.
- *
+ * Extract the ticks from the parameter GTS or Encoder instances or list thereof, in the order they are stored in the GTS, and push them onto the stack.
+ * <p>
  * Only the ticks with actual values are returned
  */
-public class TICKLIST extends GTSStackFunction {
+public class TICKLIST extends ElementOrListStackFunction {
+
+  private final ElementStackFunction ticklistFunction = new ElementStackFunction() {
+    @Override
+    public Object applyOnElement(Object element) throws WarpScriptException {
+      if (element instanceof GeoTimeSerie) {
+        return GTSHelper.tickList((GeoTimeSerie) element);
+      } else if (element instanceof GTSEncoder) {
+        GTSEncoder encoder = (GTSEncoder) element;
+
+        List<Long> ticklist = new ArrayList<Long>((int) encoder.getCount());
+
+        GTSDecoder decoder = encoder.getDecoder(true);
+
+        while (decoder.next()) {
+          ticklist.add(decoder.getTimestamp());
+        }
+
+        return ticklist;
+      } else {
+        throw new WarpScriptException(getName() + " expects a GeoTimeSeries, a GTSEncoder or a list thereof on top of the stack.");
+      }
+    }
+  };
+
   public TICKLIST(String name) {
     super(name);
   }
 
   @Override
-  public Object apply(WarpScriptStack stack) throws WarpScriptException {
-    if (!(stack.peek() instanceof GTSEncoder)) {
-      return super.apply(stack);
-    }
-    
-    GTSEncoder encoder = (GTSEncoder) stack.pop();
-    
-    List<Long> ticklist = new ArrayList<Long>((int) encoder.getCount());
-    
-    GTSDecoder decoder = encoder.getDecoder(true);
-    
-    while(decoder.next()) {
-      ticklist.add(decoder.getTimestamp());
-    }
-    
-    stack.push(ticklist);
-    
-    return stack;
-  }
-  
-  @Override
-  protected Map<String, Object> retrieveParameters(WarpScriptStack stack) throws WarpScriptException {
-    return null;
-  }
-
-  @Override
-  protected Object gtsOp(Map<String, Object> params, GeoTimeSerie gts) throws WarpScriptException {
-    return GTSHelper.tickList(gts);
+  public ElementStackFunction generateFunction(WarpScriptStack stack) throws WarpScriptException {
+    return ticklistFunction;
   }
 }


### PR DESCRIPTION
The converted function accepted GTS, GTSEncoders or List of GTSs.
They now also accept List of GTSEncoders.

Also fix a bug in GTSEncoder.cloneEmpty where the metadata was not copied.