### PR TITLE
minor bugfix error message warp10-standalone.sh

### DIFF
--- a/warp10/src/main/sh/warp10-standalone.sh
+++ b/warp10/src/main/sh/warp10-standalone.sh
@@ -62,8 +62,7 @@ fi
 # Check java version
 #
 JAVA_VERSION="`${JAVACMD} -version 2>&1 | head -n 1`"
-CHECK_JAVA="`echo ${JAVA_VERSION} | egrep '.*\"1\.(7|8).*'`"
-if [ "$CHECK_JAVA" == "" ]; then
+if [ "`echo ${JAVA_VERSION} | egrep '.*\"1\.(7|8).*'`" == "" ]; then
   echo "You are using a non compatible java version: ${JAVA_VERSION}"
   echo "We recommend the latest update of OpenJDK 1.8"
   exit 1


### PR DESCRIPTION
"if" statement from line 66 was unreachable in case it would be false since "set -euo pipefail" was inserted at the begining of the script.
With -e option, if egrep command fails then the script exits immediately, except if it is put in a conditional statement.