### PR TITLE
Exception detail in EVAL

### DIFF
--- a/warp10/src/main/java/io/warp10/script/MemoryWarpScriptStack.java
+++ b/warp10/src/main/java/io/warp10/script/MemoryWarpScriptStack.java
@@ -500,7 +500,7 @@ public class MemoryWarpScriptStack implements WarpScriptStack, Progressable {
       // Rethrow WarpScriptStopExceptions as is
       throw wsse;
     } catch (Exception e) {
-      throw new WarpScriptException(e);
+      throw new WarpScriptException("Line #" + i, e);
     }
    
     //String[] lines = UnsafeString.split(script, '\n');

--- a/warp10/src/main/java/io/warp10/script/MemoryWarpScriptStack.java
+++ b/warp10/src/main/java/io/warp10/script/MemoryWarpScriptStack.java
@@ -500,7 +500,7 @@ public class MemoryWarpScriptStack implements WarpScriptStack, Progressable {
       // Rethrow WarpScriptStopExceptions as is
       throw wsse;
     } catch (Exception e) {
-      throw new WarpScriptException("Line #" + i + ": " + e.getMessage(), e);
+      throw new WarpScriptException(e);
     }
    
     //String[] lines = UnsafeString.split(script, '\n');

--- a/warp10/src/main/java/io/warp10/script/MemoryWarpScriptStack.java
+++ b/warp10/src/main/java/io/warp10/script/MemoryWarpScriptStack.java
@@ -500,7 +500,7 @@ public class MemoryWarpScriptStack implements WarpScriptStack, Progressable {
       // Rethrow WarpScriptStopExceptions as is
       throw wsse;
     } catch (Exception e) {
-      throw new WarpScriptException("Line #" + i + ": " + e.getMessage());
+      throw new WarpScriptException("Line #" + i + ": " + e.getMessage(), e);
     }
    
     //String[] lines = UnsafeString.split(script, '\n');


### PR DESCRIPTION
` 2 0 /` raise the error : `Exception at '2 0 =>/<=' in section [TOP] (/ by zero)`

` '2 0 /' EVAL` raise the error : `Exception at ''2%200%20/' =>EVAL<=' in section [TOP] (Line #1: Exception at '2 0 =>/<=' in section [TOP])` You do not know what goes wrong.

With this fix, which might not be the best, the error message is now:
` '2 0 /' EVAL` raise the error : `Exception at '"2%200%20/" =>EVAL<=' in section [TOP] (io.warp10.script.WarpScriptException: Exception at '2 0 =>/<=' in section [TOP] (Exception at '2 0 =>/<=' in section [TOP] (/ by zero)))`

