### PR TITLE
Add parameters about Listen Queue/Backlog in TCP

### DIFF
--- a/etc/conf.templates/distributed/10-directory.conf.template
+++ b/etc/conf.templates/distributed/10-directory.conf.template
@@ -150,9 +150,19 @@ directory.partition = 1:0
 directory.port = 8883
 
 //
+// TCP Backlog applied to the DirectoryService listener
+//
+#directory.tcp.backlog =
+
+//
 // Port the streaming directory service listens to
 //
 directory.streaming.port = 8885
+
+//
+// TCP Backlog applied to the streaming directory service listener
+//
+#directory.streaming.tcp.backlog =
 
 //
 // Number of Jetty selectors for the streaming server

--- a/etc/conf.templates/distributed/10-egress.conf.template
+++ b/etc/conf.templates/distributed/10-egress.conf.template
@@ -39,6 +39,11 @@ egress.clients.expose = false
 egress.port = 8881
 
 //
+// TCP Backlog applied to the egress server listener
+//
+#egress.tcp.backlog =
+
+//
 // Host onto which the egress server should listen
 //
 egress.host = 127.0.0.1

--- a/etc/conf.templates/distributed/10-ingress.conf.template
+++ b/etc/conf.templates/distributed/10-ingress.conf.template
@@ -71,6 +71,11 @@ ingress.host = 127.0.0.1
 ingress.port = 8882
 
 //
+// TCP Backlog applied to the ingress server listener
+//
+#ingress.tcp.backlog =
+
+//
 // Size of metadata cache in number of entries
 //
 ingress.metadata.cache.size = 10000000

--- a/etc/conf.templates/distributed/10-plasma.conf.template
+++ b/etc/conf.templates/distributed/10-plasma.conf.template
@@ -82,6 +82,11 @@ plasma.frontend.host = 127.0.0.1
 plasma.frontend.port = 8884
 
 //
+// TCP Backlog applied to the ingress server listener
+//
+#plasma.frontend.tcp.backlog =
+
+//
 // Number of acceptors
 //
 plasma.frontend.acceptors = 2

--- a/etc/conf.templates/distributed/30-ssl.conf.template
+++ b/etc/conf.templates/distributed/30-ssl.conf.template
@@ -24,6 +24,8 @@
 #ingress.ssl.host =
 # Port the SSL endpoint should bind to
 #ingress.ssl.port =
+# TCP Backlog for the SSL endpoint
+#ingress.ssl.tcp.backlog =
 # Number of Jetty acceptors (defaults to 2)
 #ingress.ssl.acceptors =
 # Number of Jetty selectors (defaults to 4)
@@ -45,6 +47,8 @@
 #egress.ssl.host =
 # Port the SSL endpoint should bind to
 #egress.ssl.port =
+# TCP Backlog for the SSL endpoint
+#egress.ssl.tcp.backlog =
 # Number of Jetty acceptors (defaults to 2)
 #egress.ssl.acceptors =
 # Number of Jetty selectors (defaults to 4)
@@ -66,6 +70,8 @@
 #plasma.frontend.ssl.host =
 # Port the SSL endpoint should bind to
 #plasma.frontend.ssl.port =
+# TCP Backlog for the SSL endpoint
+#plasma.frontend.ssl.tcp.backlog =
 # Number of Jetty acceptors (defaults to 2)
 #plasma.frontend.ssl.acceptors =
 # Number of Jetty selectors (defaults to 4)
@@ -87,6 +93,8 @@
 #http.ssl.host =
 # Port the SSL endpoint should bind to
 #http.ssl.port =
+# TCP Backlog for the SSL endpoint
+#http.ssl.tcp.backlog =
 # Number of Jetty acceptors (defaults to 2)
 # Adapt value of http.maxthreads accordingly
 #http.ssl.acceptors =

