### PR TITLE
Set the source and target to Java 8, making this project only support Java 8+.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,8 +60,8 @@ subprojects {
 
     group = 'io.warp10'
 
-    sourceCompatibility = 1.7
-    targetCompatibility = 1.7
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
 
     //map key = archive base name : value a artifact version
     ext {

--- a/warp10/src/main/java/io/warp10/continuum/ingress/Ingress.java
+++ b/warp10/src/main/java/io/warp10/continuum/ingress/Ingress.java
@@ -57,8 +57,6 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.lang3.JavaVersion;
-import org.apache.commons.lang3.SystemUtils;
 import org.apache.hadoop.util.ShutdownHookManager;
 import org.apache.thrift.TDeserializer;
 import org.apache.thrift.TException;
@@ -1522,11 +1520,7 @@ public class Ingress extends AbstractHandler implements Runnable {
           throw new IOException("Both " + Constants.HTTP_PARAM_START + " and " + Constants.HTTP_PARAM_END + " should be defined.");
         }
         if (startstr.contains("T")) {
-          if (SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_1_8)) {
-            start = io.warp10.script.unary.TOTIMESTAMP.parseTimestamp(startstr);
-          } else {
-            start = fmt.parseDateTime(startstr).getMillis() * Constants.TIME_UNITS_PER_MS;
-          }
+          start = io.warp10.script.unary.TOTIMESTAMP.parseTimestamp(startstr);
         } else {
           start = Long.valueOf(startstr);
         }
@@ -1537,11 +1531,7 @@ public class Ingress extends AbstractHandler implements Runnable {
           throw new IOException("Both " + Constants.HTTP_PARAM_START + " and " + Constants.HTTP_PARAM_END + " should be defined.");
         }
         if (endstr.contains("T")) {
-          if (SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_1_8)) {
-            end = io.warp10.script.unary.TOTIMESTAMP.parseTimestamp(endstr);
-          } else {
-            end = fmt.parseDateTime(endstr).getMillis() * Constants.TIME_UNITS_PER_MS;
-          }
+          end = io.warp10.script.unary.TOTIMESTAMP.parseTimestamp(endstr);
         } else {
           end = Long.valueOf(endstr);
         }

--- a/warp10/src/main/java/io/warp10/script/WarpScriptLib.java
+++ b/warp10/src/main/java/io/warp10/script/WarpScriptLib.java
@@ -27,8 +27,6 @@ import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
 
-import org.apache.commons.lang3.JavaVersion;
-import org.apache.commons.lang3.SystemUtils;
 import org.bouncycastle.crypto.digests.MD5Digest;
 import org.bouncycastle.crypto.digests.SHA1Digest;
 import org.bouncycastle.crypto.digests.SHA256Digest;
@@ -1673,13 +1671,8 @@ public class WarpScriptLib {
     addNamedWarpScriptFunction(new REPLACE(REPLACEALL, true));
     addNamedWarpScriptFunction(new REOPTALT(REOPTALT));
     
-    if (SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_1_8)) {
-      addNamedWarpScriptFunction(new TEMPLATE(TEMPLATE));
-      addNamedWarpScriptFunction(new TOTIMESTAMP(TOTIMESTAMP));
-    } else {
-      addNamedWarpScriptFunction(new FAIL(TEMPLATE, "Requires JAVA 1.8+"));
-      addNamedWarpScriptFunction(new FAIL(TOTIMESTAMP, "Requires JAVA 1.8+"));
-    }
+    addNamedWarpScriptFunction(new TEMPLATE(TEMPLATE));
+    addNamedWarpScriptFunction(new TOTIMESTAMP(TOTIMESTAMP));
 
     addNamedWarpScriptFunction(new STRINGFORMAT(STRINGFORMAT));
 

--- a/warp10/src/main/java/io/warp10/script/functions/FETCH.java
+++ b/warp10/src/main/java/io/warp10/script/functions/FETCH.java
@@ -32,8 +32,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.zip.GZIPInputStream;
 
 import org.apache.commons.io.output.ByteArrayOutputStream;
-import org.apache.commons.lang3.JavaVersion;
-import org.apache.commons.lang3.SystemUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.thrift.TDeserializer;
 import org.apache.thrift.TException;
