### PR TITLE
Attribute check for tokens

### DIFF
--- a/etc/conf.templates/distributed/00-warp.conf.template
+++ b/etc/conf.templates/distributed/00-warp.conf.template
@@ -99,6 +99,11 @@ warp.components =
 #warp10.telemetry = 
 
 //
+// Comma separated list of banned token attributes. Token having one of those attributes will be rejected
+//
+#warp.token.banned.attributes =
+
+//
 // Token file
 //
 #warp.token.file =

--- a/etc/conf.templates/standalone/00-warp.conf.template
+++ b/etc/conf.templates/standalone/00-warp.conf.template
@@ -180,6 +180,11 @@ plasma.frontend.websocket.maxmessagesize = 1048576
 #standalone.splits.enable = true
 
 //
+// Comma separated list of banned token attributes. Token having one of those attributes will be rejected
+//
+#warp.token.banned.attributes =
+
+//
 // Token file
 //
 #warp.token.file =

--- a/warp10/src/main/java/io/warp10/continuum/Configuration.java
+++ b/warp10/src/main/java/io/warp10/continuum/Configuration.java
@@ -24,6 +24,11 @@ public class Configuration {
   
   public static final String WARP_COMPONENTS = "warp.components";
 
+  /**
+   * Comma separated list of attributes which will invalidate the tokens they appear in
+   */
+  public static final String WARP_TOKEN_BANNED_ATTRIBUTES = "warp.token.banned.attributes";
+  
   public static final String WARP_TOKEN_FILE = "warp.token.file";
   
   public static final String WARP_HASH_CLASS = "warp.hash.class";

--- a/warp10/src/main/java/io/warp10/continuum/Tokens.java
+++ b/warp10/src/main/java/io/warp10/continuum/Tokens.java
@@ -70,7 +70,7 @@ public class Tokens {
   /**
    * If set, skip attribute checks
    */
-  private static ThreadLocal<Boolean> skipCheckAttributes = new ThreadLocal<Boolean>() {
+  private static final ThreadLocal<Boolean> skipCheckAttributes = new ThreadLocal<Boolean>() {
     protected Boolean initialValue() {
       return Boolean.TRUE;
     }

--- a/warp10/src/main/java/io/warp10/continuum/Tokens.java
+++ b/warp10/src/main/java/io/warp10/continuum/Tokens.java
@@ -326,6 +326,15 @@ public class Tokens {
   private static void checkAttributes(WriteToken wtoken) {
     checkAttributes(wtoken.getAttributes());
   }
+  
+  public static void disableCheckAttributes() {
+    skipCheckAttributes.set(true);
+  }
+  
+  public static void enableCheckAttributes() {
+    skipCheckAttributes.set(false);
+  }
+  
   /**
    * Return a map of selectors from the elements of the ReadToken
    * 

--- a/warp10/src/main/java/io/warp10/continuum/Tokens.java
+++ b/warp10/src/main/java/io/warp10/continuum/Tokens.java
@@ -65,6 +65,31 @@ public class Tokens {
   
   private static List<AuthenticationPlugin> plugins = new ArrayList<>();
   
+  private static final List<String> blockedAttributes;
+  
+  /**
+   * If set, skip attribute checks
+   */
+  private static ThreadLocal<Boolean> skipCheckAttributes = new ThreadLocal<Boolean>() {
+    protected Boolean initialValue() {
+      return Boolean.TRUE;
+    }
+  };
+  
+  static {
+    if (null != WarpConfig.getProperty(Configuration.WARP_TOKEN_BANNED_ATTRIBUTES)) {
+      String[] attr = WarpConfig.getProperty(Configuration.WARP_TOKEN_BANNED_ATTRIBUTES).split(",");
+      
+      blockedAttributes = new ArrayList<String>();
+      
+      for (String a: attr) {
+        blockedAttributes.add(a.trim());
+      }
+    } else {
+      blockedAttributes = null;
+    }
+  }
+  
   private static QuasarTokenFilter getTokenFilter() {
     if (null != tokenFilter) {
       return tokenFilter;
@@ -82,7 +107,7 @@ public class Tokens {
     return tokenFilter;
   }
   
-  public static ReadToken getReadToken(String token) {
+  private static ReadToken getReadToken(String token) {
     
     synchronized (fileTokens) {
       if (fileTokens.containsKey(token) && fileTokens.get(token) instanceof ReadToken) {
@@ -114,6 +139,8 @@ public class Tokens {
     rtoken.setIssuanceTimestamp(0L);
     rtoken.setExpiryTimestamp(Long.MAX_VALUE);
 
+    rtoken.setTokenType(TokenType.READ);
+    
     rtoken.setBilledId(bb.duplicate());
     rtoken.addToOwners(bb.duplicate());
     rtoken.addToProducers(bb.duplicate());
@@ -121,7 +148,7 @@ public class Tokens {
     return rtoken;
   }
   
-  public static WriteToken getWriteToken(String token) {
+  private static WriteToken getWriteToken(String token) {
     
     synchronized (fileTokens) {
       if (fileTokens.containsKey(token) && fileTokens.get(token) instanceof WriteToken) {
@@ -155,7 +182,7 @@ public class Tokens {
     wtoken.setExpiryTimestamp(Long.MAX_VALUE);
     
     wtoken.setTokenType(TokenType.WRITE);
-    
+        
     return wtoken;
   }
   
@@ -213,6 +240,7 @@ public class Tokens {
     WriteToken wtoken = Tokens.getWriteToken(token);
     
     if (null != wtoken) {
+      checkAttributes(wtoken);
       return wtoken;
     }
     
@@ -232,6 +260,8 @@ public class Tokens {
       throw new WarpScriptException("Invalid token.");
     }
     
+    checkAttributes(wtoken);
+    
     return wtoken;
   }
   
@@ -249,6 +279,7 @@ public class Tokens {
     ReadToken rtoken = Tokens.getReadToken(token);
     
     if (null != rtoken) {
+      checkAttributes(rtoken);
       return rtoken;
     }
       
@@ -268,9 +299,33 @@ public class Tokens {
       throw new WarpScriptException("Invalid token.");
     }
     
+    checkAttributes(rtoken);
+    
     return rtoken;
   }
   
+  /**
+   * Perform attribute checks on a token
+   */
+  private static void checkAttributes(Map<String,String> attributes) {
+    if (null == blockedAttributes || blockedAttributes.isEmpty() || skipCheckAttributes.get() || null == attributes || attributes.isEmpty()) {
+      return;
+    }
+    
+    for (String attr: blockedAttributes) {
+      if (attributes.containsKey(attr)) {
+        throw new RuntimeException("Invalid token attribute.");
+      }
+    }
+  }
+  
+  private static void checkAttributes(ReadToken rtoken) {
+    checkAttributes(rtoken.getAttributes());
+  }
+  
+  private static void checkAttributes(WriteToken wtoken) {
+    checkAttributes(wtoken.getAttributes());
+  }
   /**
    * Return a map of selectors from the elements of the ReadToken
    * 


### PR DESCRIPTION
Add the ability to define a list of token attributes which are banned. Any token bearing one of those attributes will be rejected with an error by the standard token parsing code.

The ability to disable those checks is offered so authentication plugins can rely on token extraction even if the token is bearing a banned attribute.