### PR TITLE
Fixed commonticks so it correctly copies duplicate ticks

### DIFF
--- a/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
+++ b/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
@@ -10397,7 +10397,7 @@ public class GTSHelper {
         while(idx[i] < serie.values && serie.ticks[idx[i]] < target) {
           idx[i]++;
         }
-        
+                
         //
         // We've reached the end of one of the GTS, we know we're done
         //
@@ -10428,19 +10428,32 @@ public class GTSHelper {
       }
       
       //
-      // We have a march of all the ticks, add the current datapoint to the resulting GTS
+      // We have a match of all the ticks, add the datapoints with the current tick to the resulting GTS
       //
       
-      if (match) {
+      if (match) {        
         for (int i = 0; i < series.size(); i++) {
           GeoTimeSerie serie = series.get(i);
-          GTSHelper.setValue(result.get(i),
-            GTSHelper.tickAtIndex(serie, idx[i]),
-            GTSHelper.locationAtIndex(serie, idx[i]),
-            GTSHelper.elevationAtIndex(serie, idx[i]),
-            GTSHelper.valueAtIndex(serie, idx[i]),
-            false);
-        }   
+          
+          int tidx = idx[i];
+          
+          while (tidx < serie.values && target == serie.ticks[tidx]) {
+            GTSHelper.setValue(result.get(i),
+                GTSHelper.tickAtIndex(serie, tidx),
+                GTSHelper.locationAtIndex(serie, tidx),
+                GTSHelper.elevationAtIndex(serie, tidx),
+                GTSHelper.valueAtIndex(serie, tidx),
+                false);
+            tidx++;
+          }
+          
+          if (tidx < serie.values) {
+            tidx--;
+          }
+          
+          idx[i] = tidx;
+        }
+        
         idx[leader]++;
         if (idx[leader] >= leadergts.values) {
           return result;


### PR DESCRIPTION
This fix allows the following to correctly preserve datapoints at tick 0

NEWGTS 'a' RENAME
0 NaN NaN NaN 0 ADDVALUE
0 NaN NaN NaN 10 ADDVALUE
1 NaN NaN NaN 1 ADDVALUE
2 NaN NaN NaN 2 ADDVALUE

NEWGTS 'b' RENAME
0 NaN NaN NaN 2 ADDVALUE
0 NaN NaN NaN 3 ADDVALUE

2 ->LIST
COMMONTICKS
