### PR TITLE
Modified validation of GTS list.

### DIFF
--- a/warp10/src/main/java/io/warp10/script/functions/FETCH.java
+++ b/warp10/src/main/java/io/warp10/script/functions/FETCH.java
@@ -276,9 +276,9 @@ public class FETCH extends NamedWarpScriptFunction implements WarpScriptStackFun
         //
         
         if (!matches) {
-          m.getLabels().remove(Constants.PRODUCER_LABEL);
-          m.getLabels().remove(Constants.OWNER_LABEL);
-          m.getLabels().remove(Constants.APPLICATION_LABEL);
+          //
+          // We will now set producer/owner/application
+          //
               
           //
           // If the token doesn't contain a single app we abort the selection as we cannot
@@ -302,15 +302,17 @@ public class FETCH extends NamedWarpScriptFunction implements WarpScriptStackFun
             // If the token has a single producer but no owner, use the producer as the owner, this would
             // lead to a narrower scope than what the token would actually select so it is fine.
             //
-            m.getLabels().put(Constants.PRODUCER_LABEL, tokenSelectors.get(Constants.PRODUCER_LABEL).substring(1));
-            m.getLabels().put(Constants.OWNER_LABEL, m.getLabels().get(Constants.PRODUCER_LABEL));                        
+            String producer = tokenSelectors.get(Constants.PRODUCER_LABEL).substring(1);
+            m.getLabels().put(Constants.PRODUCER_LABEL, producer);
+            m.getLabels().put(Constants.OWNER_LABEL, producer);                        
           } else if (singleOwner && !tokenSelectors.containsKey(Constants.PRODUCER_LABEL)) {
             //
             // If the token has a single owner but no producer, use the owner as the producer, again this would
             // lead to a narrower scope than what the token can actually access so it is fine too.
             //
-            m.getLabels().put(Constants.OWNER_LABEL, tokenSelectors.get(Constants.OWNER_LABEL).substring(1));            
-            m.getLabels().put(Constants.PRODUCER_LABEL, m.getLabels().get(Constants.OWNER_LABEL));            
+            String owner = tokenSelectors.get(Constants.OWNER_LABEL).substring(1);
+            m.getLabels().put(Constants.OWNER_LABEL, owner);            
+            m.getLabels().put(Constants.PRODUCER_LABEL, owner);            
           } else {
             throw new WarpScriptException(getName() + " provided token is incompatible with '" + PARAM_GTS + "' parameter, expecting a single producer and/or single owner.");            
           }

--- a/warp10/src/main/java/io/warp10/script/functions/FETCH.java
+++ b/warp10/src/main/java/io/warp10/script/functions/FETCH.java
@@ -243,6 +243,10 @@ public class FETCH extends NamedWarpScriptFunction implements WarpScriptStackFun
       boolean singleOwner = tokenSelectors.containsKey(Constants.OWNER_LABEL) && '=' == tokenSelectors.get(Constants.OWNER_LABEL).charAt(0);
       boolean singleProducer = tokenSelectors.containsKey(Constants.PRODUCER_LABEL) && '=' == tokenSelectors.get(Constants.PRODUCER_LABEL).charAt(0); 
 
+      String application = singleApp ? tokenSelectors.get(Constants.APPLICATION_LABEL).substring(1) : null;
+      String owner = singleOwner ? tokenSelectors.get(Constants.OWNER_LABEL).substring(1) : null;
+      String producer = singleProducer ? tokenSelectors.get(Constants.PRODUCER_LABEL).substring(1) : null;
+      
       Metadata tmeta = new Metadata();
       tmeta.setName("");
       tmeta.setLabels(tokenSelectors);
@@ -286,7 +290,7 @@ public class FETCH extends NamedWarpScriptFunction implements WarpScriptStackFun
           //
           
           if (singleApp) {
-            m.getLabels().put(Constants.APPLICATION_LABEL, tokenSelectors.get(Constants.APPLICATION_LABEL).substring(1));
+            m.getLabels().put(Constants.APPLICATION_LABEL, application);
           } else {
             throw new WarpScriptException(getName() + " provided token is incompatible with '" + PARAM_GTS + "' parameter, expecting a single application.");
           }