--- a/etc/conf.templates/distributed/80-http-plugin.conf.template
+++ b/etc/conf.templates/distributed/80-http-plugin.conf.template
@@ -22,6 +22,8 @@
 #http.host = 127.0.0.1
 // Port the HTTP plugin will listen on
 #http.port = 10080
+// TCP Backlog for the HTTP plugin listener
+#http.tcp.backlog =
 // Number of Jetty acceptors to use (defaults to 2)
 #http.acceptors = 2
 // Number of Jetty selectors to use (defaults to 4)

--- a/etc/conf.templates/standalone/00-warp.conf.template
+++ b/etc/conf.templates/standalone/00-warp.conf.template
@@ -90,6 +90,11 @@ standalone.host = 127.0.0.1
 standalone.port = 8080
 
 //
+// TCP Backlog applied to incoming connections listener.
+//
+#standalone.tcp.backlog =
+
+//
 // Number of Jetty acceptors
 //
 standalone.acceptors = 1

--- a/etc/conf.templates/standalone/30-ssl.conf.template
+++ b/etc/conf.templates/standalone/30-ssl.conf.template
@@ -22,6 +22,8 @@
 #standalone.ssl.host =
 # Port the SSL endpoint should bind to
 #standalone.ssl.port =
+# TCP Backlog for the SSL endpoint
+#standalone.ssl.tcp.backlog =
 # Number of Jetty acceptors (defaults to 2)
 #standalone.ssl.acceptors =
 # Number of Jetty selectors (defaults to 4)
@@ -43,6 +45,8 @@
 #http.ssl.host =
 # Port the SSL endpoint should bind to
 #http.ssl.port =
+# TCP Backlog for the SSL endpoint
+#http.ssl.tcp.backlog =
 # Number of Jetty acceptors (defaults to 2)
 # Adapt value of http.maxthreads accordingly
 #http.ssl.acceptors =

--- a/etc/conf.templates/standalone/80-http-plugin.conf.template
+++ b/etc/conf.templates/standalone/80-http-plugin.conf.template
@@ -22,6 +22,8 @@
 #http.host = 127.0.0.1
 // Port the HTTP plugin will listen on
 #http.port = 10080
+// TCP Backlog for the HTTP plugin listener
+#http.tcp.backlog =
 // Number of Jetty acceptors to use (defaults to 2)
 #http.acceptors = 2
 // Number of Jetty selectors to use (defaults to 4)

