### PR TITLE
duplicate stderr to logs and stderr for process journal

### DIFF
--- a/warp10/src/main/sh/warp10-standalone.sh
+++ b/warp10/src/main/sh/warp10-standalone.sh
@@ -422,7 +422,7 @@ start() {
   #
   # Start Warp10 instance..
   #
-  ${JAVACMD} ${JAVA_OPTS} -cp ${WARP10_CP} ${WARP10_CLASS} ${CONFIG_FILES} >> ${WARP10_HOME}/logs/warp10.log 2>&1 &
+  ${JAVACMD} ${JAVA_OPTS} -cp ${WARP10_CP} ${WARP10_CLASS} ${CONFIG_FILES} >> ${WARP10_HOME}/logs/warp10.log 2> >(tee >(cat 1>&2)) &
 
   echo $! > ${PID_FILE}
 

--- a/warp10/src/main/sh/warp10-standalone.sh
+++ b/warp10/src/main/sh/warp10-standalone.sh
@@ -421,6 +421,8 @@ start() {
 
   #
   # Start Warp10 instance..
+  # By default, standard and error output is redirected to warp10.log file, and error output is duplicated to standard output
+  # As a consequence, if Warp 10 is launched by systemd, error messages will be in systemd journal too.
   #
   ${JAVACMD} ${JAVA_OPTS} -cp ${WARP10_CP} ${WARP10_CLASS} ${CONFIG_FILES} >> ${WARP10_HOME}/logs/warp10.log 2> >(tee >(cat 1>&2)) &
 


### PR DESCRIPTION
Allow to log errors in warp10.log, and also to have them in systemd logs when installed as a service.

Follow tutorial [here](https://www.warp10.io/content/03_Documentation/02_Installation/01_Standalone#autostart), then try `journalctl -f -u warp10` 

Usefull when warp10 fails to start, or with STDERR WarpScript function.