### PR TITLE
fix #635

### DIFF
--- a/warp10/src/main/java/io/warp10/script/binary/ADD.java
+++ b/warp10/src/main/java/io/warp10/script/binary/ADD.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2020  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.

--- a/warp10/src/main/java/io/warp10/script/binary/ADD.java
+++ b/warp10/src/main/java/io/warp10/script/binary/ADD.java
@@ -101,7 +101,7 @@ public class ADD extends NamedWarpScriptFunction implements WarpScriptStackFunct
         type = TYPE.STRING;
       } else if (TYPE.DOUBLE == gts1.getType() || TYPE.DOUBLE == gts2.getType()) {
         type = TYPE.DOUBLE;
-      } else if (TYPE.LONG == gts1.getType() && TYPE.LONG == gts2.getType()) {
+      } else if (TYPE.LONG == gts1.getType() || TYPE.LONG == gts2.getType()) {
         type = TYPE.LONG;
       }
       
@@ -137,7 +137,9 @@ public class ADD extends NamedWarpScriptFunction implements WarpScriptStackFunct
           };
           break;
         default:
-          throw new WarpScriptException(getName() + " Invalid Geo Time Series™ type.");
+          // both inputs are empty, return an empty gts.
+          stack.push(new GeoTimeSerie());
+          return stack;
       }
 
       GTSOpsHelper.applyBinaryOp(result, gts1, gts2, op);

--- a/warp10/src/main/java/io/warp10/script/binary/ComparisonOperation.java
+++ b/warp10/src/main/java/io/warp10/script/binary/ComparisonOperation.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2019  SenX S.A.S.
+//   Copyright 2020  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.

--- a/warp10/src/main/java/io/warp10/script/binary/ComparisonOperation.java
+++ b/warp10/src/main/java/io/warp10/script/binary/ComparisonOperation.java
@@ -174,7 +174,7 @@ public abstract class ComparisonOperation extends NamedWarpScriptFunction implem
       } else {
         throw new WarpScriptException(getName() + "can only operate on two GTS with NUMBER or STRING values.");
       }