@@ -295,14 +299,13 @@ public class FETCH extends NamedWarpScriptFunction implements WarpScriptStackFun
             //
             // If the token has a single producer and single owner, use them for the GTS
             //
-            m.getLabels().put(Constants.PRODUCER_LABEL, tokenSelectors.get(Constants.PRODUCER_LABEL).substring(1));
-            m.getLabels().put(Constants.OWNER_LABEL, tokenSelectors.get(Constants.OWNER_LABEL).substring(1));            
+            m.getLabels().put(Constants.PRODUCER_LABEL, producer);
+            m.getLabels().put(Constants.OWNER_LABEL, owner);            
           } else if (singleProducer && !tokenSelectors.containsKey(Constants.OWNER_LABEL)) {
             //
             // If the token has a single producer but no owner, use the producer as the owner, this would
             // lead to a narrower scope than what the token would actually select so it is fine.
             //
-            String producer = tokenSelectors.get(Constants.PRODUCER_LABEL).substring(1);
             m.getLabels().put(Constants.PRODUCER_LABEL, producer);
             m.getLabels().put(Constants.OWNER_LABEL, producer);                        
           } else if (singleOwner && !tokenSelectors.containsKey(Constants.PRODUCER_LABEL)) {
@@ -310,7 +313,6 @@ public class FETCH extends NamedWarpScriptFunction implements WarpScriptStackFun
             // If the token has a single owner but no producer, use the owner as the producer, again this would
             // lead to a narrower scope than what the token can actually access so it is fine too.
             //
-            String owner = tokenSelectors.get(Constants.OWNER_LABEL).substring(1);
             m.getLabels().put(Constants.OWNER_LABEL, owner);            
             m.getLabels().put(Constants.PRODUCER_LABEL, owner);            
           } else {

--- a/warp10/src/main/java/io/warp10/script/functions/FETCH.java
+++ b/warp10/src/main/java/io/warp10/script/functions/FETCH.java
@@ -303,13 +303,15 @@ public class FETCH extends NamedWarpScriptFunction implements WarpScriptStackFun
             // If the token has a single producer but no owner, use the producer as the owner, this would
             // lead to a narrower scope than what the token would actually select so it is fine.
             //
-            m.getLabels().put(Constants.OWNER_LABEL, m.getLabels().get(Constants.PRODUCER_LABEL).substring(1));                        
+            m.getLabels().put(Constants.PRODUCER_LABEL, m.getLabels().get(Constants.PRODUCER_LABEL).substring(1));
+            m.getLabels().put(Constants.OWNER_LABEL, m.getLabels().get(Constants.PRODUCER_LABEL));                        
           } else if (singleOwner && !tokenSelectors.containsKey(Constants.PRODUCER_LABEL)) {
             //
             // If the token has a single owner but no producer, use the owner as the producer, again this would
             // lead to a narrower scope than what the token can actually access so it is fine too.
             //
-            m.getLabels().put(Constants.PRODUCER_LABEL, m.getLabels().get(Constants.OWNER_LABEL).substring(1));            
+            m.getLabels().put(Constants.OWNER_LABEL, m.getLabels().get(Constants.OWNER_LABEL).substring(1));            
+            m.getLabels().put(Constants.PRODUCER_LABEL, m.getLabels().get(Constants.OWNER_LABEL));            
           } else {
             throw new WarpScriptException(getName() + " provided token is incompatible with '" + PARAM_GTS + "' parameter, expecting a single producer and/or single owner.");            
           }

--- a/warp10/src/main/java/io/warp10/script/functions/FETCH.java
+++ b/warp10/src/main/java/io/warp10/script/functions/FETCH.java
@@ -279,7 +279,6 @@ public class FETCH extends NamedWarpScriptFunction implements WarpScriptStackFun
           m.getLabels().remove(Constants.PRODUCER_LABEL);
           m.getLabels().remove(Constants.OWNER_LABEL);
           m.getLabels().remove(Constants.APPLICATION_LABEL);
-          m.getLabels().putAll(tokenSelectors);
               
           //
           // If the token doesn't contain a single app we abort the selection as we cannot
