### PR TITLE
set log4j properties to fix #694

### DIFF
--- a/etc/log4j.properties
+++ b/etc/log4j.properties
@@ -26,13 +26,26 @@ log4j.logger.org.apache.zookeeper=WARN
 log4j.logger.org.apache.hadoop=WARN
 
 #
-# Loggers
+# Log all the WarpScript execution failures to logs/warpscript.out
 #
+log4j.additivity.warpscript.events = false
+log4j.logger.warpscript.events = INFO, warpscriptLog
 
-log4j.rootLogger=warn, warpLog
+#
+# Log plugin and extension loading messages to stdout (by default, logs/warp10.log)
+#
+log4j.additivity.io.warp10.warp.sdk.AbstractWarp10Plugin = false
+log4j.logger.io.warp10.warp.sdk.AbstractWarp10Plugin = INFO, stdout
+log4j.additivity.io.warp10.script.WarpScriptLib = false
+log4j.logger.io.warp10.script.WarpScriptLib = INFO, stdout
 
-log4j.additivity.io.warp10.continuum=false
-log4j.logger.io.warp10.continuum=INFO, warpLog
+#
+# Also log all other continuum info messages to logs/nohup.out
+#
+log4j.additivity.io.warp10.continuum = false
+log4j.logger.io.warp10.continuum = INFO, warpLog
 
-log4j.additivity.io.warp10.continuum.egress.EgressExecHandler=false
-log4j.logger.io.warp10.continuum.egress.EgressExecHandler=INFO, warpscriptLog
+#
+# Default logger logs warnings to logs/nohup.out
+#
+log4j.rootLogger = WARN, warpLog


### PR DESCRIPTION
- fix  #694 by appending plugin and extension loading messages to stdout. 
- "warpscript.events" logger was created on purpose in egress execution, but was not used as it should be, or may have been. (warpscript.out remains empty)
- fix additivity to avoid double logs.

Didn't touch hadoop and zookeeper parts... 