### PR TITLE
Avoid a copy when building List from stack

### DIFF
--- a/warp10/src/main/java/io/warp10/WrapperList.java
+++ b/warp10/src/main/java/io/warp10/WrapperList.java
@@ -1,0 +1,166 @@
+//
+//   Copyright 2020  SenX S.A.S.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+package io.warp10;
+
+import java.util.AbstractList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Spliterator;
+import java.util.Spliterators;
+
+/**
+ * A wrapper for an Object array to expose AbstractList methods.
+ * The only difference with the class returned by Arrays.asList is that the toArray method does NOT return a clone
+ * of the array, but the array itself.
+ * This makes it possible to avoid an array copy when converting an Object[] to an ArrayList for instance:
+ * // Create an Object array
+ * Object[] anArray = ...
+ * // The listNoCopy will directly use the anArray array (until it needs to reallocate a new one)
+ * ArrayList<Object> listNoCopy = new ArrayList<Object>(new ListWrapper(anArray));
+ * // The listWithCopy will use a clone of the anArray array
+ * ArrayList<Object> listWithCopy = new ArrayList<Object>(Arrays.asList(anArray));
+ */
+public class WrapperList extends AbstractList<Object> {
+
+  public static class ArrayItr implements Iterator<Object> {
+    private int cursor;
+    private final Object[] a;
+
+    ArrayItr(Object[] a) {
+      this.a = a;
+    }
+
+    @Override
+    public boolean hasNext() {
+      return cursor < a.length;
+    }
+
+    @Override
+    public Object next() {
+      int i = cursor;
+      if (i >= a.length) {
+        throw new NoSuchElementException();
+      }
+      cursor = i + 1;
+      return a[i];
+    }
+  }
+
+  /**
+   * The array to be wrapped.
+   */
+  private final Object[] array;
+
+  public WrapperList(Object[] array) {
+    if (null == array) {
+      throw new IllegalArgumentException("The wrapped array cannot be null");
+    }
+
+    this.array = array;
+  }
+
+  @Override
+  public int size() {
+    return array.length;
+  }
+
+  /**
+   * Returns the wrapped array.
+   *
+   * @return The wrapped array, this is NOT a copy!
+   */
+  @Override
+  public Object[] toArray() {
+    return array;
+  }
+
+  /**
+   * @param a
+   * @return a copy of the wrapped array, in the given array if it is big enough, else in a new one.
+   */
+  @Override
+  public <T> T[] toArray(T[] a) {
+    int size = size();
+    if (a.length < size) {
+      return Arrays.copyOf(array, size, (Class<? extends T[]>) a.getClass());
+    }
+    System.arraycopy(array, 0, a, 0, size);
+    if (a.length > size) {
+      a[size] = null;
+    }
+    return a;
+  }
+
+  @Override
+  public Object get(int index) {
+    return array[index];
+  }
+
+  @Override
+  public Object set(int index, Object element) {
+    Object oldValue = array[index];
+    array[index] = element;
+    return oldValue;
+  }
+
+  @Override
+  public int indexOf(Object o) {
+    Object[] a = array;
+    if (o == null) {
+      for (int i = 0; i < a.length; i++) {
+        if (a[i] == null) {
+          return i;
+        }
+      }
+    } else {
+      for (int i = 0; i < a.length; i++) {
+        if (o.equals(a[i])) {
+          return i;
+        }
+      }
+    }
+    return -1;
+  }
+
+  @Override
+  public boolean contains(Object o) {
+    return indexOf(o) >= 0;
+  }
+
+  @Override
+  public Spliterator<Object> spliterator() {
+    return Spliterators.spliterator(array, Spliterator.ORDERED);
+  }
+
+  @Override
+  public Iterator<Object> iterator() {
+    return new ArrayItr(array);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    } else if (!(o instanceof WrapperList)) {
+      return false;
+    } else {
+      return ((WrapperList) o).array == this.array;
+    }
+  }
+}

