### PR TITLE
fix issue #698, gts ops type consistency

### DIFF
--- a/warp10/src/main/java/io/warp10/script/binary/ADD.java
+++ b/warp10/src/main/java/io/warp10/script/binary/ADD.java
@@ -143,7 +143,11 @@ public class ADD extends NamedWarpScriptFunction implements WarpScriptStackFunct
       }
 
       GTSOpsHelper.applyBinaryOp(result, gts1, gts2, op);
-
+      
+      // Returns an non typed GTS if the result is empty
+      if (0 == result.size()) {
+        result = new GeoTimeSerie();
+      }
       stack.push(result);
     } else if (op1 instanceof GeoTimeSerie || op2 instanceof GeoTimeSerie) {
       TYPE type = TYPE.UNDEFINED;

--- a/warp10/src/main/java/io/warp10/script/binary/ComparisonOperation.java
+++ b/warp10/src/main/java/io/warp10/script/binary/ComparisonOperation.java
@@ -170,6 +170,10 @@ public abstract class ComparisonOperation extends NamedWarpScriptFunction implem
           result.setType(GeoTimeSerie.TYPE.LONG);
           GTSOpsHelper.applyBinaryOp(result, gts1, gts2, longOp, true);
         }
+        // Empty result should not be typed
+        if (0 == result.size()) {
+          result = new GeoTimeSerie();
+        }
         stack.push(result);
       } else {
         throw new WarpScriptException(getName() + "can only operate on two GTS with NUMBER or STRING values.");
@@ -185,6 +189,10 @@ public abstract class ComparisonOperation extends NamedWarpScriptFunction implem
       for (int i = 0; i < GTSHelper.nvalues(gts); i++) {
         GTSHelper.setValue(result, GTSHelper.tickAtIndex(gts, i), GTSHelper.locationAtIndex(gts, i), GTSHelper.elevationAtIndex(gts, i),
             operator((GTSHelper.valueAtIndex(gts, i)).toString().compareTo(op2.toString()), 0) ? GTSHelper.valueAtIndex(gts, i) : null, false);
+      }
+      // Empty result should not be typed
+      if (0 == result.size()) {
+        result = new GeoTimeSerie();
       }
       stack.push(result);
     } else if (op1 instanceof GeoTimeSerie && op2 instanceof Number && GeoTimeSerie.TYPE.DOUBLE == ((GeoTimeSerie) op1).getType()) {
@@ -211,6 +219,10 @@ public abstract class ComparisonOperation extends NamedWarpScriptFunction implem
                 operator(EQ.compare((Number) GTSHelper.valueAtIndex(gts, i), (Number) op2), 0) ? GTSHelper.valueAtIndex(gts, i) : null, false);
           }
         }
+      }        
+      // Empty result should not be typed
+      if (0 == result.size()) {
+        result = new GeoTimeSerie();
       }
       stack.push(result);
     } else if (op1 instanceof GeoTimeSerie && op2 instanceof Number && GeoTimeSerie.TYPE.LONG == ((GeoTimeSerie) op1).getType()) {
@@ -225,6 +237,10 @@ public abstract class ComparisonOperation extends NamedWarpScriptFunction implem
         for (int i = 0; i < GTSHelper.nvalues(gts); i++) {
           GTSHelper.setValue(result, GTSHelper.tickAtIndex(gts, i), GTSHelper.locationAtIndex(gts, i), GTSHelper.elevationAtIndex(gts, i),
               operator(EQ.compare((Number) GTSHelper.valueAtIndex(gts, i), (Number) op2), 0) ? GTSHelper.valueAtIndex(gts, i) : null, false);
+        }
+        // Empty result should not be typed
+        if (0 == result.size()) {
+          result = new GeoTimeSerie();
         }
         stack.push(result);
       }

--- a/warp10/src/main/java/io/warp10/script/binary/CondShortCircuit.java
+++ b/warp10/src/main/java/io/warp10/script/binary/CondShortCircuit.java
@@ -97,6 +97,10 @@ public abstract class CondShortCircuit extends NamedWarpScriptFunction implement
           GeoTimeSerie result = new GeoTimeSerie(Math.max(GTSHelper.nvalues(gts1), GTSHelper.nvalues(gts2)));
           result.setType(GeoTimeSerie.TYPE.BOOLEAN);
           GTSOpsHelper.applyBinaryOp(result, gts1, gts2, this.op);
