### PR TITLE
Systemd unit fix

### DIFF
--- a/warp10/src/main/sh/warp10.service
+++ b/warp10/src/main/sh/warp10.service
@@ -6,6 +6,7 @@ Type=forking
 User=warp10
 ExecStart=/opt/warp10-@VERSION@/bin/warp10-standalone.sh start
 ExecStop=/opt/warp10-@VERSION@/bin/warp10-standalone.sh stop
+SuccessExitStatus=143
 RestartSec=10s
 TimeoutStartSec=60s
 #If you do not want systemd to monitor and restart Warp&nbsp;10™ automatically, comment out this line:

--- a/warp10/src/main/sh/warp10.service
+++ b/warp10/src/main/sh/warp10.service
@@ -9,7 +9,7 @@ ExecStop=/opt/warp10-@VERSION@/bin/warp10-standalone.sh stop
 SuccessExitStatus=143
 RestartSec=10s
 TimeoutStartSec=60s
-#If you do not want systemd to monitor and restart Warp&nbsp;10™ automatically, comment out this line:
+#If you do not want systemd to monitor and restart automatically, comment out this line:
 Restart=always
 
 #You can customize default system limits here: see https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Process%20Properties

--- a/warp10/src/main/sh/warp10.service
+++ b/warp10/src/main/sh/warp10.service
@@ -9,7 +9,7 @@ ExecStop=/opt/warp10-@VERSION@/bin/warp10-standalone.sh stop
 SuccessExitStatus=143
 RestartSec=10s
 TimeoutStartSec=60s
-#If you do not want systemd to monitor and restart automatically, comment out this line:
+#If you do not want systemd to monitor and restart Warp 10 automatically, comment out this line:
 Restart=always
 
 #You can customize default system limits here: see https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Process%20Properties

--- a/warp10/src/main/sh/warp10.service
+++ b/warp10/src/main/sh/warp10.service
@@ -2,11 +2,20 @@
 Description=Warp 10 Standalone
 
 [Service]
-Type=oneshot
+Type=forking
 User=warp10
 ExecStart=/opt/warp10-@VERSION@/bin/warp10-standalone.sh start
 ExecStop=/opt/warp10-@VERSION@/bin/warp10-standalone.sh stop
-RemainAfterExit=yes
+RestartSec=10s
+TimeoutStartSec=60s
+#If you do not want systemd to monitor and restart Warp&nbsp;10™ automatically, comment out this line:
+Restart=always
+
+#You can customize default system limits here: see https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Process%20Properties
+#LimitNOFILE=1000000
+#LimitCORE=infinity
+#LimitNPROC=32000
+#LimitMEMLOCK=500000
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
It is a forking unit, not a oneshot with remainAfterExit.
Tested with several level of kill, systemd relaunch warp 10 correctly.
journalctl is now cleaner.
