### PR TITLE
feat(directory): add a gts per app metrics

### DIFF
--- a/warp10/src/main/java/io/warp10/continuum/sensision/SensisionConstants.java
+++ b/warp10/src/main/java/io/warp10/continuum/sensision/SensisionConstants.java
@@ -119,6 +119,11 @@ public class SensisionConstants {
    * Number of distinct owners known by a Directory
    */
   public static final String SENSISION_CLASS_CONTINUUM_DIRECTORY_OWNERS = "warp.directory.owners";
+  
+  /**
+   * Number of distinct classes per owner known by a Directory
+   */
+  public static final String SENSISION_CLASS_CONTINUUM_DIRECTORY_GTS_PERAPP = "warp.directory.gts.perapp";
 
   /**
    * Number of times the Thrift directory client cache was changed

--- a/warp10/src/main/java/io/warp10/continuum/store/Directory.java
+++ b/warp10/src/main/java/io/warp10/continuum/store/Directory.java
@@ -1399,17 +1399,12 @@ public class Directory extends AbstractHandler implements DirectoryService.Iface
         // TODO(hbs): allow setting of writeBufferSize
 
         MetadataID id = null;
-
-        // 'tracked' is used to know if we pushing metadata due to tracking.
-        // This allows to avoid incrementing the GTS/Classes perowner metrics.
-        boolean tracked;
         
         byte[] hbaseAESKey = directory.keystore.getKey(KeyStore.AES_HBASE_METADATA);
         
         while (iter.hasNext()) {
           Sensision.set(SensisionConstants.SENSISION_CLASS_CONTINUUM_DIRECTORY_JVM_FREEMEMORY, Sensision.EMPTY_LABELS, Runtime.getRuntime().freeMemory());
-          
-          tracked = false;
+
           //
           // Since the call to 'next' may block, we need to first
           // check that there is a message available, otherwise we
@@ -1673,8 +1668,6 @@ public class Directory extends AbstractHandler implements DirectoryService.Iface
                 
                 if (!directory.trackingActivity) {
                   continue;
-                } else {
-                  tracked = true;
                 }
                 
                 //
@@ -1867,9 +1860,7 @@ public class Directory extends AbstractHandler implements DirectoryService.Iface
               // 128bits
               if (null == directory.metadatas.get(metadata.getName()).put(labelsId, metadata)) {
                 Sensision.update(SensisionConstants.SENSISION_CLASS_CONTINUUM_DIRECTORY_GTS, Sensision.EMPTY_LABELS, 1);
-                if (!tracked) {
-                  Sensision.update(SensisionConstants.SENSISION_CLASS_CONTINUUM_DIRECTORY_GTS_PERAPP, sensisionLabels, 1);
-                }
+                Sensision.update(SensisionConstants.SENSISION_CLASS_CONTINUUM_DIRECTORY_GTS_PERAPP, sensisionLabels, 1);
               }
            
             } finally {

--- a/warp10/src/main/java/io/warp10/continuum/store/Directory.java
+++ b/warp10/src/main/java/io/warp10/continuum/store/Directory.java
@@ -678,6 +678,10 @@ public class Directory extends AbstractHandler implements DirectoryService.Iface
                 //
                 
                 String owner = metadata.getLabels().get(Constants.OWNER_LABEL);
+
+                String app = metadata.getLabels().get(Constants.APPLICATION_LABEL);
+                Map<String,String> sensisionLabels = new HashMap<String,String>();
+                sensisionLabels.put(SensisionConstants.SENSISION_LABEL_APPLICATION, app);
                 
                 synchronized(classesPerOwner) {
                   Set<String> classes = classesPerOwner.get(owner);
@@ -690,6 +694,7 @@ public class Directory extends AbstractHandler implements DirectoryService.Iface
                   classes.add(metadata.getName());
                 }
 
+                Sensision.update(SensisionConstants.SENSISION_CLASS_CONTINUUM_DIRECTORY_GTS_PERAPP, sensisionLabels, 1);
                 Sensision.set(SensisionConstants.SENSISION_CLASS_CONTINUUM_DIRECTORY_OWNERS, Sensision.EMPTY_LABELS, classesPerOwner.size());
 
                 synchronized(metadatas.get(metadata.getName())) {
@@ -1394,12 +1399,17 @@ public class Directory extends AbstractHandler implements DirectoryService.Iface
         // TODO(hbs): allow setting of writeBufferSize
 
         MetadataID id = null;
+
+        // 'tracked' is used to know if we pushing metadata due to tracking.
+        // This allows to avoid incrementing the GTS/Classes perowner metrics.
+        boolean tracked;
         
         byte[] hbaseAESKey = directory.keystore.getKey(KeyStore.AES_HBASE_METADATA);
         
         while (iter.hasNext()) {
           Sensision.set(SensisionConstants.SENSISION_CLASS_CONTINUUM_DIRECTORY_JVM_FREEMEMORY, Sensision.EMPTY_LABELS, Runtime.getRuntime().freeMemory());
-
+          
+          tracked = false;
           //
           // Since the call to 'next' may block, we need to first
           // check that there is a message available, otherwise we
@@ -1498,6 +1508,9 @@ public class Directory extends AbstractHandler implements DirectoryService.Iface
               continue;
             }
             
+            String app = metadata.getLabels().get(Constants.APPLICATION_LABEL);
+            Map<String,String> sensisionLabels = new HashMap<String,String>();
+            sensisionLabels.put(SensisionConstants.SENSISION_LABEL_APPLICATION, app);
             
             //
             // Check the source of the metadata
@@ -1562,6 +1575,7 @@ public class Directory extends AbstractHandler implements DirectoryService.Iface
                     }                    
                   }
                   Sensision.update(SensisionConstants.SENSISION_CLASS_CONTINUUM_DIRECTORY_GTS, Sensision.EMPTY_LABELS, -1);
+                  Sensision.update(SensisionConstants.SENSISION_CLASS_CONTINUUM_DIRECTORY_GTS_PERAPP, sensisionLabels, -1);
                 }
               }
 
@@ -1659,6 +1673,8 @@ public class Directory extends AbstractHandler implements DirectoryService.Iface
                 
                 if (!directory.trackingActivity) {
                   continue;
+                } else {
+                  tracked = true;
                 }
                 
                 //
@@ -1851,6 +1867,9 @@ public class Directory extends AbstractHandler implements DirectoryService.Iface
               // 128bits
               if (null == directory.metadatas.get(metadata.getName()).put(labelsId, metadata)) {
                 Sensision.update(SensisionConstants.SENSISION_CLASS_CONTINUUM_DIRECTORY_GTS, Sensision.EMPTY_LABELS, 1);
+                if (!tracked) {
+                  Sensision.update(SensisionConstants.SENSISION_CLASS_CONTINUUM_DIRECTORY_GTS_PERAPP, sensisionLabels, 1);
+                }
               }
            
             } finally {

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneDirectoryClient.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneDirectoryClient.java
@@ -227,6 +227,10 @@ public class StandaloneDirectoryClient implements DirectoryClient {
 
               Metadata metadata = new Metadata();
               deserializer.deserialize(metadata, unpadded);
+
+              String app = metadata.getLabels().get(Constants.APPLICATION_LABEL);
+              Map<String,String> sensisionLabels = new HashMap<String,String>();
+              sensisionLabels.put(SensisionConstants.SENSISION_LABEL_APPLICATION, app);
               
               //
               // Compute classId/labelsId and compare it to the values in the row key
@@ -279,6 +283,8 @@ public class StandaloneDirectoryClient implements DirectoryClient {
                   GTSHelper.fillGTSIds(bytes, 0, classId, labelsId);
                   BigInteger id = new BigInteger(bytes);
                   metadatasById.put(id, metadata);
+
+                  Sensision.update(SensisionConstants.SENSISION_CLASS_CONTINUUM_DIRECTORY_GTS_PERAPP, sensisionLabels, 1);
 
                   continue;
                 }
@@ -662,6 +668,10 @@ public class StandaloneDirectoryClient implements DirectoryClient {
       metadatas.remove(metadata.getName());
     }
 
+    String app = metadata.getLabels().get(Constants.APPLICATION_LABEL);
+    Map<String,String> sensisionLabels = new HashMap<String,String>();
+    sensisionLabels.put(SensisionConstants.SENSISION_LABEL_APPLICATION, app);
+
     // 128BITS
     long classId = GTSHelper.classId(this.classLongs, metadata.getName());
 
@@ -676,6 +686,7 @@ public class StandaloneDirectoryClient implements DirectoryClient {
     
     if (null == this.db) {
       Sensision.update(SensisionConstants.SENSISION_CLASS_CONTINUUM_DIRECTORY_GTS, Sensision.EMPTY_LABELS, -1);
+      Sensision.update(SensisionConstants.SENSISION_CLASS_CONTINUUM_DIRECTORY_GTS_PERAPP, sensisionLabels, -1);
       return;
     }
 
@@ -706,6 +717,7 @@ public class StandaloneDirectoryClient implements DirectoryClient {
     this.db.delete(bytes);
     
     Sensision.update(SensisionConstants.SENSISION_CLASS_CONTINUUM_DIRECTORY_GTS, Sensision.EMPTY_LABELS, -1);
+    Sensision.update(SensisionConstants.SENSISION_CLASS_CONTINUUM_DIRECTORY_GTS_PERAPP, sensisionLabels, -1);
   }
   
   private ThreadLocal<WriteBatch> perThreadWriteBatch = new ThreadLocal<WriteBatch>() {
@@ -763,6 +775,10 @@ public class StandaloneDirectoryClient implements DirectoryClient {
     // 128BITS
     long classId = GTSHelper.classId(this.classLongs, metadata.getName());
     long labelsId = GTSHelper.labelsId(this.labelsLongs, metadata.getLabels());
+
+    String app = metadata.getLabels().get(Constants.APPLICATION_LABEL);
+    Map<String,String> sensisionLabels = new HashMap<String,String>();
+    sensisionLabels.put(SensisionConstants.SENSISION_LABEL_APPLICATION, app);
     
     //ByteBuffer bb = ByteBuffer.wrap(new byte[1 + 8 + 8]).order(ByteOrder.BIG_ENDIAN);    
     //bb.put(METADATA_PREFIX);
@@ -835,6 +851,7 @@ public class StandaloneDirectoryClient implements DirectoryClient {
         }
         if (null == metadatas.get(metadata.getName()).put(labelsId, metadata)) {
           Sensision.update(SensisionConstants.SENSISION_CLASS_CONTINUUM_DIRECTORY_GTS, Sensision.EMPTY_LABELS, 1);
+          Sensision.update(SensisionConstants.SENSISION_CLASS_CONTINUUM_DIRECTORY_GTS_PERAPP, sensisionLabels, 1);
         }
       }
       //


### PR DESCRIPTION
In a context of user in Warp10, it can be great to keep trace of the series account per Warp application. 

In this PR, we simply add a Metrics `warp.directory.gts.perapp` directly in the directory.

Written by @StevenLeRoux and me.