+          // Empty result should not be typed
+          if (0 == result.size()) {
+            result = new GeoTimeSerie();
+          }
           stack.push(result);
           return stack;
         } else if ((GeoTimeSerie.TYPE.UNDEFINED == gts1.getType() && GeoTimeSerie.TYPE.BOOLEAN == gts2.getType())

--- a/warp10/src/main/java/io/warp10/script/binary/DIV.java
+++ b/warp10/src/main/java/io/warp10/script/binary/DIV.java
@@ -66,9 +66,10 @@ public class DIV extends NamedWarpScriptFunction implements WarpScriptStackFunct
         throw new WarpScriptException(typeCheckErrorMsg);
       }
 
-      // The result will be of type DOUBLE
+      // The result type is LONG if both inputs are LONG.
       GeoTimeSerie result = new GeoTimeSerie(Math.max(GTSHelper.nvalues(gts1), GTSHelper.nvalues(gts2)));
-      
+      result.setType((gts1.getType() == TYPE.LONG && gts2.getType() == TYPE.LONG) ? TYPE.LONG : TYPE.DOUBLE);
+
       if (GTSHelper.isBucketized(gts1) && GTSHelper.isBucketized(gts2)) {
         if (GTSHelper.getBucketSpan(gts1) == GTSHelper.getBucketSpan(gts2)) {
           // Both GTS have the same bucket span, check their lastbucket to see if they have the
@@ -84,7 +85,6 @@ public class DIV extends NamedWarpScriptFunction implements WarpScriptStackFunct
           }
         }
       }
-      result.setType(TYPE.DOUBLE);
       
       // Sort GTS
       GTSHelper.sort(gts1);
@@ -149,7 +149,10 @@ public class DIV extends NamedWarpScriptFunction implements WarpScriptStackFunct
           tsb = GTSHelper.tickAtIndex(gts2, idxb);
         }
       }
-
+      // Returns an non typed GTS if the result is empty
+      if (0 == result.size()) {
+        result = new GeoTimeSerie();
+      }
       stack.push(result);
     } else if ((op1 instanceof GeoTimeSerie && op2 instanceof Number) || (op1 instanceof Number && op2 instanceof GeoTimeSerie)) {
       boolean op1gts = op1 instanceof GeoTimeSerie;
@@ -168,19 +171,31 @@ public class DIV extends NamedWarpScriptFunction implements WarpScriptStackFunct
       if (!(gts.getType() == TYPE.LONG || gts.getType() == TYPE.DOUBLE)) {
         throw new WarpScriptException(typeCheckErrorMsg);
       }
-      
-      double op = op1gts ? ((Number) op2).doubleValue() : ((Number) op1).doubleValue();
-      
-      for (int i = 0; i < n; i++) {
-       double value;
-       if (op1gts) {
-         value = ((Number) GTSHelper.valueAtIndex(gts, i)).doubleValue() / op;
-       } else {
-         value = op / ((Number) GTSHelper.valueAtIndex(gts, i)).doubleValue();
-       }
-       GTSHelper.setValue(result, GTSHelper.tickAtIndex(gts, i), GTSHelper.locationAtIndex(gts, i), GTSHelper.elevationAtIndex(gts, i), value, false);
-      }      
 
+      Number op = op1gts ? (Number) op2 : (Number) op1;
+
+      if (op instanceof Double || gts.getType() == TYPE.DOUBLE) {
+        for (int i = 0; i < n; i++) {
+          double value;
+          if (op1gts) {
+            value = ((Number) GTSHelper.valueAtIndex(gts, i)).doubleValue() / op.doubleValue();
+          } else {
+            value = op.doubleValue() / ((Number) GTSHelper.valueAtIndex(gts, i)).doubleValue();
+          }
+          GTSHelper.setValue(result, GTSHelper.tickAtIndex(gts, i), GTSHelper.locationAtIndex(gts, i), GTSHelper.elevationAtIndex(gts, i), value, false);
+        }
+      } else {
+        result.setType(TYPE.LONG);
+        for (int i = 0; i < n; i++) {
+          double value;
+          if (op1gts) {
+            value = ((Number) GTSHelper.valueAtIndex(gts, i)).longValue() / op.longValue();
+          } else {
+            value = op.longValue() / ((Number) GTSHelper.valueAtIndex(gts, i)).longValue();
+          }
+          GTSHelper.setValue(result, GTSHelper.tickAtIndex(gts, i), GTSHelper.locationAtIndex(gts, i), GTSHelper.elevationAtIndex(gts, i), value, false);
+        }
+      }
       stack.push(result);
     } else {
       throw new WarpScriptException(typeCheckErrorMsg);

--- a/warp10/src/main/java/io/warp10/script/binary/SUB.java
+++ b/warp10/src/main/java/io/warp10/script/binary/SUB.java
@@ -69,8 +69,9 @@ public class SUB extends NamedWarpScriptFunction implements WarpScriptStackFunct
         throw new WarpScriptException(typeCheckErrorMsg);
       }
 
