### PR TITLE
add error location tip into error message

### DIFF
--- a/warp10/src/main/java/io/warp10/script/MemoryWarpScriptStack.java
+++ b/warp10/src/main/java/io/warp10/script/MemoryWarpScriptStack.java
@@ -47,6 +47,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.util.Progressable;
 
 public class MemoryWarpScriptStack implements WarpScriptStack, Progressable {
@@ -594,308 +595,321 @@ public class MemoryWarpScriptStack implements WarpScriptStack, Progressable {
       //
       
       progress();
-      
+
       //
       // Loop over the statements
       //
-      
-      for (String stmt: statements) {
 
-        //
-        // Skip empty statements if we are not currently building a multiline
-        //
-        
-        if (0 == stmt.length() && !inMultiline.get()) {
-          continue;
-        }
-        
-        //
-        // Trim statement
-        //
-        
-        if (!inMultiline.get()) {
-          stmt = stmt.trim();
-        }
+      for (int st = 0; st < statements.length; st++) {
+        String stmt = statements[st];
 
-        //
-        // End execution on encountering a comment
-        //
-                
-        if (!inMultiline.get() && stmt.length() > 0 && (stmt.charAt(0) == '#' || (stmt.charAt(0) == '/' && stmt.length() >= 2 && stmt.charAt(1) == '/'))) {
-          // Skip comments and blank lines
-          return;
-        }
+        try {
+          //
+          // Skip empty statements if we are not currently building a multiline
+          //
 
-        if (WarpScriptStack.MULTILINE_END.equals(stmt)) {
+          if (0 == stmt.length() && !inMultiline.get()) {
+            continue;
+          }
+
+          //
+          // Trim statement
+          //
+
           if (!inMultiline.get()) {
-            throw new WarpScriptException("Not inside a multiline.");
+            stmt = stmt.trim();
           }
-          inMultiline.set(false);
-          
-          String mlcontent = multiline.toString();
-          
-          if (null != secureScript) {
-            secureScript.append(" ");
-            secureScript.append("'");
-            try {
-              secureScript.append(WarpURLEncoder.encode(mlcontent, "UTF-8"));
-            } catch (UnsupportedEncodingException uee) {              
-            }
-            secureScript.append("'");
-          } else {
-            if (macros.isEmpty()) {
-              this.push(mlcontent);
-            } else {
-              macros.get(0).add(mlcontent);
-            }            
-          }
-          multiline.setLength(0);
-          continue;
-        } else if (inMultiline.get()) {
-          if (multiline.length() > 0) {
-            multiline.append("\n");            
-          }
-          multiline.append(stmt);
-          continue;
-        } else if (WarpScriptStack.COMMENT_END.equals(stmt)) {
-          if (!inComment.get()) {
-            throw new WarpScriptException("Not inside a comment.");
-          }
-          inComment.set(false);
-          continue;
-        } else if (inComment.get()) {
-          continue;
-        } else if (WarpScriptStack.COMMENT_START.equals(stmt)) {
-          inComment.set(true);
-          continue;
-        } else if (WarpScriptStack.MULTILINE_START.equals(stmt)) {
-          if (1 != statements.length) {
-            throw new WarpScriptException("Can only start multiline strings by using " + WarpScriptStack.MULTILINE_START + " on a line by itself.");
-          }
-          inMultiline.set(true);
-          multiline = new StringBuilder();
-          continue;
-        }
-        
-        incOps();
-        checkOps();
 
-        if (WarpScriptStack.SECURE_SCRIPT_END.equals(stmt)) {
-          if (null == secureScript) {
-            throw new WarpScriptException("Not inside a secure script definition.");
-          } else {
-            this.push(secureScript.toString());
-            secureScript = null;
-            new SECURE("SECURESCRIPT").apply(this);
-          }
-        } else if (WarpScriptStack.SECURE_SCRIPT_START.equals(stmt)) {
-          if (null == secureScript) {
-            secureScript = new StringBuilder();
-          } else {
-            throw new WarpScriptException("Already inside a secure script definition.");
-          }
-        } else if (null != secureScript) {
-          secureScript.append(" ");
-          secureScript.append(stmt);
-        } else if (WarpScriptStack.MACRO_END.equals(stmt)) {
-          if (macros.isEmpty()) {
-            throw new WarpScriptException("Not inside a macro definition.");
-          } else {
-            Macro lastmacro = macros.remove(0);
-            
-            boolean secure = Boolean.TRUE.equals(this.getAttribute(WarpScriptStack.ATTRIBUTE_IN_SECURE_MACRO));
+          //
+          // End execution on encountering a comment
+          //
 
-            lastmacro.setSecure(secure);
-            
-            if (macros.isEmpty()) {
-              this.push(lastmacro);
-            } else {
-              // Add the macro to the outer macro
-              macros.get(0).add(lastmacro);
+          if (!inMultiline.get() && stmt.length() > 0 && (stmt.charAt(0) == '#' || (stmt.charAt(0) == '/' && stmt.length() >= 2 && stmt.charAt(1) == '/'))) {
+            // Skip comments and blank lines
+            return;
+          }
+
+          if (WarpScriptStack.MULTILINE_END.equals(stmt)) {
+            if (!inMultiline.get()) {
+              throw new WarpScriptException("Not inside a multiline.");
             }
-          }
-        } else if (WarpScriptStack.MACRO_START.equals(stmt)) {
-          //
-          // Create holder for current macro
-          //
-          
-          macros.add(0, new Macro());
-        } else if ((stmt.charAt(0) == '\'' && stmt.charAt(stmt.length() - 1) == '\'')
-            || (stmt.charAt(0) == '\"' && stmt.charAt(stmt.length() - 1) == '\"')) {
-          //
-          // Push Strings onto the stack
-          //
-          
-          try {
-            String str = stmt.substring(1, stmt.length() - 1);
-            
-            if (-1 != UnsafeString.indexOf(str, '%')) {
-              // replace occurrences of '+' with '%2B'
-              str = str.replaceAll("\\+", "%2B");
-              str = URLDecoder.decode(str, "UTF-8");
-            }
-            
-            if (macros.isEmpty()) {
-              push(str);
-            } else {
-              macros.get(0).add(str);
-            }
-          } catch (UnsupportedEncodingException uee) {
-            // Cannot happen...
-            throw new WarpScriptException(uee);
-          }
-        } else if (stmt.length() > 2 && stmt.charAt(1) == 'x' && stmt.charAt(0) == '0') {          
-          long hexl = stmt.length() < 18 ? Long.parseLong(stmt.substring(2), 16) : new BigInteger(stmt.substring(2), 16).longValue();
-          if (macros.isEmpty()) {
-            push(hexl);
-          } else {
-            macros.get(0).add(hexl);
-          }
-        } else if (stmt.length() > 2 && stmt.charAt(1) == 'b' && stmt.charAt(0) == '0') {
-          long binl = stmt.length() < 66 ? Long.parseLong(stmt.substring(2), 2) : new BigInteger(stmt.substring(2), 2).longValue();
-          if (macros.isEmpty()) {
-            push(binl);
-          } else {
-            macros.get(0).add(binl);
-          }
-        } else if (UnsafeString.isLong(stmt)) {
-          //
-          // Push longs onto the stack
-          //
-          
-          if (macros.isEmpty()) {
-            push(Long.valueOf(stmt));
-          } else {
-            macros.get(0).add(Long.valueOf(stmt));
-          }
-        } else if (UnsafeString.isDouble(stmt)) {
-          //
-          // Push doubles onto the stack
-          //
-          if (macros.isEmpty()) {
-            push(Double.valueOf(stmt));
-          } else {
-            macros.get(0).add(Double.valueOf(stmt));
-          }
-        } else if (stmt.equalsIgnoreCase("T")
-                   || stmt.equalsIgnoreCase("F")
-                   || stmt.equalsIgnoreCase("true")
-                   || stmt.equalsIgnoreCase("false")) {
-          //
-          // Push booleans onto the stack
-          //
-          if (stmt.startsWith("T") || stmt.startsWith("t")) {
-            if (macros.isEmpty()) {
-              push(true);
-            } else {
-              macros.get(0).add(true);
-            }
-          } else {
-            if (macros.isEmpty()) {
-              push(false);
-            } else {
-              macros.get(0).add(false);
-            }
-          }
-        } else if (stmt.startsWith("$")) {
-          if (macros.isEmpty()) {
-            //
-            // This is a deferred variable dereference
-            //
-            Object o = load(stmt.substring(1));
-            
-            if (null == o) {
-              if (!getSymbolTable().containsKey(stmt.substring(1))) {
-                throw new WarpScriptException("Unknown symbol '" + stmt.substring(1) + "'");
+            inMultiline.set(false);
+
+            String mlcontent = multiline.toString();
+
+            if (null != secureScript) {
+              secureScript.append(" ");
+              secureScript.append("'");
+              try {
+                secureScript.append(WarpURLEncoder.encode(mlcontent, "UTF-8"));
+              } catch (UnsupportedEncodingException uee) {
               }
-            }
-            
-            push(o);
-          } else {
-            macros.get(0).add(stmt.substring(1));
-            macros.get(0).add(WarpScriptLib.getFunction(WarpScriptLib.LOAD));
-          }
-        } else if (stmt.startsWith("!$")) {
-          //
-          // This is an immediate variable dereference
-          //
-          Object o = load(stmt.substring(2));
-          
-          if (null == o) {
-            if (!getSymbolTable().containsKey(stmt.substring(2))) {
-              throw new WarpScriptException("Unknown symbol '" + stmt.substring(2) + "'");
-            }
-          }
-
-          if (macros.isEmpty()) {
-            push(o);
-          } else {
-            macros.get(0).add(o);
-          }
-        } else if (stmt.startsWith("@")) {          
-          if (macros.isEmpty()) {
-            //
-            // This is a macro dereference
-            //
-            
-            String symbol = stmt.substring(1);
-
-            run(symbol);
-          } else {
-            macros.get(0).add(stmt.substring(1));
-            macros.get(0).add(WarpScriptLib.getFunction(WarpScriptLib.RUN));
-          }          
-        } else {
-          //
-          // This is a function call
-          //
-
-          Object func = null;
-          
-          //
-          // Check WarpScript functions
-          //
-
-          func = null != func ? func : defined.get(stmt);
-          
-          if (null != func && Boolean.FALSE.equals(getAttribute(WarpScriptStack.ATTRIBUTE_ALLOW_REDEFINED))) {
-            throw new WarpScriptException("Disallowed redefined function '" + stmt + "'.");
-          }
-          
-          func = null != func ? func : WarpScriptLib.getFunction(stmt);
-
-          if (null == func) {
-            throw new WarpScriptException("Unknown function '" + stmt + "'");
-          }
-
-          Map<String,String> labels = new HashMap<String,String>();
-          labels.put(SensisionConstants.SENSISION_LABEL_FUNCTION, stmt);
-          
-          long nano = System.nanoTime();
-          
-          try {
-            if (func instanceof WarpScriptStackFunction && macros.isEmpty()) {
-              //
-              // Function is an WarpScriptStackFunction, call it on this stack
-              //
-              
-              WarpScriptStackFunction esf = (WarpScriptStackFunction) func;
-
-              esf.apply(this);
+              secureScript.append("'");
             } else {
-              //
-              // Push any other type of function onto the stack
-              //
               if (macros.isEmpty()) {
-                push(func);
+                this.push(mlcontent);
               } else {
-                macros.get(0).add(func);
+                macros.get(0).add(mlcontent);
               }
-            }          
-          } finally {
-            Sensision.update(SensisionConstants.SENSISION_CLASS_WARPSCRIPT_FUNCTION_COUNT, labels, 1);
-            Sensision.update(SensisionConstants.SENSISION_CLASS_WARPSCRIPT_FUNCTION_TIME_US, labels, (System.nanoTime() - nano) / 1000L);
+            }
+            multiline.setLength(0);
+            continue;
+          } else if (inMultiline.get()) {
+            if (multiline.length() > 0) {
+              multiline.append("\n");
+            }
+            multiline.append(stmt);
+            continue;
+          } else if (WarpScriptStack.COMMENT_END.equals(stmt)) {
+            if (!inComment.get()) {
+              throw new WarpScriptException("Not inside a comment.");
+            }
+            inComment.set(false);
+            continue;
+          } else if (inComment.get()) {
+            continue;
+          } else if (WarpScriptStack.COMMENT_START.equals(stmt)) {
+            inComment.set(true);
+            continue;
+          } else if (WarpScriptStack.MULTILINE_START.equals(stmt)) {
+            if (1 != statements.length) {
+              throw new WarpScriptException("Can only start multiline strings by using " + WarpScriptStack.MULTILINE_START + " on a line by itself.");
+            }
+            inMultiline.set(true);
+            multiline = new StringBuilder();
+            continue;
           }
+
+          incOps();
+          checkOps();
+
+          if (WarpScriptStack.SECURE_SCRIPT_END.equals(stmt)) {
+            if (null == secureScript) {
+              throw new WarpScriptException("Not inside a secure script definition.");
+            } else {
+              this.push(secureScript.toString());
+              secureScript = null;
+              new SECURE("SECURESCRIPT").apply(this);
+            }
+          } else if (WarpScriptStack.SECURE_SCRIPT_START.equals(stmt)) {
+            if (null == secureScript) {
+              secureScript = new StringBuilder();
+            } else {
+              throw new WarpScriptException("Already inside a secure script definition.");
+            }
+          } else if (null != secureScript) {
+            secureScript.append(" ");
+            secureScript.append(stmt);
+          } else if (WarpScriptStack.MACRO_END.equals(stmt)) {
+            if (macros.isEmpty()) {
+              throw new WarpScriptException("Not inside a macro definition.");
+            } else {
+              Macro lastmacro = macros.remove(0);
+
+              boolean secure = Boolean.TRUE.equals(this.getAttribute(WarpScriptStack.ATTRIBUTE_IN_SECURE_MACRO));
+
+              lastmacro.setSecure(secure);
+
+              if (macros.isEmpty()) {
+                this.push(lastmacro);
+              } else {
+                // Add the macro to the outer macro
+                macros.get(0).add(lastmacro);
+              }
+            }
+          } else if (WarpScriptStack.MACRO_START.equals(stmt)) {
+            //
+            // Create holder for current macro
+            //
+
+            macros.add(0, new Macro());
+          } else if ((stmt.charAt(0) == '\'' && stmt.charAt(stmt.length() - 1) == '\'')
+              || (stmt.charAt(0) == '\"' && stmt.charAt(stmt.length() - 1) == '\"')) {
+            //
+            // Push Strings onto the stack
+            //
+
+            try {
+              String str = stmt.substring(1, stmt.length() - 1);
+
+              if (-1 != UnsafeString.indexOf(str, '%')) {
+                // replace occurrences of '+' with '%2B'
+                str = str.replaceAll("\\+", "%2B");
+                str = URLDecoder.decode(str, "UTF-8");
+              }
+
+              if (macros.isEmpty()) {
+                push(str);
+              } else {
+                macros.get(0).add(str);
+              }
+            } catch (UnsupportedEncodingException uee) {
+              // Cannot happen...
+              throw new WarpScriptException(uee);
+            }
+          } else if (stmt.length() > 2 && stmt.charAt(1) == 'x' && stmt.charAt(0) == '0') {
+            long hexl = stmt.length() < 18 ? Long.parseLong(stmt.substring(2), 16) : new BigInteger(stmt.substring(2), 16).longValue();
+            if (macros.isEmpty()) {
+              push(hexl);
+            } else {
+              macros.get(0).add(hexl);
+            }
+          } else if (stmt.length() > 2 && stmt.charAt(1) == 'b' && stmt.charAt(0) == '0') {
+            long binl = stmt.length() < 66 ? Long.parseLong(stmt.substring(2), 2) : new BigInteger(stmt.substring(2), 2).longValue();
+            if (macros.isEmpty()) {
+              push(binl);
+            } else {
+              macros.get(0).add(binl);
+            }
+          } else if (UnsafeString.isLong(stmt)) {
+            //
+            // Push longs onto the stack
+            //
+
+            if (macros.isEmpty()) {
+              push(Long.valueOf(stmt));
+            } else {
+              macros.get(0).add(Long.valueOf(stmt));
+            }
+          } else if (UnsafeString.isDouble(stmt)) {
+            //
+            // Push doubles onto the stack
+            //
+            if (macros.isEmpty()) {
+              push(Double.valueOf(stmt));
+            } else {
+              macros.get(0).add(Double.valueOf(stmt));
+            }
+          } else if (stmt.equalsIgnoreCase("T")
+                     || stmt.equalsIgnoreCase("F")
+                     || stmt.equalsIgnoreCase("true")
+                     || stmt.equalsIgnoreCase("false")) {
+            //
+            // Push booleans onto the stack
+            //
+            if (stmt.startsWith("T") || stmt.startsWith("t")) {
+              if (macros.isEmpty()) {
+                push(true);
+              } else {
+                macros.get(0).add(true);
+              }
+            } else {
+              if (macros.isEmpty()) {
+                push(false);
+              } else {
+                macros.get(0).add(false);
+              }
+            }
+          } else if (stmt.startsWith("$")) {
+            if (macros.isEmpty()) {
+              //
+              // This is a deferred variable dereference
+              //
+              Object o = load(stmt.substring(1));
+
+              if (null == o) {
+                if (!getSymbolTable().containsKey(stmt.substring(1))) {
+                  throw new WarpScriptException("Unknown symbol '" + stmt.substring(1) + "'");
+                }
+              }
+
+              push(o);
+            } else {
+              macros.get(0).add(stmt.substring(1));
+              macros.get(0).add(WarpScriptLib.getFunction(WarpScriptLib.LOAD));
+            }
+          } else if (stmt.startsWith("!$")) {
+            //
+            // This is an immediate variable dereference
+            //
+            Object o = load(stmt.substring(2));
+
+            if (null == o) {
+              if (!getSymbolTable().containsKey(stmt.substring(2))) {
+                throw new WarpScriptException("Unknown symbol '" + stmt.substring(2) + "'");
+              }
+            }
+
+            if (macros.isEmpty()) {
+              push(o);
+            } else {
+              macros.get(0).add(o);
+            }
+          } else if (stmt.startsWith("@")) {
+            if (macros.isEmpty()) {
+              //
+              // This is a macro dereference
+              //
+
+              String symbol = stmt.substring(1);
+
+              run(symbol);
+            } else {
+              macros.get(0).add(stmt.substring(1));
+              macros.get(0).add(WarpScriptLib.getFunction(WarpScriptLib.RUN));
+            }
+          } else {
+            //
+            // This is a function call
+            //
+
+            Object func = null;
+
+            //
+            // Check WarpScript functions
+            //
+
+            func = null != func ? func : defined.get(stmt);
+
+            if (null != func && Boolean.FALSE.equals(getAttribute(WarpScriptStack.ATTRIBUTE_ALLOW_REDEFINED))) {
+              throw new WarpScriptException("Disallowed redefined function '" + stmt + "'.");
+            }
+
+            func = null != func ? func : WarpScriptLib.getFunction(stmt);
+
+            if (null == func) {
+              throw new WarpScriptException("Unknown function '" + stmt + "'");
+            }
+
+            Map<String,String> labels = new HashMap<String,String>();
+            labels.put(SensisionConstants.SENSISION_LABEL_FUNCTION, stmt);
+
+            long nano = System.nanoTime();
+
+            try {
+              if (func instanceof WarpScriptStackFunction && macros.isEmpty()) {
+                //
+                // Function is an WarpScriptStackFunction, call it on this stack
+                //
+
+                WarpScriptStackFunction esf = (WarpScriptStackFunction) func;
+
+                esf.apply(this);
+              } else {
+                //
+                // Push any other type of function onto the stack
+                //
+                if (macros.isEmpty()) {
+                  push(func);
+                } else {
+                  macros.get(0).add(func);
+                }
+              }
+            } finally {
+              Sensision.update(SensisionConstants.SENSISION_CLASS_WARPSCRIPT_FUNCTION_COUNT, labels, 1);
+              Sensision.update(SensisionConstants.SENSISION_CLASS_WARPSCRIPT_FUNCTION_TIME_US, labels, (System.nanoTime() - nano) / 1000L);
+            }
+          }
+        } catch (WarpScriptException e) {
+          String scriptLine = "";
+          for (int stc = 0; stc < statements.length; stc++) {
+            if (st == stc) {
+              scriptLine += "=>" + StringUtils.abbreviate(statements[stc].trim(), 30) + "<= ";
+            } else {
+              scriptLine += StringUtils.abbreviate(statements[stc], 30) + " ";
+            }
+          }
+          throw new WarpScriptException(" " + scriptLine + " : " + e.getMessage());
         }
       }
       

--- a/warp10/src/main/java/io/warp10/script/MemoryWarpScriptStack.java
+++ b/warp10/src/main/java/io/warp10/script/MemoryWarpScriptStack.java
@@ -900,6 +900,8 @@ public class MemoryWarpScriptStack implements WarpScriptStack, Progressable {
               Sensision.update(SensisionConstants.SENSISION_CLASS_WARPSCRIPT_FUNCTION_TIME_US, labels, (System.nanoTime() - nano) / 1000L);
             }
           }
+        } catch (WarpScriptATCException e) {
+          throw e;
         } catch (WarpScriptException e) {
           String scriptLine = "";
           for (int stc = 0; stc < statements.length; stc++) {


### PR DESCRIPTION
Idea: to know exactly what instruction in the line causes the failure.
- Independant of LINEON, there is no cost to do it.
- comments are preserved, long statements are cut to 30 characters (also helps to preserve secrets).

Example:
```java
//will fail
[ 1 ] 0    GET 1 GET 1 GET STOP    'very very very very very very very very long string'  //very very very very very very very very long comment

```

Error message:
`2 in section '[TOP]':  [ 1 ] 0    GET 1 =>GET<= 1 GET STOP    'very%20very%20very%20very%...  //very very very very very very very very long comment  : GET operates on a map, list or byte array.`

Possible enhancement : copy `StringUtils.abbreviate` function somewhere to avoid another import.