@@ -287,7 +286,7 @@ public class FETCH extends NamedWarpScriptFunction implements WarpScriptStackFun
           //
           
           if (singleApp) {
-            m.getLabels().put(Constants.APPLICATION_LABEL, m.getLabels().get(Constants.APPLICATION_LABEL).substring(1));
+            m.getLabels().put(Constants.APPLICATION_LABEL, tokenSelectors.get(Constants.APPLICATION_LABEL).substring(1));
           } else {
             throw new WarpScriptException(getName() + " provided token is incompatible with '" + PARAM_GTS + "' parameter, expecting a single application.");
           }
@@ -296,21 +295,21 @@ public class FETCH extends NamedWarpScriptFunction implements WarpScriptStackFun
             //
             // If the token has a single producer and single owner, use them for the GTS
             //
-            m.getLabels().put(Constants.PRODUCER_LABEL, m.getLabels().get(Constants.PRODUCER_LABEL).substring(1));
-            m.getLabels().put(Constants.OWNER_LABEL, m.getLabels().get(Constants.OWNER_LABEL).substring(1));            
+            m.getLabels().put(Constants.PRODUCER_LABEL, tokenSelectors.get(Constants.PRODUCER_LABEL).substring(1));
+            m.getLabels().put(Constants.OWNER_LABEL, tokenSelectors.get(Constants.OWNER_LABEL).substring(1));            
           } else if (singleProducer && !tokenSelectors.containsKey(Constants.OWNER_LABEL)) {
             //
             // If the token has a single producer but no owner, use the producer as the owner, this would
             // lead to a narrower scope than what the token would actually select so it is fine.
             //
-            m.getLabels().put(Constants.PRODUCER_LABEL, m.getLabels().get(Constants.PRODUCER_LABEL).substring(1));
+            m.getLabels().put(Constants.PRODUCER_LABEL, tokenSelectors.get(Constants.PRODUCER_LABEL).substring(1));
             m.getLabels().put(Constants.OWNER_LABEL, m.getLabels().get(Constants.PRODUCER_LABEL));                        
           } else if (singleOwner && !tokenSelectors.containsKey(Constants.PRODUCER_LABEL)) {
             //
             // If the token has a single owner but no producer, use the owner as the producer, again this would
             // lead to a narrower scope than what the token can actually access so it is fine too.
             //
-            m.getLabels().put(Constants.OWNER_LABEL, m.getLabels().get(Constants.OWNER_LABEL).substring(1));            
+            m.getLabels().put(Constants.OWNER_LABEL, tokenSelectors.get(Constants.OWNER_LABEL).substring(1));            
             m.getLabels().put(Constants.PRODUCER_LABEL, m.getLabels().get(Constants.OWNER_LABEL));            
           } else {
             throw new WarpScriptException(getName() + " provided token is incompatible with '" + PARAM_GTS + "' parameter, expecting a single producer and/or single owner.");            

--- a/warp10/src/main/java/io/warp10/standalone/WarpRepair.java
+++ b/warp10/src/main/java/io/warp10/standalone/WarpRepair.java
@@ -50,8 +50,7 @@ public class WarpRepair {
     } catch (UnsatisfiedLinkError ule) {
       ule.printStackTrace();
       if (!javadisabled) {
-        LevelDBRepair.repair(new File(path));
-        //Iq80DBFactory.factory.repair(new File(path), options);
+        Iq80DBFactory.factory.repair(new File(path), options);
       } else {
         throw new RuntimeException("No usable LevelDB implementation, aborting.");
       }

--- a/warp10/src/main/java/io/warp10/standalone/WarpRepair.java
+++ b/warp10/src/main/java/io/warp10/standalone/WarpRepair.java
@@ -50,7 +50,8 @@ public class WarpRepair {
     } catch (UnsatisfiedLinkError ule) {
       ule.printStackTrace();
       if (!javadisabled) {
-        Iq80DBFactory.factory.repair(new File(path), options);
+        LevelDBRepair.repair(new File(path));
+        //Iq80DBFactory.factory.repair(new File(path), options);
       } else {
         throw new RuntimeException("No usable LevelDB implementation, aborting.");
       }


### PR DESCRIPTION
When using the 'gts' parameter of the FETCH input map, we now perform some more advanced checks to ensure that the provided READ token would actually select the given GTS. We also replace somme labels (namely owner or producer) if absent by a value extracted from the token and which makes the GTS fall within the set of GTS which could be selected with the given token.