-    } else if (op1 instanceof GeoTimeSerie && GeoTimeSerie.TYPE.UNDEFINED == ((GeoTimeSerie) op1).getType() && (op2 instanceof String || op1 instanceof Number)) {
+    } else if (op1 instanceof GeoTimeSerie && GeoTimeSerie.TYPE.UNDEFINED == ((GeoTimeSerie) op1).getType() && (op2 instanceof String || op2 instanceof Number)) {
       // empty gts compared to a string or a number
       stack.push(((GeoTimeSerie) op1).cloneEmpty());
     } else if (op1 instanceof GeoTimeSerie && op2 instanceof String && GeoTimeSerie.TYPE.STRING == ((GeoTimeSerie) op1).getType()) {

--- a/warp10/src/main/java/io/warp10/script/binary/DIV.java
+++ b/warp10/src/main/java/io/warp10/script/binary/DIV.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2020  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.

--- a/warp10/src/main/java/io/warp10/script/binary/DIV.java
+++ b/warp10/src/main/java/io/warp10/script/binary/DIV.java
@@ -58,7 +58,6 @@ public class DIV extends NamedWarpScriptFunction implements WarpScriptStackFunct
       // Returns immediately a new gts if both inputs are empty
       if (0 == GTSHelper.nvalues(gts1) || 0 == GTSHelper.nvalues(gts2)) {
         GeoTimeSerie result = new GeoTimeSerie();
-        result.setType(TYPE.DOUBLE);
         stack.push(result);
         return stack;
       }
@@ -162,7 +161,6 @@ public class DIV extends NamedWarpScriptFunction implements WarpScriptStackFunct
 
       // Returns immediately a new clone if gts is empty.
       if (0 == n) {
-        result.setType(TYPE.DOUBLE);
         stack.push(result);
         return stack;
       }

--- a/warp10/src/main/java/io/warp10/script/binary/DIV.java
+++ b/warp10/src/main/java/io/warp10/script/binary/DIV.java
@@ -55,6 +55,14 @@ public class DIV extends NamedWarpScriptFunction implements WarpScriptStackFunct
       GeoTimeSerie gts1 = (GeoTimeSerie) op1;
       GeoTimeSerie gts2 = (GeoTimeSerie) op2;
 
+      // Returns immediately a new gts if both inputs are empty
+      if (0 == GTSHelper.nvalues(gts1) || 0 == GTSHelper.nvalues(gts2)) {
+        GeoTimeSerie result = new GeoTimeSerie();
+        result.setType(TYPE.DOUBLE);
+        stack.push(result);
+        return stack;
+      }
+
       if (!(gts1.getType() == TYPE.DOUBLE || gts1.getType() == TYPE.LONG) || !(gts2.getType() == TYPE.DOUBLE || gts2.getType() == TYPE.LONG)) {
         throw new WarpScriptException(typeCheckErrorMsg);
       }
@@ -151,6 +159,13 @@ public class DIV extends NamedWarpScriptFunction implements WarpScriptStackFunct
       
       GeoTimeSerie result = op1gts ? ((GeoTimeSerie) op1).cloneEmpty(n) : ((GeoTimeSerie) op2).cloneEmpty();
       GeoTimeSerie gts = op1gts ? (GeoTimeSerie) op1 : (GeoTimeSerie) op2;
+
+      // Returns immediately a new clone if gts is empty.
+      if (0 == n) {
+        result.setType(TYPE.DOUBLE);
+        stack.push(result);
+        return stack;
+      }
 
       if (!(gts.getType() == TYPE.LONG || gts.getType() == TYPE.DOUBLE)) {
         throw new WarpScriptException(typeCheckErrorMsg);

--- a/warp10/src/main/java/io/warp10/script/binary/MUL.java
+++ b/warp10/src/main/java/io/warp10/script/binary/MUL.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2020  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.

--- a/warp10/src/main/java/io/warp10/script/binary/MUL.java
+++ b/warp10/src/main/java/io/warp10/script/binary/MUL.java
@@ -71,7 +71,6 @@ public class MUL extends NamedWarpScriptFunction implements WarpScriptStackFunct
       // Returns immediately a new gts if both inputs are empty
       if (0 == GTSHelper.nvalues(gts1) || 0 == GTSHelper.nvalues(gts2)) {
         GeoTimeSerie result = new GeoTimeSerie();
-        result.setType(TYPE.DOUBLE);
         stack.push(result);
         return stack;
       }
@@ -171,7 +170,6 @@ public class MUL extends NamedWarpScriptFunction implements WarpScriptStackFunct
 
       // Returns immediately a new clone if gts is empty.
       if (0 == n) {
-        result.setType(TYPE.DOUBLE);
         stack.push(result);
         return stack;
       }

--- a/warp10/src/main/java/io/warp10/script/binary/MUL.java
+++ b/warp10/src/main/java/io/warp10/script/binary/MUL.java
@@ -68,6 +68,14 @@ public class MUL extends NamedWarpScriptFunction implements WarpScriptStackFunct
       GeoTimeSerie gts1 = (GeoTimeSerie) op1;
       GeoTimeSerie gts2 = (GeoTimeSerie) op2;
 
+      // Returns immediately a new gts if both inputs are empty
+      if (0 == GTSHelper.nvalues(gts1) || 0 == GTSHelper.nvalues(gts2)) {
+        GeoTimeSerie result = new GeoTimeSerie();
+        result.setType(TYPE.DOUBLE);
+        stack.push(result);
+        return stack;
+      }
+
       if (!(gts1.getType() == TYPE.DOUBLE || gts1.getType() == TYPE.LONG) || !(gts2.getType() == TYPE.DOUBLE || gts2.getType() == TYPE.LONG)) {
         throw new WarpScriptException(typeCheckErrorMsg);
       }
@@ -160,6 +168,13 @@ public class MUL extends NamedWarpScriptFunction implements WarpScriptStackFunct
       
       GeoTimeSerie result = op1gts ? ((GeoTimeSerie) op1).cloneEmpty(n) : ((GeoTimeSerie) op2).cloneEmpty();
       GeoTimeSerie gts = op1gts ? (GeoTimeSerie) op1 : (GeoTimeSerie) op2;
+
+      // Returns immediately a new clone if gts is empty.
+      if (0 == n) {
+        result.setType(TYPE.DOUBLE);
+        stack.push(result);
+        return stack;
+      }
 
       if (!(gts.getType() == TYPE.LONG || gts.getType() == TYPE.DOUBLE)) {
         throw new WarpScriptException(typeCheckErrorMsg);

--- a/warp10/src/main/java/io/warp10/script/binary/SUB.java
+++ b/warp10/src/main/java/io/warp10/script/binary/SUB.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2020  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.

--- a/warp10/src/main/java/io/warp10/script/binary/SUB.java
+++ b/warp10/src/main/java/io/warp10/script/binary/SUB.java
@@ -61,7 +61,6 @@ public class SUB extends NamedWarpScriptFunction implements WarpScriptStackFunct
       // Returns immediately a new gts if both inputs are empty
       if (0 == GTSHelper.nvalues(gts1) || 0 == GTSHelper.nvalues(gts2)) {
         GeoTimeSerie result = new GeoTimeSerie();
-        result.setType(TYPE.DOUBLE);
         stack.push(result);
         return stack;
       }
@@ -165,7 +164,6 @@ public class SUB extends NamedWarpScriptFunction implements WarpScriptStackFunct
 
       // Returns immediately a new clone if gts is empty.
       if (0 == n) {
-        result.setType(TYPE.DOUBLE);
         stack.push(result);
         return stack;
       }

--- a/warp10/src/main/java/io/warp10/script/binary/SUB.java
+++ b/warp10/src/main/java/io/warp10/script/binary/SUB.java
@@ -58,6 +58,14 @@ public class SUB extends NamedWarpScriptFunction implements WarpScriptStackFunct
       GeoTimeSerie gts1 = (GeoTimeSerie) op1;
       GeoTimeSerie gts2 = (GeoTimeSerie) op2;
 
+      // Returns immediately a new gts if both inputs are empty
+      if (0 == GTSHelper.nvalues(gts1) || 0 == GTSHelper.nvalues(gts2)) {
+        GeoTimeSerie result = new GeoTimeSerie();
+        result.setType(TYPE.DOUBLE);
+        stack.push(result);
+        return stack;
+      }
+
       if (!(gts1.getType() == TYPE.DOUBLE || gts1.getType() == TYPE.LONG) || !(gts2.getType() == TYPE.DOUBLE || gts2.getType() == TYPE.LONG)) {
         throw new WarpScriptException(typeCheckErrorMsg);
       }
@@ -154,6 +162,13 @@ public class SUB extends NamedWarpScriptFunction implements WarpScriptStackFunct
       
       GeoTimeSerie result = op1gts ? ((GeoTimeSerie) op1).cloneEmpty(n) : ((GeoTimeSerie) op2).cloneEmpty();
       GeoTimeSerie gts = op1gts ? (GeoTimeSerie) op1 : (GeoTimeSerie) op2;
+
+      // Returns immediately a new clone if gts is empty.
+      if (0 == n) {
+        result.setType(TYPE.DOUBLE);
+        stack.push(result);
+        return stack;
+      }
 
       if (!(gts.getType() == TYPE.LONG || gts.getType() == TYPE.DOUBLE)) {
         throw new WarpScriptException(typeCheckErrorMsg);


### PR DESCRIPTION
Add more tolerance to empty GTS in all operators.

```
NEWGTS 'foo' RENAME 0.1 *
```
now valid.

```
NEWGTS 'dodo' RENAME 
0 NaN NaN NaN 8 ADDVALUE
NEWGTS 'fuu' RENAME
0 NaN NaN NaN 1 ADDVALUE
[ SWAP 5 mapper.gt 0 0 0 ] MAP 0 GET // non typed gts
*
```
now valid

```
NEWGTS NEWGTS *
```
now valid.

Same for + / - operators.
Also fix a bug in comparison operators, when comparing an empty gts to a number.


