### PR TITLE
Integrate formatted functions into "list or not list" warpscript pattern

### DIFF
--- a/warp10/src/main/java/io/warp10/script/formatted/FormattedWarpScriptFunction.java
+++ b/warp10/src/main/java/io/warp10/script/formatted/FormattedWarpScriptFunction.java
@@ -264,13 +264,14 @@ public abstract class FormattedWarpScriptFunction extends NamedWarpScriptFunctio
         }
       }
 
-      Map<String, Object> map = (Map) stack.peek();
+      // use this map as function's parameters
+      formattedArgs = (Map) ((HashMap<String, Object>) stack.peek()).clone();
 
       //
       // Check that the map does not contain unrecognized argument
       //
 
-      for (String key: map.keySet()) {
+      for (String key: formattedArgs.keySet()) {
         boolean found = false;
 
         for (ArgumentSpecification arg: args) {
@@ -302,7 +303,7 @@ public abstract class FormattedWarpScriptFunction extends NamedWarpScriptFunctio
 
       for (ArgumentSpecification arg: args) {
 
-        Object value = map.get(arg.getName());
+        Object value = formattedArgs.get(arg.getName());
 
         if (null == value) {
 
@@ -328,7 +329,7 @@ public abstract class FormattedWarpScriptFunction extends NamedWarpScriptFunctio
                 " be a " + firstArg.WarpScriptSubType() + " or a list of " + firstArg.WarpScriptSubType() + ".");
             }
 
-            map.put(arg.getName(), value);
+            formattedArgs.put(arg.getName(), value);
           }
         }
 
@@ -349,7 +350,7 @@ public abstract class FormattedWarpScriptFunction extends NamedWarpScriptFunctio
 
       for (ArgumentSpecification arg: optArgs) {
 
-        Object value = map.get(arg.getName());
+        Object value = formattedArgs.get(arg.getName());
 
         if (null != value && !arg.getClazz().isInstance(value)) {
 
@@ -368,7 +369,7 @@ public abstract class FormattedWarpScriptFunction extends NamedWarpScriptFunctio
 
       for (ArgumentSpecification arg: both) {
 
-        Object candidate = map.get(arg.getName());
+        Object candidate = formattedArgs.get(arg.getName());
         if (null == candidate) {
           continue;
         }
@@ -411,10 +412,10 @@ public abstract class FormattedWarpScriptFunction extends NamedWarpScriptFunctio
       }
 
       //
-      // Consume the top of the stack
+      // Removes the top of the stack
       //
 
-      formattedArgs = new HashMap<String, Object> ((Map) stack.pop());
+      stack.pop();
 
     } else {
 
@@ -557,7 +558,19 @@ public abstract class FormattedWarpScriptFunction extends NamedWarpScriptFunctio
         stack.push(list);
 
         return stack;
+
+      } else if (1 == firstArg.size()) {
+
+        formattedArgs.put(args.get(0).getName(), firstArg.get(0));
+        return apply(formattedArgs, stack);
+
+      } else {
+
+        // first arg list is empty so result is empty
+        stack.push(new ArrayList<>());
+        return stack;
       }
+
     }
 
     return apply(formattedArgs, stack);

--- a/warp10/src/main/java/io/warp10/script/formatted/FormattedWarpScriptFunction.java
+++ b/warp10/src/main/java/io/warp10/script/formatted/FormattedWarpScriptFunction.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Arrays;
 
 /**
  * Do the extraction of arguments from the stack in a formatted manner.
@@ -39,13 +40,31 @@ public abstract class FormattedWarpScriptFunction extends NamedWarpScriptFunctio
   private final StringBuilder docstring;
   private final List<String> unitTests;
 
+  //
+  // Argument of formatted WarpScript functions are instances of Arguments, which are built by ArgumentsBuilder
+  //
+
   public static class Arguments {
+
+    //
+    // args: list of arguments
+    // optArgs: list of optional arguments
+    //
+
     private final List<ArgumentSpecification> args;
     private final List<ArgumentSpecification> optArgs;
 
-    private Arguments(List<ArgumentSpecification> args, List<ArgumentSpecification> optArgs) {
+    //
+    // listExpandable: whether the first argument of the WarpScript function can be a list or not.
+    // In that case, the result would be a list of results
+    //
+
+    private final boolean listExpandable;
+
+    private Arguments(List<ArgumentSpecification> args, List<ArgumentSpecification> optArgs, boolean listExpandable) {
       this.args = args;
       this.optArgs = optArgs;
+      this.listExpandable = listExpandable;
     }
 
     public List<ArgumentSpecification> getArgsCopy() {
@@ -55,15 +74,21 @@ public abstract class FormattedWarpScriptFunction extends NamedWarpScriptFunctio
     public List<ArgumentSpecification> getOptArgsCopy() {
       return new ArrayList<>(optArgs);
     }
+
+    public boolean isListExpandable() {
+      return listExpandable;
+    }
   }
 
   public static class ArgumentsBuilder {
     private final List<ArgumentSpecification> args;
     private final List<ArgumentSpecification> optArgs;
+    private boolean listExpandable;
 
     public ArgumentsBuilder() {
       args = new ArrayList<>();
       optArgs = new ArrayList<>();
+      listExpandable = false;
     }
 
     public ArgumentsBuilder addArgument(Class<?> clazz, String name, String doc) {
@@ -96,8 +121,16 @@ public abstract class FormattedWarpScriptFunction extends NamedWarpScriptFunctio
       return this;
     }
 
+    public ArgumentsBuilder firstArgIsListExpandable() {
+      listExpandable = true;
+      ArgumentSpecification firstArgs = args.remove(0);
+      args.add(0, new ListSpecification(firstArgs.getClazz(), firstArgs.getName(), firstArgs.getDoc()));
+
+      return this;
+    }
+
     public Arguments build() {
-      return new Arguments(args, optArgs);
+      return new Arguments(args, optArgs, listExpandable);
     }
   }
 
@@ -179,6 +212,14 @@ public abstract class FormattedWarpScriptFunction extends NamedWarpScriptFunctio
         throw new WarpScriptException("Output of " + getClass().getSimpleName() + "'s method getArguments() must" +
           " only contain arguments with a default value.");
       }
+    }
+
+    if (getArguments().isListExpandable() && ((ListSpecification) args.get(0)).getSubClazz() == List.class) {
+      throw new WarpScriptException(getClass().getSimpleName() + " implementation error: a list argument can not be list-expandable.");
+    }
+
+    if (getArguments().isListExpandable() && args.size() == 0) {
+      throw new WarpScriptException(getClass().getSimpleName() + " implementation error: a function with 0 argument can not be list-expandable.");
     }
 
     //
@@ -268,6 +309,32 @@ public abstract class FormattedWarpScriptFunction extends NamedWarpScriptFunctio
           throw new WarpScriptException("The MAP that is on top of the stack does not have the argument '" + arg.getName() +
             "' (of type "  + arg.WarpScriptType() + ") that is required by " + getName());
         }
+
+        //
+        // If first argument is list-expandable, put it in a singleton list if it is not expanded
+        //
+
+        if (getArguments().isListExpandable() && arg == args.get(0)) {
+
+          if (!List.class.isInstance(value)) {
+            Object value_ = value;
+            value = new ArrayList<Object>();
+            ((ArrayList<Object>) value).add(value_);
+
+            ListSpecification firstArg = (ListSpecification) arg;
+            if (!firstArg.getSubClazz().isInstance(value_)) {
+
+              throw new WarpScriptException(getClass().getSimpleName() + " expects the argument '" + firstArg.getName() + "' to" +
+                " be a " + firstArg.WarpScriptSubType() + " or a list of " + firstArg.WarpScriptSubType() + ".");
+            }
+
+            map.put(arg.getName(), value);
+          }
+        }
+
+        //
+        // Check type
+        //
 
         if (!arg.getClazz().isInstance(value)) {
 
@@ -361,6 +428,36 @@ public abstract class FormattedWarpScriptFunction extends NamedWarpScriptFunctio
       }
 
       //
+      // If first argument is list-expandable and is not a list, replace it with a singleton list that contains it
+      //
+
+      if (getArguments().isListExpandable()) {
+        Object first = stack.get(args.size() - 1);
+
+        if (!List.class.isInstance(first)) {
+
+          stack.push(args.size() - 1);
+          Object[] cache = stack.popn();
+          List<Object> arr = new ArrayList<>();
+          arr.add(stack.pop());
+          stack.push(arr);
+          for (Object o: cache) {
+            stack.push(o);
+          }
+
+          ListSpecification firstArg = (ListSpecification) args.get(0);
+          if (!firstArg.getSubClazz().isInstance(first)) {
+
+            System.out.println(first);
+            System.out.println(firstArg.getSubClazz());
+
+            throw new WarpScriptException(getClass().getSimpleName() + " expects the first argument to" +
+              " be a " + firstArg.WarpScriptSubType() + " or a list of " + firstArg.WarpScriptSubType() + ".");
+          }
+        }
+      }
+
+      //
       // Check argument types
       //
 
@@ -430,6 +527,36 @@ public abstract class FormattedWarpScriptFunction extends NamedWarpScriptFunctio
     for (ArgumentSpecification arg: optArgs) {
       if (null == formattedArgs.get(arg.getName())) {
         formattedArgs.put(arg.getName(), arg.getDefaultValue());
+      }
+    }
+
+    //
+    // Apply child's apply
+    //
+
+    if (getArguments().isListExpandable()) {
+
+      List<Object> firstArg = (List) formattedArgs.get(args.get(0).getName());
+
+      if (firstArg.size() > 1) {
+
+        int initial_depth = stack.depth();
+        for (Object o : firstArg) {
+
+          // clone arguments in case child's apply is messing with the parameter map
+          Map<String, Object> subFormattedArgs = (Map) ((HashMap<String, Object>) formattedArgs).clone();
+
+          subFormattedArgs.put(args.get(0).getName(), o);
+          stack = apply(subFormattedArgs, stack);
+        }
+
+        stack.push(stack.depth() - initial_depth);
+        Object[] elements = stack.popn();
+        List<Object> list = new ArrayList<Object>();
+        list.addAll(Arrays.asList(elements));
+        stack.push(list);
+
+        return stack;
       }
     }
 

--- a/warp10/src/main/java/io/warp10/script/formatted/ListSpecification.java
+++ b/warp10/src/main/java/io/warp10/script/formatted/ListSpecification.java
@@ -16,6 +16,8 @@
 
 package io.warp10.script.formatted;
 
+import io.warp10.script.functions.TYPEOF;
+
 import java.util.List;
 
 public class ListSpecification extends ArgumentSpecification {
@@ -41,5 +43,9 @@ public class ListSpecification extends ArgumentSpecification {
   public ListSpecification(Class clazz, String name) {
     super(List.class, name);
     subClazz = clazz;
+  }
+
+  public String WarpScriptSubType() {
+    return TYPEOF.typeof(subClazz);
   }
 }

--- a/warp10/src/test/java/io/warp10/script/formatted/FormattedWarpScriptFunctionTest.java
+++ b/warp10/src/test/java/io/warp10/script/formatted/FormattedWarpScriptFunctionTest.java
@@ -70,7 +70,7 @@ public class FormattedWarpScriptFunctionTest extends FormattedWarpScriptFunction
     // test positional arguments
     StringBuilder test1 = new StringBuilder();
     test1.append("NEWGTS 3 0.5 EXAMPLE 'res' STORE" + System.lineSeparator());
-    test1.append("$res '1st arg' GET DUP SIZE 1 == ASSERT 0 GET TYPEOF 'GTS' == ASSERT" + System.lineSeparator());
+    test1.append("$res '1st arg' GET TYPEOF 'GTS' == ASSERT" + System.lineSeparator());
     test1.append("$res '2nd arg' GET 3 == ASSERT" + System.lineSeparator());
     test1.append("$res '3rd arg' GET 0.5 == ASSERT" + System.lineSeparator());
     test1.append("$res SIZE 5 == ASSERT" + System.lineSeparator());
@@ -81,7 +81,7 @@ public class FormattedWarpScriptFunctionTest extends FormattedWarpScriptFunction
     // test map arguments
     StringBuilder test2 = new StringBuilder();
     test2.append("{ '1st arg' NEWGTS '2nd arg' 3 '3rd arg' 0.5 } EXAMPLE 'res' STORE" + System.lineSeparator());
-    test2.append("$res '1st arg' GET 0 GET TYPEOF 'GTS' == ASSERT" + System.lineSeparator());
+    test2.append("$res '1st arg' GET TYPEOF 'GTS' == ASSERT" + System.lineSeparator());
     test2.append("$res '2nd arg' GET 3 == ASSERT" + System.lineSeparator());
     test2.append("$res '3rd arg' GET 0.5 == ASSERT" + System.lineSeparator());
     test2.append("$res SIZE 5 == ASSERT" + System.lineSeparator());
@@ -91,7 +91,7 @@ public class FormattedWarpScriptFunctionTest extends FormattedWarpScriptFunction
     // test map arguments with optional ones
     StringBuilder test3 = new StringBuilder();
     test3.append("{ '1st arg' NEWGTS '2nd arg' 3 '3rd arg' 0.5 '1st opt arg' 'hi' } EXAMPLE 'res' STORE" + System.lineSeparator());
-    test3.append("$res '1st arg' GET 0 GET TYPEOF 'GTS' == ASSERT" + System.lineSeparator());
+    test3.append("$res '1st arg' GET TYPEOF 'GTS' == ASSERT" + System.lineSeparator());
     test3.append("$res '2nd arg' GET 3 == ASSERT" + System.lineSeparator());
     test3.append("$res '3rd arg' GET 0.5 == ASSERT" + System.lineSeparator());
     test3.append("$res '1st opt arg' GET 'hi' == ASSERT" + System.lineSeparator());
@@ -101,12 +101,23 @@ public class FormattedWarpScriptFunctionTest extends FormattedWarpScriptFunction
     // test ListSpecification
     StringBuilder test4 = new StringBuilder();
     test4.append("{ '1st arg' NEWGTS '2nd arg' 3 '3rd arg' 0.5 '2nd opt arg' [ 1 2 ] } EXAMPLE 'res' STORE" + System.lineSeparator());
-    test4.append("$res '1st arg' GET 0 GET TYPEOF 'GTS' == ASSERT" + System.lineSeparator());
+    test4.append("$res '1st arg' GET TYPEOF 'GTS' == ASSERT" + System.lineSeparator());
     test4.append("$res '2nd arg' GET 3 == ASSERT" + System.lineSeparator());
     test4.append("$res '3rd arg' GET 0.5 == ASSERT" + System.lineSeparator());
     test4.append("$res '2nd opt arg' GET LIST-> 2 == ASSERT 2 == ASSERT 1 == ASSERT" + System.lineSeparator());
     test4.append("$res SIZE 5 == ASSERT");
     unitTests.add(test4.toString());
+
+
+    // test expanded first arg
+    StringBuilder test5 = new StringBuilder();
+    test5.append("[ NEWGTS NEWGTS NEWGTS ] 3 0.5 EXAMPLE 'res' STORE" + System.lineSeparator());
+    test5.append("$res DUP TYPEOF 'LIST' == ASSERT SIZE 3 == ASSERT" + System.lineSeparator());
+    test5.append("$res <% '1st arg' GET TYPEOF 'GTS' == ASSERT %> FOREACH" + System.lineSeparator());
+    test5.append("$res <% '2nd arg' GET 3 == ASSERT %> FOREACH" + System.lineSeparator());
+    test5.append("$res <% '3rd arg' GET 0.5 == ASSERT %> FOREACH" + System.lineSeparator());
+    test5.append("$res <% SIZE 5 == ASSERT %> FOREACH");
+    unitTests.add(test5.toString());
   }
 
   //
@@ -161,6 +172,13 @@ public class FormattedWarpScriptFunctionTest extends FormattedWarpScriptFunction
     MemoryWarpScriptStack stack = new MemoryWarpScriptStack(null, null);
 
     stack.execMulti(getUnitTests().get(3));
+  }
+
+  @Test
+  public void testExpandedFirstArg() throws Exception {
+    MemoryWarpScriptStack stack = new MemoryWarpScriptStack(null, null);
+
+    stack.execMulti(getUnitTests().get(4));
   }
 
   @Test

--- a/warp10/src/test/java/io/warp10/script/formatted/FormattedWarpScriptFunctionTest.java
+++ b/warp10/src/test/java/io/warp10/script/formatted/FormattedWarpScriptFunctionTest.java
@@ -47,6 +47,7 @@ public class FormattedWarpScriptFunctionTest extends FormattedWarpScriptFunction
 
     args = new ArgumentsBuilder()
       .addArgument(GeoTimeSerie.class, "1st arg","A Geo Time Series™.")
+      .firstArgIsListExpandable()
       .addArgument(Long.class, "2nd arg","A LONG.")
       .addArgument(Double.class, "3rd arg","A DOUBLE.")
       .addOptionalArgument(String.class, "1st opt arg", "A STRING.", "The default value.")
@@ -69,7 +70,7 @@ public class FormattedWarpScriptFunctionTest extends FormattedWarpScriptFunction
     // test positional arguments
     StringBuilder test1 = new StringBuilder();
     test1.append("NEWGTS 3 0.5 EXAMPLE 'res' STORE" + System.lineSeparator());
-    test1.append("$res '1st arg' GET TYPEOF 'GTS' == ASSERT" + System.lineSeparator());
+    test1.append("$res '1st arg' GET DUP SIZE 1 == ASSERT 0 GET TYPEOF 'GTS' == ASSERT" + System.lineSeparator());
     test1.append("$res '2nd arg' GET 3 == ASSERT" + System.lineSeparator());
     test1.append("$res '3rd arg' GET 0.5 == ASSERT" + System.lineSeparator());
     test1.append("$res SIZE 5 == ASSERT" + System.lineSeparator());
@@ -80,7 +81,7 @@ public class FormattedWarpScriptFunctionTest extends FormattedWarpScriptFunction
     // test map arguments
     StringBuilder test2 = new StringBuilder();
     test2.append("{ '1st arg' NEWGTS '2nd arg' 3 '3rd arg' 0.5 } EXAMPLE 'res' STORE" + System.lineSeparator());
-    test2.append("$res '1st arg' GET TYPEOF 'GTS' == ASSERT" + System.lineSeparator());
+    test2.append("$res '1st arg' GET 0 GET TYPEOF 'GTS' == ASSERT" + System.lineSeparator());
     test2.append("$res '2nd arg' GET 3 == ASSERT" + System.lineSeparator());
     test2.append("$res '3rd arg' GET 0.5 == ASSERT" + System.lineSeparator());
     test2.append("$res SIZE 5 == ASSERT" + System.lineSeparator());
@@ -90,7 +91,7 @@ public class FormattedWarpScriptFunctionTest extends FormattedWarpScriptFunction
     // test map arguments with optional ones
     StringBuilder test3 = new StringBuilder();
     test3.append("{ '1st arg' NEWGTS '2nd arg' 3 '3rd arg' 0.5 '1st opt arg' 'hi' } EXAMPLE 'res' STORE" + System.lineSeparator());
-    test3.append("$res '1st arg' GET TYPEOF 'GTS' == ASSERT" + System.lineSeparator());
+    test3.append("$res '1st arg' GET 0 GET TYPEOF 'GTS' == ASSERT" + System.lineSeparator());
     test3.append("$res '2nd arg' GET 3 == ASSERT" + System.lineSeparator());
     test3.append("$res '3rd arg' GET 0.5 == ASSERT" + System.lineSeparator());
     test3.append("$res '1st opt arg' GET 'hi' == ASSERT" + System.lineSeparator());
@@ -100,7 +101,7 @@ public class FormattedWarpScriptFunctionTest extends FormattedWarpScriptFunction
     // test ListSpecification
     StringBuilder test4 = new StringBuilder();
     test4.append("{ '1st arg' NEWGTS '2nd arg' 3 '3rd arg' 0.5 '2nd opt arg' [ 1 2 ] } EXAMPLE 'res' STORE" + System.lineSeparator());
-    test4.append("$res '1st arg' GET TYPEOF 'GTS' == ASSERT" + System.lineSeparator());
+    test4.append("$res '1st arg' GET 0 GET TYPEOF 'GTS' == ASSERT" + System.lineSeparator());
     test4.append("$res '2nd arg' GET 3 == ASSERT" + System.lineSeparator());
     test4.append("$res '3rd arg' GET 0.5 == ASSERT" + System.lineSeparator());
     test4.append("$res '2nd opt arg' GET LIST-> 2 == ASSERT 2 == ASSERT 1 == ASSERT" + System.lineSeparator());
@@ -179,7 +180,7 @@ public class FormattedWarpScriptFunctionTest extends FormattedWarpScriptFunction
     }
 
     // manual check that INFO is correct
-    System.out.println(stack.dump(10));
+    // System.out.println(stack.dump(10));
   }
 
 }


### PR DESCRIPTION
First argument of a formatted function can now be defined as "list-expandable".

In this argument is a list, a list of results as though it was applied foreach element of this list is returned.