### PR TITLE
Make median aggregator always return a double.

### DIFF
--- a/warp10/src/main/java/io/warp10/script/aggregator/Median.java
+++ b/warp10/src/main/java/io/warp10/script/aggregator/Median.java
@@ -51,15 +51,13 @@ public class Median extends NamedWarpScriptFunction implements WarpScriptAggrega
     final Object[] values = (Object[]) args[6];
 
     //
-    // count null value. Also check if there is one double at least
+    // count null value.
     //
     int nullCounter = 0;
-    boolean inputHasDouble = false;
     for (Object v: values) {
       if (null == v) {
         nullCounter++;
       }
-      inputHasDouble |= (v instanceof Double);
     }
 
     if (0 != nullCounter && this.forbidNulls) {
@@ -92,7 +90,7 @@ public class Median extends NamedWarpScriptFunction implements WarpScriptAggrega
 
     long location = GeoTimeSerie.NO_LOCATION;
     long elevation = GeoTimeSerie.NO_ELEVATION;
-    Object median;
+    double median;
 
     int nonNullLength = values.length - nullCounter;
 
@@ -100,7 +98,7 @@ public class Median extends NamedWarpScriptFunction implements WarpScriptAggrega
     // singleton case
     //
     if (1 == nonNullLength) {
-      return new Object[] {tick, locations[indices[0]], elevations[indices[0]], values[indices[0]]};
+      return new Object[] {tick, locations[indices[0]], elevations[indices[0]], ((Number) values[indices[0]]).doubleValue()};
     } else {
       if (0 == nonNullLength % 2) {
         //
@@ -140,10 +138,6 @@ public class Median extends NamedWarpScriptFunction implements WarpScriptAggrega
 
     }
 
-    // if the input has only long values, return a long.
-    if (!inputHasDouble) {
-      median = ((Double) median).longValue();
-    }
     return new Object[] {tick, location, elevation, median};
   }
 }


### PR DESCRIPTION
TLDR: Median aggregator must always return a double to avoid confusion. 

A wildly accepted definition of the median, [as on NIST](https://www.itl.nist.gov/div898/handbook/eda/section3/eda351.htm), makes it so the median of an even number of elements is the mean of two elements. This means the median has a probability of 1 of being a floating point number for a list of floating point number and a probability of 0.25 of being a floating point number for a list of integers (0.5 the list has an odd number of elements, 0.25 the list has an even number of elements and the difference between the two elements use to compute the mean is even and 0.25 the list has an even number of elements and the difference between the two elements use to compute the mean is odd). The simplest solution is thus to always return a double.

This PR also fixes this bug/unexpected behavior:
```
[
  [ 1 2 3 ] [] [] []
  [ 1 2 3 ]
  MAKEGTS
  [ 1   2   3   ] [] [] []
  [ 2.3 3.2 4.1 ]
  MAKEGTS
]
// Returns a GTS of doubles
[ SWAP NULL reducer.median ] REDUCE

[
  [ 1 2 3 ] [] [] []
  [ 1 2 3 ]
  MAKEGTS
  [     2   3   ] [] [] []
  [     3.2 4.1 ]
  MAKEGTS
]
// Returns a GTS of longs
[ SWAP NULL reducer.median ] REDUCE
```