### PR TITLE
MAP to accept abs(occurrences)>Integer.MAX_VALUE and code simplification.

### DIFF
--- a/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
+++ b/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
@@ -5076,15 +5076,18 @@ public class GTSHelper {
     }
 
     //
-    // Limit pre/post windows to Integer.MAX_VALUE
+    // Limit pre/post windows and occurrences to Integer.MAX_VALUE
     // as this is as many indices we may have at most in a GTS
     //
     
-    if (prewindow > 0 && prewindow > Integer.MAX_VALUE) {
+    if (prewindow > Integer.MAX_VALUE) {
       prewindow = Integer.MAX_VALUE;
     }
-    if (postwindow > 0 && postwindow > Integer.MAX_VALUE) {
+    if (postwindow > Integer.MAX_VALUE) {
       postwindow = Integer.MAX_VALUE;
+    }
+    if (occurrences > Integer.MAX_VALUE) {
+      occurrences = Integer.MAX_VALUE;
     }
     List<GeoTimeSerie> results = new ArrayList<GeoTimeSerie>();
 

--- a/warp10/src/main/java/io/warp10/script/functions/MAP.java
+++ b/warp10/src/main/java/io/warp10/script/functions/MAP.java
@@ -142,7 +142,7 @@ public class MAP extends NamedWarpScriptFunction implements WarpScriptStackFunct
     Object mapper = params.get(PARAM_MAPPER);
     long prewindow = !params.containsKey(PARAM_PREWINDOW) ? 0 : (long) params.get(PARAM_PREWINDOW);
     long postwindow = !params.containsKey(PARAM_POSTWINDOW) ? 0 : (long) params.get(PARAM_POSTWINDOW);
-    int occurrences = !params.containsKey(PARAM_OCCURENCES) ? 0 : (int) ((long) params.get(PARAM_OCCURENCES));
+    long occurrences = !params.containsKey(PARAM_OCCURENCES) ? 0 : (long) params.get(PARAM_OCCURENCES);
     int step = !params.containsKey(PARAM_STEP) ? 1 : (int) ((long) params.get(PARAM_STEP));
     boolean overrideTick = !params.containsKey(PARAM_OVERRIDE) ? false : (boolean) params.get(PARAM_OVERRIDE);
     Object outputTicks = params.get(PARAM_OUTPUTTICKS);
@@ -187,6 +187,11 @@ public class MAP extends NamedWarpScriptFunction implements WarpScriptStackFunct
     // Call MAP
     
     List<Object> mapped = new ArrayList<Object>();
+
+    // Make sure Math.abs(occurrences) will return a positive value.
+    if (Long.MIN_VALUE == occurrences) {
+      occurrences = Long.MIN_VALUE + 1;
+    }
     
     for (GeoTimeSerie gts: series) {
       List<GeoTimeSerie> res = GTSHelper.map(gts, mapper, prewindow, postwindow, Math.abs(occurrences), occurrences < 0 ? true : false, step, overrideTick, mapper instanceof Macro ? stack : null,

--- a/warp10/src/main/java/io/warp10/script/functions/MAP.java
+++ b/warp10/src/main/java/io/warp10/script/functions/MAP.java
@@ -144,7 +144,7 @@ public class MAP extends NamedWarpScriptFunction implements WarpScriptStackFunct
     long postwindow = !params.containsKey(PARAM_POSTWINDOW) ? 0 : (long) params.get(PARAM_POSTWINDOW);
     long occurrences = !params.containsKey(PARAM_OCCURENCES) ? 0 : (long) params.get(PARAM_OCCURENCES);
     int step = !params.containsKey(PARAM_STEP) ? 1 : (int) ((long) params.get(PARAM_STEP));
-    boolean overrideTick = !params.containsKey(PARAM_OVERRIDE) ? false : (boolean) params.get(PARAM_OVERRIDE);
+    boolean overrideTick = params.containsKey(PARAM_OVERRIDE) && (boolean) params.get(PARAM_OVERRIDE);
     Object outputTicks = params.get(PARAM_OUTPUTTICKS);
     
     // Handle gts and nested list of gts
@@ -194,7 +194,7 @@ public class MAP extends NamedWarpScriptFunction implements WarpScriptStackFunct
     }
     
     for (GeoTimeSerie gts: series) {
-      List<GeoTimeSerie> res = GTSHelper.map(gts, mapper, prewindow, postwindow, Math.abs(occurrences), occurrences < 0 ? true : false, step, overrideTick, mapper instanceof Macro ? stack : null,
+      List<GeoTimeSerie> res = GTSHelper.map(gts, mapper, prewindow, postwindow, Math.abs(occurrences), occurrences < 0, step, overrideTick, mapper instanceof Macro ? stack : null,
               (List<Long>) outputTicks);
 
       if (res.size() < 2) {


### PR DESCRIPTION
Avoid MAP to silently overflow on `occurrences`.