--- a/warp10/src/main/java/io/warp10/SSLUtils.java
+++ b/warp10/src/main/java/io/warp10/SSLUtils.java
@@ -33,6 +33,7 @@ public class SSLUtils {
 
     int sslPort = Integer.parseInt(WarpConfig.getProperty(prefix + Configuration._SSL_PORT));
     String sslHost = WarpConfig.getProperty(prefix + Configuration._SSL_HOST);
+    int sslTcpBacklog = Integer.parseInt(WarpConfig.getProperty(prefix + Configuration._SSL_TCP_BACKLOG, "0"));
 
     SslContextFactory sslContextFactory = new SslContextFactory();
     sslContextFactory.setKeyStorePath(WarpConfig.getProperty(prefix + Configuration._SSL_KEYSTORE_PATH));
@@ -48,6 +49,7 @@ public class SSLUtils {
     ServerConnector connector = new ServerConnector(server, sslAcceptors, sslSelectors, sslContextFactory);
     
     connector.setPort(sslPort);
+    connector.setAcceptQueueSize(sslTcpBacklog);
     
     if (null != sslHost) {
       connector.setHost(sslHost);

--- a/warp10/src/main/java/io/warp10/continuum/Configuration.java
+++ b/warp10/src/main/java/io/warp10/continuum/Configuration.java
@@ -440,11 +440,21 @@ public class Configuration {
    * Port on which the DirectoryService will listen
    */
   public static final String DIRECTORY_PORT = "directory.port";
-  
+
+  /**
+   * TCP Backlog applied to the DirectoryService listener
+   */
+  public static final String DIRECTORY_TCP_BACKLOG = "directory.tcp.backlog";
+
   /**
    * Port the streaming directory service listens to
    */
   public static final String DIRECTORY_STREAMING_PORT = "directory.streaming.port";
+
+  /**
+   * TCP Backlog applied to the streaming directory service listener
+   */
+  public static final String DIRECTORY_STREAMING_TCP_BACKLOG = "directory.streaming.tcp.backlog";
 
   /**
    * Should we ignore the proxy settings when doing a streaming request?
@@ -672,6 +682,11 @@ public class Configuration {
    */
   public static final String INGRESS_PORT = "ingress.port";
   
+  /**
+   * TCP Backlog applied to the ingress server listener
+   */
+  public static final String INGRESS_TCP_BACKLOG = "ingress.tcp.backlog";
+
   /**
    * Size of metadata cache in number of entries
    */
@@ -1108,7 +1123,12 @@ public class Configuration {
    * Port on which to listen
    */
   public static final String PLASMA_FRONTEND_PORT = "plasma.frontend.port";
-  
+
+  /**
+   * TCP Backlog applied to the Plasma listener
+   */
+  public static final String PLASMA_FRONTEND_TCP_BACKLOG = "plasma.frontend.tcp.backlog";
+
   /**
    * Number of acceptors
    */
@@ -1427,6 +1447,11 @@ public class Configuration {
   public static final String STANDALONE_PORT = "standalone.port";
 
   /**
+   * TCP Backlog applied to incoming connections listener.
+   */
+  public static final String STANDALONE_TCP_BACKLOG = "standalone.tcp.backlog";
+
+  /**
    * Number of Jetty acceptors
    */
   public static final String STANDALONE_ACCEPTORS = "standalone.acceptors";
@@ -1729,7 +1754,12 @@ public class Configuration {
    * Port onto which the egress server should listen
    */
   public static final String EGRESS_PORT = "egress.port";
-  
+
+  /**
+   * TCP Backlog applied to the egress server listener
+   */
+  public static final String EGRESS_TCP_BACKLOG = "egress.tcp.backlog";
+
   /**
    * Host onto which the egress server should listen
    */
@@ -2139,6 +2169,11 @@ public class Configuration {
    * SSL Port
    */
   public static final String _SSL_PORT = ".ssl.port";
+
+  /**
+   * SSL TCP Backlog
+   */
+  public static final String _SSL_TCP_BACKLOG = ".ssl.tcp.backlog";
 
   /**
    * SSL Host

--- a/warp10/src/main/java/io/warp10/continuum/egress/Egress.java
+++ b/warp10/src/main/java/io/warp10/continuum/egress/Egress.java
@@ -108,6 +108,7 @@ public class Egress {
     if (useHttp) {
       int port = Integer.valueOf(props.getProperty(Configuration.EGRESS_PORT));
       String host = props.getProperty(Configuration.EGRESS_HOST);
+      int tcpBacklog = Integer.valueOf(props.getProperty(Configuration.EGRESS_TCP_BACKLOG, "0"));
       int acceptors = Integer.valueOf(props.getProperty(Configuration.EGRESS_ACCEPTORS));
       int selectors = Integer.valueOf(props.getProperty(Configuration.EGRESS_SELECTORS));
       long idleTimeout = Long.parseLong(props.getProperty(Configuration.EGRESS_IDLE_TIMEOUT));
@@ -116,6 +117,7 @@ public class Egress {
       connector.setIdleTimeout(idleTimeout);
       connector.setPort(port);
       connector.setHost(host);
+      connector.setAcceptQueueSize(tcpBacklog);
       connector.setName("Continuum Egress HTTP");
       
       connectors.add(connector);

--- a/warp10/src/main/java/io/warp10/continuum/ingress/Ingress.java
+++ b/warp10/src/main/java/io/warp10/continuum/ingress/Ingress.java
@@ -588,6 +588,7 @@ public class Ingress extends AbstractHandler implements Runnable {
     if (useHttp) {
       int port = Integer.valueOf(props.getProperty(Configuration.INGRESS_PORT));
       String host = props.getProperty(Configuration.INGRESS_HOST);
+      int tcpBacklog = Integer.valueOf(props.getProperty(Configuration.INGRESS_TCP_BACKLOG, "0"));
       int acceptors = Integer.valueOf(props.getProperty(Configuration.INGRESS_ACCEPTORS));
       int selectors = Integer.valueOf(props.getProperty(Configuration.INGRESS_SELECTORS));
       long idleTimeout = Long.parseLong(props.getProperty(Configuration.INGRESS_IDLE_TIMEOUT));
@@ -596,6 +597,7 @@ public class Ingress extends AbstractHandler implements Runnable {
       connector.setIdleTimeout(idleTimeout);
       connector.setPort(port);
       connector.setHost(host);
+      connector.setAcceptQueueSize(tcpBacklog);
       connector.setName("Continuum Ingress HTTP");
       
       connectors.add(connector);

--- a/warp10/src/main/java/io/warp10/continuum/plasma/PlasmaFrontEnd.java
+++ b/warp10/src/main/java/io/warp10/continuum/plasma/PlasmaFrontEnd.java
@@ -307,6 +307,7 @@ public class PlasmaFrontEnd extends StandalonePlasmaHandler implements Runnable,
     
     boolean useHttp = null != properties.getProperty(Configuration.PLASMA_FRONTEND_PORT);
     boolean useHttps = null != properties.getProperty(Configuration.PLASMA_FRONTEND_PREFIX + Configuration._SSL_PORT);
+    int tcpBacklog = Integer.valueOf(properties.getProperty(Configuration.PLASMA_FRONTEND_TCP_BACKLOG, "0"));
     
     List<ServerConnector> connectors = new ArrayList<ServerConnector>();
     
@@ -315,7 +316,9 @@ public class PlasmaFrontEnd extends StandalonePlasmaHandler implements Runnable,
       connector.setIdleTimeout(Long.parseLong(properties.getProperty(Configuration.PLASMA_FRONTEND_IDLE_TIMEOUT)));    
       connector.setPort(Integer.parseInt(properties.getProperty(Configuration.PLASMA_FRONTEND_PORT)));
       connector.setHost(properties.getProperty(Configuration.PLASMA_FRONTEND_HOST));
+      connector.setAcceptQueueSize(tcpBacklog);
       connector.setName("Continuum Plasma Front End HTTP");
+
       connectors.add(connector);
     }
     

--- a/warp10/src/main/java/io/warp10/continuum/store/Directory.java
+++ b/warp10/src/main/java/io/warp10/continuum/store/Directory.java
@@ -50,7 +50,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.math.BigInteger;
-import java.net.InetSocketAddress;
+import java.net.InetAddress;
+import java.net.ServerSocket;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
@@ -221,7 +222,9 @@ public class Directory extends AbstractHandler implements DirectoryService.Iface
   private final int remainder;
   private String host;
   private int port;
+  private int tcpBacklog;
   private int streamingport;
+  private int streamingTcpBacklog;
   private int streamingselectors;
   private int streamingacceptors;
     
@@ -846,7 +849,9 @@ public class Directory extends AbstractHandler implements DirectoryService.Iface
     
     this.host = properties.getProperty(io.warp10.continuum.Configuration.DIRECTORY_HOST);
     this.port = Integer.parseInt(properties.getProperty(io.warp10.continuum.Configuration.DIRECTORY_PORT));
+    this.tcpBacklog = Integer.parseInt(properties.getProperty(io.warp10.continuum.Configuration.DIRECTORY_TCP_BACKLOG, "0"));
     this.streamingport = Integer.parseInt(properties.getProperty(io.warp10.continuum.Configuration.DIRECTORY_STREAMING_PORT));
+    this.streamingTcpBacklog = Integer.parseInt(properties.getProperty(io.warp10.continuum.Configuration.DIRECTORY_STREAMING_TCP_BACKLOG, "0"));
     this.streamingacceptors = Integer.parseInt(properties.getProperty(io.warp10.continuum.Configuration.DIRECTORY_STREAMING_ACCEPTORS));
     this.streamingselectors = Integer.parseInt(properties.getProperty(io.warp10.continuum.Configuration.DIRECTORY_STREAMING_SELECTORS));
     
@@ -1034,6 +1039,7 @@ public class Directory extends AbstractHandler implements DirectoryService.Iface
     connector.setIdleTimeout(idleTimeout);
     connector.setPort(this.streamingport);
     connector.setHost(host);
+    connector.setAcceptQueueSize(this.streamingTcpBacklog);
     connector.setName("Directory Streaming Service");
     
     server.setConnectors(new Connector[] { connector });
@@ -1093,8 +1099,8 @@ public class Directory extends AbstractHandler implements DirectoryService.Iface
     ServiceInstance<Map> instance = null;
 
     try {
-      InetSocketAddress bindAddress = new InetSocketAddress(this.host, this.port);
-      TServerTransport transport = new TServerSocket(bindAddress);
+      InetAddress bindAddress = InetAddress.getByName(this.host);
+      TServerTransport transport = new TServerSocket(new ServerSocket(this.port, this.tcpBacklog, bindAddress));
       TThreadPoolServer.Args args = new TThreadPoolServer.Args(transport);
       args.processor(processor);
       //

--- a/warp10/src/main/java/io/warp10/plugins/http/HTTPWarp10Plugin.java
+++ b/warp10/src/main/java/io/warp10/plugins/http/HTTPWarp10Plugin.java
@@ -60,6 +60,7 @@ public class HTTPWarp10Plugin extends AbstractWarp10Plugin implements Runnable {
 
   private static final String CONF_HTTP_HOST = "http.host";
   private static final String CONF_HTTP_PORT = "http.port";
+  private static final String CONF_HTTP_TCP_BACKLOG = "http.tcp.backlog";
 
   /**
    * Directory where spec files are located
@@ -88,6 +89,7 @@ public class HTTPWarp10Plugin extends AbstractWarp10Plugin implements Runnable {
   private long period;
   private String host;
   private int port = -1;
+  private int tcpBacklog = 0;
   private int acceptors = 2;
   private int selectors = 4;
   private int maxthreads = -1;
@@ -95,6 +97,7 @@ public class HTTPWarp10Plugin extends AbstractWarp10Plugin implements Runnable {
   private BlockingQueue<Runnable> queue = null;
 
   private int sslport = -1;
+  private int tcpBacklog = 0;
 
   /**
    * Map of uri to macros
@@ -152,6 +155,7 @@ public class HTTPWarp10Plugin extends AbstractWarp10Plugin implements Runnable {
       connector.setIdleTimeout(idleTimeout);
       connector.setPort(port);
       connector.setHost(host);
+      connector.setAcceptQueueSize(tcpBacklog);
       connector.setName("Warp 10 HTTP Plugin Jetty HTTP Connector");
       server.addConnector(connector);
       minthreads += acceptors + acceptors * selectors;
@@ -334,6 +338,7 @@ public class HTTPWarp10Plugin extends AbstractWarp10Plugin implements Runnable {
     
     
     this.port = Integer.parseInt(properties.getProperty(CONF_HTTP_PORT, "-1"));
+    this.tcpBacklog = Integer.parseInt(properties.getProperty(CONF_HTTP_TCP_BACKLOG, "0"));
     this.sslport = Integer.parseInt(properties.getProperty("http" + Configuration._SSL_PORT, "-1"));
 
     if (-1 == this.port && -1 == this.sslport) {

--- a/warp10/src/main/java/io/warp10/plugins/tcp/TCPManager.java
+++ b/warp10/src/main/java/io/warp10/plugins/tcp/TCPManager.java
@@ -51,6 +51,7 @@ public class TCPManager extends Thread {
   private static final int DEFAULT_QSIZE = 1024;
   private static final int DEFAULT_MAXMESSAGES = 1;
   private static final int DEFAULT_MAXCONNECTIONS = 1;
+  private static final int DEFAULT_TCP_BACKLOG = 0;
   private static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
 
   private static final String PARAM_MODE = "mode";
@@ -61,6 +62,7 @@ public class TCPManager extends Thread {
   private static final String PARAM_QSIZE = "qsize";
   private static final String PARAM_HOST = "host";
   private static final String PARAM_PORT = "port";
+  private static final String PARAM_TCP_BACKLOG = "tcpBacklog";
   private static final String PARAM_TIMEOUT = "timeout";
   private static final String PARAM_MAXMESSAGES = "maxMessages";
   private static final String PARAM_MAXCONNECTIONS = "maxConnections";
@@ -79,6 +81,7 @@ public class TCPManager extends Thread {
 
   private final int parallelism;
   private final int port;
+  private final int tcpBacklog;
 
   private Thread[] executors;
 
@@ -142,6 +145,7 @@ public class TCPManager extends Thread {
     partitioner = (Macro) config.get(PARAM_PARTITIONER);
     host = String.valueOf(config.get(PARAM_HOST));
     port = ((Number) config.get(PARAM_PORT)).intValue();
+    tcpBacklog = ((Number) config.getOrDefault(PARAM_TCP_BACKLOG, DEFAULT_TCP_BACKLOG)).intValue();
     parallelism = ((Number) config.getOrDefault(PARAM_PARALLELISM, 1)).intValue();
     timeout = ((Number) config.getOrDefault(PARAM_TIMEOUT, 0L)).longValue();
     maxMessages = ((Number) config.getOrDefault(PARAM_MAXMESSAGES, DEFAULT_MAXMESSAGES)).intValue();
@@ -164,7 +168,7 @@ public class TCPManager extends Thread {
 
     // Create server or client socket
     if ("server".equals(mode)) {
-      serverSocket = new ServerSocket(port, 50, InetAddress.getByName(host));
+      serverSocket = new ServerSocket(port, tcpBacklog, InetAddress.getByName(host));
     } else if (!"client".equals(mode)) {
       throw new RuntimeException("Mode must be either server or client.");
     }

--- a/warp10/src/main/java/io/warp10/standalone/Warp.java
+++ b/warp10/src/main/java/io/warp10/standalone/Warp.java
@@ -295,10 +295,12 @@ public class Warp extends WarpDist implements Runnable {
       int selectors = Integer.valueOf(properties.getProperty(Configuration.STANDALONE_SELECTORS, DEFAULT_HTTP_SELECTORS));
       port = Integer.valueOf(properties.getProperty(Configuration.STANDALONE_PORT));
       host = properties.getProperty(Configuration.STANDALONE_HOST, "0.0.0.0");
+      int tcpBacklog = Integer.valueOf(properties.getProperty(Configuration.STANDALONE_TCP_BACKLOG, "0"));
       
       httpConnector = new ServerConnector(server, acceptors, selectors);
       
       httpConnector.setPort(port);
+      httpConnector.setAcceptQueueSize(tcpBacklog);
       
       if (null != host) {
         httpConnector.setHost(host);


### PR DESCRIPTION
Default values in Kernel and Java are pretty conservative. When scaling, those parameters cause some SYN requests to be dropped without notice.
JVM default value is 50.

Effective value (ss -ltpn) is the minimum between supplied value and net.core.somaxconn.