--- a/warp10/src/main/java/io/warp10/script/MemoryWarpScriptStack.java
+++ b/warp10/src/main/java/io/warp10/script/MemoryWarpScriptStack.java
@@ -24,8 +24,10 @@ import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.EmptyStackException;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -355,23 +357,22 @@ public class MemoryWarpScriptStack implements WarpScriptStack, Progressable {
   @Override
   public Object[] popn() throws EmptyStackException, IndexOutOfBoundsException {
     int n = getn();
-    
+
+    return popn(n);
+  }
+
+  @Override
+  public Object[] popn(int n) throws EmptyStackException, IndexOutOfBoundsException {
     if (size < n || n < 0) {
       throw new IndexOutOfBoundsException("Index out of bound.");
     }
-    
+
     Object[] objects = new Object[n];
 
-    //
-    // Remove objects from the end of the stack so the call to remove is blazing
-    // fast.
-    //
-    
-    for (int i = n - 1; i >= 0; i--) {
-      objects[i] = elements[size - 1];
-      size--;
-    }
-    
+    System.arraycopy(elements, size - n, objects, 0, n);
+
+    size -= n;
+
     return objects;
   }
   

--- a/warp10/src/main/java/io/warp10/script/WarpScriptStack.java
+++ b/warp10/src/main/java/io/warp10/script/WarpScriptStack.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2020  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import io.warp10.warp.sdk.WarpScriptJavaFunction;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
@@ -478,23 +479,38 @@ public interface WarpScriptStack {
    * @throws InformativeEmptyStackException if the stack is empty.
    */
   public Object pop() throws InformativeEmptyStackException;
-  
+
   /**
    * Remove and return 'N' objects from the top of the
    * stack.
-   * 
+   *
    * 'N' is consumed at the top of the stack prior to
    * removing and returning the objects.
-   * 
-   * 
+   *
+   *
    * @return An array of 'N' objects, the first being the deepest.
-   *  
+   *
    * @throws InformativeEmptyStackException if the stack is empty.
    * @throws IndexOutOfBoundsException If 'N' is not present or if
    *         'N' is invalid or if the stack is not deep enough.
    */
   public Object[] popn() throws WarpScriptException;
-  
+
+  /**
+   * Remove and return 'N' objects from the top of the
+   * stack.
+   *
+   * 'N' is NOT taken from the stack but given as parameter.
+   *
+   *
+   * @return An array of 'N' objects, the first being the deepest.
+   *
+   * @throws InformativeEmptyStackException if the stack is empty.
+   * @throws IndexOutOfBoundsException If 'N' is invalid or if
+   *          the stack is not deep enough.
+   */
+  public Object[] popn(int n) throws WarpScriptException;
+
   /**
    * Return the object on top of the stack without removing
    * it from the stack.

--- a/warp10/src/main/java/io/warp10/script/functions/STACKTOLIST.java
+++ b/warp10/src/main/java/io/warp10/script/functions/STACKTOLIST.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2020  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -16,26 +16,28 @@
 
 package io.warp10.script.functions;
 
+import io.warp10.WrapperList;
 import io.warp10.script.NamedWarpScriptFunction;
-import io.warp10.script.WarpScriptStackFunction;
 import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptStack;
+import io.warp10.script.WarpScriptStackFunction;
+
+import java.util.ArrayList;
 
 /**
  * Convert the whole stack into a list and push this list on the top of the stack.
  */
 public class STACKTOLIST extends NamedWarpScriptFunction implements WarpScriptStackFunction {
-  
-  private static final TOLIST tl = new TOLIST("");
-  
+
   public STACKTOLIST(String name) {
     super(name);
   }
-  
+
   @Override
   public Object apply(WarpScriptStack stack) throws WarpScriptException {
-    stack.push(stack.depth());
-    tl.apply(stack);
+    Object[] elements = stack.popn(stack.depth());
+    ArrayList<Object> list = new ArrayList<Object>(new WrapperList(elements));
+    stack.push(list);
     return stack;
   }
 }

--- a/warp10/src/main/java/io/warp10/script/functions/TOLIST.java
+++ b/warp10/src/main/java/io/warp10/script/functions/TOLIST.java
@@ -16,35 +16,33 @@
 
 package io.warp10.script.functions;
 
+import io.warp10.WrapperList;
 import io.warp10.script.NamedWarpScriptFunction;
-import io.warp10.script.WarpScriptStackFunction;
 import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptStack;
+import io.warp10.script.WarpScriptStackFunction;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * Make a list with 'N' elements present in the stack.
  * Replace those 'N' elements and 'N' with the list.
- * 
+ *
  * @param element1 First element of the resulting list
  * @param element2
  * @param elementN Last element of the resulting list
- * @param N Number of elements to add to the list
+ * @param N        Number of elements to add to the list
  */
 public class TOLIST extends NamedWarpScriptFunction implements WarpScriptStackFunction {
-  
+
   public TOLIST(String name) {
     super(name);
   }
-  
+
   @Override
   public Object apply(WarpScriptStack stack) throws WarpScriptException {
     Object[] elements = stack.popn();
-    List<Object> list = new ArrayList<Object>();
-    list.addAll(Arrays.asList(elements));
+    ArrayList<Object> list = new ArrayList<Object>(new WrapperList(elements));
     stack.push(list);
     return stack;
   }

--- a/warpscript/build.gradle
+++ b/warpscript/build.gradle
@@ -46,6 +46,7 @@ jar {
     include 'io/warp10/WarpURLDecoder.class'
     include 'io/warp10/DoubleUtils.class'
     include 'io/warp10/FloatUtils.class'
+    include 'io/warp10/ListWrapper.class'
     include 'io/warp10/Revision.class'
     include 'io/warp10/ThrowableUtils.class'
     include 'io/warp10/continuum/AuthenticationPlugin.class'


### PR DESCRIPTION
When `Stack.popn()` is called, it copies the requested elements in the stack array in a new array. In `TOLIST`, this new array is wrapped in a `List` using `Arrays.asList`, which does not copy the data. However when using either `addAll` or the `ArrayList` constructor, it calls `toArray()` on the wrapped array which does a `clone`. 

This PR avoids this last unneeded copy by assigning directly the array produced by `popn()` to the internal array of the `ArrayList`. It also uses `System.arraycopy` which is much faster.

Perf gains expressed as % of time taken for a `->LIST` using the PR code wrt the pre-PR code ie _100 * time_pr / time_pre_pr_.
| Number of elements  | % time taken |
| ------------- | ------------- |
| 1 | 60%  |
| 10  | 65%  |
| 100 | 45%  |
| 1000  | 14%  |
| 10000 | 11%  |
| 10000 | 10%  |

This PR makes `STACKTOLIST` work on a stack which has reached the depth limit.