@@ -1246,11 +1244,7 @@ public class FETCH extends NamedWarpScriptFunction implements WarpScriptStackFun
         } catch (NumberFormatException nfe) {
           // Not string representation of a Long, try ISO8601
           try {
-            if (SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_1_8)) {
-              timestamp = io.warp10.script.unary.TOTIMESTAMP.parseTimestamp((String) timestampRepresentation);
-            } else {
-              timestamp = fmt.parseDateTime((String) timestampRepresentation).getMillis() * Constants.TIME_UNITS_PER_MS;
-            }
+            timestamp = io.warp10.script.unary.TOTIMESTAMP.parseTimestamp((String) timestampRepresentation);
           } catch (WarpScriptException | IllegalArgumentException e) {
             // Don't set the cause of the execption because we don't know which of the two (nfs or e) it is.
             throw new WarpScriptException("Invalid format for parameter '" + timestampRepresentationParameterName + "'.");

--- a/warp10/src/main/java/io/warp10/script/functions/NOTAFTER.java
+++ b/warp10/src/main/java/io/warp10/script/functions/NOTAFTER.java
@@ -17,14 +17,11 @@
 package io.warp10.script.functions;
 
 import io.warp10.continuum.TimeSource;
-import io.warp10.continuum.store.Constants;
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptStackFunction;
 import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptStack;
 
-import org.apache.commons.lang3.JavaVersion;
-import org.apache.commons.lang3.SystemUtils;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
 
@@ -45,11 +42,7 @@ public class NOTAFTER extends NamedWarpScriptFunction implements WarpScriptStack
     long instant;
     
     if (top instanceof String) {
-      if (SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_1_8)) {
-        instant = io.warp10.script.unary.TOTIMESTAMP.parseTimestamp(top.toString());
-      } else {
-        instant = fmt.parseDateTime((String) top).getMillis() * Constants.TIME_UNITS_PER_MS;
-      }
+      instant = io.warp10.script.unary.TOTIMESTAMP.parseTimestamp(top.toString());
     } else if (!(top instanceof Long)) {
       throw new WarpScriptException(getName() + " expects a timestamp or ISO8601 datetime string on top of the stack.");
     } else {

--- a/warp10/src/main/java/io/warp10/script/functions/NOTBEFORE.java
+++ b/warp10/src/main/java/io/warp10/script/functions/NOTBEFORE.java
@@ -17,14 +17,11 @@
 package io.warp10.script.functions;
 
 import io.warp10.continuum.TimeSource;
-import io.warp10.continuum.store.Constants;
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptStackFunction;
 import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptStack;
 
-import org.apache.commons.lang3.JavaVersion;
-import org.apache.commons.lang3.SystemUtils;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
 
@@ -45,11 +42,7 @@ public class NOTBEFORE extends NamedWarpScriptFunction implements WarpScriptStac
     long instant;
     
     if (top instanceof String) {
-      if (SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_1_8)) {
-        instant = io.warp10.script.unary.TOTIMESTAMP.parseTimestamp(top.toString());
-      } else {
-        instant = fmt.parseDateTime((String) top).getMillis() * Constants.TIME_UNITS_PER_MS;
-      }
+      instant = io.warp10.script.unary.TOTIMESTAMP.parseTimestamp(top.toString());
     } else if (!(top instanceof Long)) {
       throw new WarpScriptException(getName() + " expects a timestamp or ISO8601 datetime string on top of the stack.");
     } else {

--- a/warp10/src/main/java/io/warp10/script/functions/TIMECLIP.java
+++ b/warp10/src/main/java/io/warp10/script/functions/TIMECLIP.java
@@ -19,12 +19,9 @@ package io.warp10.script.functions;
 import io.warp10.continuum.gts.GTSEncoder;
 import io.warp10.continuum.gts.GTSHelper;
 import io.warp10.continuum.gts.GeoTimeSerie;
-import io.warp10.continuum.store.Constants;
 import io.warp10.script.ElementOrListStackFunction;
 import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptStack;
-import org.apache.commons.lang3.JavaVersion;
-import org.apache.commons.lang3.SystemUtils;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
 
@@ -49,11 +46,7 @@ public class TIMECLIP extends ElementOrListStackFunction {
 
     if (top instanceof String) {
       iso8601 = true;
-      if (SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_1_8)) {
-        start = io.warp10.script.unary.TOTIMESTAMP.parseTimestamp(top.toString());
-      } else {
-        start = fmt.parseDateTime(top.toString()).getMillis() * Constants.TIME_UNITS_PER_MS;
-      }
+      start = io.warp10.script.unary.TOTIMESTAMP.parseTimestamp(top.toString());
     } else if (!(top instanceof Long)) {
       throw new WarpScriptException(getName() + " expects either an ISO8601 timestamp as the origin timestamp or a duration.");
     } else {
@@ -65,11 +58,7 @@ public class TIMECLIP extends ElementOrListStackFunction {
     top = stack.pop();
 
     if (top instanceof String) {
-      if (SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_1_8)) {
-        end = io.warp10.script.unary.TOTIMESTAMP.parseTimestamp(top.toString());
-      } else {
-        end = fmt.parseDateTime(top.toString()).getMillis() * Constants.TIME_UNITS_PER_MS;
-      }
+      end = io.warp10.script.unary.TOTIMESTAMP.parseTimestamp(top.toString());
     } else if (!(top instanceof Long)) {
       throw new WarpScriptException(getName() + " expects either an ISO8601 timestamp or a delta since Unix Epoch as 'now' parameter.");
     } else {

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneDeleteHandler.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneDeleteHandler.java
@@ -36,8 +36,6 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.lang3.JavaVersion;
-import org.apache.commons.lang3.SystemUtils;
 import org.apache.thrift.TDeserializer;
 import org.apache.thrift.TException;
 import org.apache.thrift.TSerializer;
@@ -435,11 +433,7 @@ public class StandaloneDeleteHandler extends AbstractHandler {
           return;
         }
         if (startstr.contains("T")) {
-          if (SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_1_8)) {
-            start = io.warp10.script.unary.TOTIMESTAMP.parseTimestamp(startstr);
-          } else {
-            start = fmt.parseDateTime(startstr).getMillis() * Constants.TIME_UNITS_PER_MS;
-          }
+          start = io.warp10.script.unary.TOTIMESTAMP.parseTimestamp(startstr);
         } else {
           start = Long.valueOf(startstr);
         }
@@ -451,11 +445,7 @@ public class StandaloneDeleteHandler extends AbstractHandler {
           return;
         }
         if (endstr.contains("T")) {
-          if (SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_1_8)) {
-            end = io.warp10.script.unary.TOTIMESTAMP.parseTimestamp(endstr);
-          } else {
-            end = fmt.parseDateTime(endstr).getMillis() * Constants.TIME_UNITS_PER_MS;
-          }
+          end = io.warp10.script.unary.TOTIMESTAMP.parseTimestamp(endstr);
         } else {
           end = Long.valueOf(endstr);
         }


### PR DESCRIPTION
This is to reflect the fact that already a lot of code is only compatible with Java 8+, mainly because of ` Math.*Exact()` and `Files.walk()`.