-      // The result will be of type DOUBLE
+      // The result type is LONG if both inputs are LONG.
       GeoTimeSerie result = new GeoTimeSerie(Math.max(GTSHelper.nvalues(gts1), GTSHelper.nvalues(gts2)));
+      result.setType((gts1.getType() == TYPE.LONG && gts2.getType() == TYPE.LONG) ? TYPE.LONG : TYPE.DOUBLE);
       
       if (GTSHelper.isBucketized(gts1) && GTSHelper.isBucketized(gts2)) {
         if (GTSHelper.getBucketSpan(gts1) == GTSHelper.getBucketSpan(gts2)) {
@@ -87,7 +88,6 @@ public class SUB extends NamedWarpScriptFunction implements WarpScriptStackFunct
           }
         }
       }
-      result.setType(TYPE.DOUBLE);
       
       // Sort GTS
       GTSHelper.sort(gts1);
@@ -152,7 +152,10 @@ public class SUB extends NamedWarpScriptFunction implements WarpScriptStackFunct
           tsb = GTSHelper.tickAtIndex(gts2, idxb);
         }
       }
-
+      // Returns an non typed GTS if the result is empty
+      if (0 == result.size()) {
+        result = new GeoTimeSerie();
+      }
       stack.push(result);
     } else if ((op1 instanceof GeoTimeSerie && op2 instanceof Number) || (op1 instanceof Number && op2 instanceof GeoTimeSerie)) {
       boolean op1gts = op1 instanceof GeoTimeSerie;
@@ -171,19 +174,32 @@ public class SUB extends NamedWarpScriptFunction implements WarpScriptStackFunct
       if (!(gts.getType() == TYPE.LONG || gts.getType() == TYPE.DOUBLE)) {
         throw new WarpScriptException(typeCheckErrorMsg);
       }
-      
-      double op = op1gts ? ((Number) op2).doubleValue() : ((Number) op1).doubleValue();
-      
-      for (int i = 0; i < n; i++) {
-       double value;
-       if (op1gts) {
-         value = ((Number) GTSHelper.valueAtIndex(gts, i)).doubleValue() - op;
-       } else {
-         value = op - ((Number) GTSHelper.valueAtIndex(gts, i)).doubleValue();
-       }
-       GTSHelper.setValue(result, GTSHelper.tickAtIndex(gts, i), GTSHelper.locationAtIndex(gts, i), GTSHelper.elevationAtIndex(gts, i), value, false);
-      }      
 
+
+      Number op = op1gts ? (Number) op2 : (Number) op1;
+
+      if (op instanceof Double || gts.getType() == TYPE.DOUBLE) {
+        for (int i = 0; i < n; i++) {
+          double value;
+          if (op1gts) {
+            value = ((Number) GTSHelper.valueAtIndex(gts, i)).doubleValue() - op.doubleValue();
+          } else {
+            value = op.doubleValue() - ((Number) GTSHelper.valueAtIndex(gts, i)).doubleValue();
+          }
+          GTSHelper.setValue(result, GTSHelper.tickAtIndex(gts, i), GTSHelper.locationAtIndex(gts, i), GTSHelper.elevationAtIndex(gts, i), value, false);
+        }
+      } else {
+        result.setType(TYPE.LONG);
+        for (int i = 0; i < n; i++) {
+          double value;
+          if (op1gts) {
+            value = ((Number) GTSHelper.valueAtIndex(gts, i)).longValue() - op.longValue();
+          } else {
+            value = op.longValue() - ((Number) GTSHelper.valueAtIndex(gts, i)).longValue();
+          }
+          GTSHelper.setValue(result, GTSHelper.tickAtIndex(gts, i), GTSHelper.locationAtIndex(gts, i), GTSHelper.elevationAtIndex(gts, i), value, false);
+        }
+      }
       stack.push(result);      
     } else {
       throw new WarpScriptException(typeCheckErrorMsg);


### PR DESCRIPTION
Clean all the weird typing issue.

Tests:

```
NEWGTS 0 0 0 0 3.14 ADDVALUE 'gtsDouble' STORE
NEWGTS 0 0 0 0 42 ADDVALUE 'gtsLong' STORE
NEWGTS 1 0 0 0 42 ADDVALUE 'gtsNotAligned' STORE

<% VALUES 0 GET TYPEOF %> 'tg' STORE
<% 2 0 0 0 "string" ADDVALUE @tg "STRING" == %> 'nottyped' STORE


$gtsDouble $gtsDouble + @tg "DOUBLE" == ASSERT
$gtsDouble $gtsLong + @tg "DOUBLE" == ASSERT
$gtsDouble 2 + @tg "DOUBLE" == ASSERT
$gtsLong $gtsDouble + @tg "DOUBLE" == ASSERT
$gtsDouble $gtsLong + @tg "DOUBLE" == ASSERT
$gtsLong $gtsLong + @tg "LONG" == ASSERT
$gtsLong 2 + @tg "LONG" == ASSERT
$gtsLong 2.0 + @tg "DOUBLE" == ASSERT
2 $gtsLong + @tg "LONG" == ASSERT
2.0 $gtsLong + @tg "DOUBLE" == ASSERT
$gtsLong 2 + @tg "LONG" == ASSERT
$gtsNotAligned $gtsDouble + @nottyped   ASSERT
NEWGTS 0 +   @nottyped   ASSERT
NEWGTS NEWGTS +   @nottyped   ASSERT

$gtsDouble $gtsDouble * @tg "DOUBLE" == ASSERT
$gtsDouble $gtsLong * @tg "DOUBLE" == ASSERT
$gtsDouble 2 * @tg "DOUBLE" == ASSERT
$gtsLong $gtsDouble * @tg "DOUBLE" == ASSERT
$gtsDouble $gtsLong * @tg "DOUBLE" == ASSERT
$gtsLong $gtsLong * @tg "LONG" == ASSERT
$gtsLong 2 * @tg "LONG" == ASSERT
$gtsLong 2.0 * @tg "DOUBLE" == ASSERT
2 $gtsLong * @tg "LONG" == ASSERT
2.0 $gtsLong * @tg "DOUBLE" == ASSERT
$gtsLong 2 * @tg "LONG" == ASSERT
$gtsNotAligned $gtsDouble * @nottyped   ASSERT
NEWGTS 0 *   @nottyped   ASSERT
NEWGTS NEWGTS *   @nottyped   ASSERT

$gtsDouble $gtsDouble / @tg "DOUBLE" == ASSERT
$gtsDouble $gtsLong / @tg "DOUBLE" == ASSERT
$gtsDouble 2 / @tg "DOUBLE" == ASSERT
$gtsLong $gtsDouble / @tg "DOUBLE" == ASSERT
$gtsDouble $gtsLong / @tg "DOUBLE" == ASSERT
$gtsLong $gtsLong / @tg "LONG" == ASSERT
$gtsLong 2 / @tg "LONG" == ASSERT
$gtsLong 2.0 / @tg "DOUBLE" == ASSERT
2 $gtsLong / @tg "LONG" == ASSERT
2.0 $gtsLong / @tg "DOUBLE" == ASSERT
$gtsLong 2 / @tg "LONG" == ASSERT
$gtsNotAligned $gtsDouble / @nottyped   ASSERT
NEWGTS 0 /   @nottyped   ASSERT
NEWGTS NEWGTS /   @nottyped   ASSERT
$gtsLong 4 / VALUES 0 GET 10 == ASSERT
85 $gtsLong / VALUES 0 GET 2 == ASSERT
$gtsLong 4.0 / VALUES 0 GET 10.5 == ASSERT
63.0 $gtsLong / VALUES 0 GET 1.5 == ASSERT

$gtsDouble $gtsDouble - @tg "DOUBLE" == ASSERT
$gtsDouble $gtsLong - @tg "DOUBLE" == ASSERT
$gtsDouble 2 - @tg "DOUBLE" == ASSERT
$gtsLong $gtsDouble - @tg "DOUBLE" == ASSERT
$gtsDouble $gtsLong - @tg "DOUBLE" == ASSERT
$gtsLong $gtsLong - @tg "LONG" == ASSERT
$gtsLong 2 - @tg "LONG" == ASSERT
$gtsLong 2.0 - @tg "DOUBLE" == ASSERT
2 $gtsLong - @tg "LONG" == ASSERT
2.0 $gtsLong - @tg "DOUBLE" == ASSERT
$gtsLong 2 - @tg "LONG" == ASSERT
$gtsNotAligned $gtsDouble - @nottyped   ASSERT
NEWGTS 0 -   @nottyped   ASSERT
NEWGTS NEWGTS -   @nottyped   ASSERT
$gtsLong 2 - VALUES 0 GET 40 == ASSERT
2 $gtsLong - VALUES 0 GET -40 == ASSERT
$gtsLong 4.0 - VALUES 0 GET 38.0 == ASSERT
63.0 $gtsLong - VALUES 0 GET 21.0 == ASSERT


$gtsLong 100 >  @nottyped    ASSERT 
$gtsLong 100.0 >  @nottyped    ASSERT
$gtsLong $gtsNotAligned >  @nottyped    ASSERT

NEWGTS 0 0 0 0 false ADDVALUE
NEWGTS 1 0 0 0 false ADDVALUE
&& @nottyped  ASSERT

```
