### PR TITLE
Factorize mappers using DateTime and fail for invalid TimeZone or offset.

### DIFF
--- a/warp10/src/main/java/io/warp10/script/mapper/MapperDateTime.java
+++ b/warp10/src/main/java/io/warp10/script/mapper/MapperDateTime.java
@@ -1,0 +1,67 @@
+//
+//   Copyright 2020  SenX S.A.S.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+package io.warp10.script.mapper;
+
+import io.warp10.continuum.store.Constants;
+import io.warp10.script.NamedWarpScriptFunction;
+import io.warp10.script.StackUtils;
+import io.warp10.script.WarpScriptAggregatorFunction;
+import io.warp10.script.WarpScriptException;
+import io.warp10.script.WarpScriptMapperFunction;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+
+public abstract class MapperDateTime extends NamedWarpScriptFunction implements WarpScriptMapperFunction, WarpScriptAggregatorFunction {
+
+  private final DateTimeZone dtz;
+
+  public MapperDateTime(String name, Object timezone) throws WarpScriptException {
+    super(name);
+    if (timezone instanceof String) {
+      this.dtz = DateTimeZone.forID(timezone.toString());
+    } else if (timezone instanceof Number) {
+      this.dtz = DateTimeZone.forOffsetMillis(((Number) timezone).intValue());
+    } else {
+      throw new WarpScriptException(getName() + " expects a STRING timezone or a NUMBER millisecond offset.");
+    }
+  }
+
+  @Override
+  public Object apply(Object[] args) throws WarpScriptException {
+    long tick = (long) args[0];
+    long[] locations = (long[]) args[4];
+    long[] elevations = (long[]) args[5];
+
+    long location = locations[0];
+    long elevation = elevations[0];
+
+    DateTime dt = new DateTime(tick / Constants.TIME_UNITS_PER_MS, this.dtz);
+
+    return new Object[] {tick, location, elevation, getDateTimeInfo(dt)};
+  }
+
+  public abstract int getDateTimeInfo(DateTime dt);
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(StackUtils.toString(this.dtz.getID()));
+    sb.append(" ");
+    sb.append(this.getName());
+    return sb.toString();
+  }
+}

--- a/warp10/src/main/java/io/warp10/script/mapper/MapperDayOfMonth.java
+++ b/warp10/src/main/java/io/warp10/script/mapper/MapperDayOfMonth.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2020  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -16,23 +16,17 @@
 
 package io.warp10.script.mapper;
 
-import io.warp10.continuum.store.Constants;
 import io.warp10.script.NamedWarpScriptFunction;
-import io.warp10.script.StackUtils;
-import io.warp10.script.WarpScriptAggregatorFunction;
-import io.warp10.script.WarpScriptMapperFunction;
-import io.warp10.script.WarpScriptStackFunction;
 import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptStack;
-
+import io.warp10.script.WarpScriptStackFunction;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 
 /**
  * Mapper which returns the day of the tick for which it
  * is computed.
  */
-public class MapperDayOfMonth extends NamedWarpScriptFunction implements WarpScriptMapperFunction, WarpScriptAggregatorFunction {
+public class MapperDayOfMonth extends MapperDateTime {
   
   public static class Builder extends NamedWarpScriptFunction implements WarpScriptStackFunction {
     
@@ -48,48 +42,12 @@ public class MapperDayOfMonth extends NamedWarpScriptFunction implements WarpScr
     }
   }
 
-  private final DateTimeZone dtz;
-  
-  /**
-   * Default constructor, the timezone will be UTC
-   */
-  public MapperDayOfMonth(String name) {
-    super (name);
-    this.dtz = DateTimeZone.UTC; 
+  public MapperDayOfMonth(String name, Object timezone) throws WarpScriptException {
+    super(name, timezone);
   }
-  
-  public MapperDayOfMonth(String name, Object timezone) {
-    super(name);
-    
-    if (timezone instanceof String) {
-      this.dtz = DateTimeZone.forID(timezone.toString());
-    } else if (timezone instanceof Number) {
-      this.dtz = DateTimeZone.forOffsetMillis(((Number) timezone).intValue());
-    } else {
-      this.dtz = DateTimeZone.UTC;
-    }
-  }
-  
-  @Override
-  public Object apply(Object[] args) throws WarpScriptException {
-    long tick = (long) args[0];
-    long[] locations = (long[]) args[4];
-    long[] elevations = (long[]) args[5];
 
-    long location = locations[0];
-    long elevation = elevations[0];
-
-    DateTime dt = new DateTime(tick / Constants.TIME_UNITS_PER_MS, this.dtz);
-        
-    return new Object[] { tick, location, elevation, dt.getDayOfMonth() };
-  }
-  
   @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append(StackUtils.toString(this.dtz.getID()));
-    sb.append(" ");
-    sb.append(this.getName());
-    return sb.toString();
-  }  
+  public int getDateTimeInfo(DateTime dt) {
+    return dt.getDayOfMonth();
+  }
 }

--- a/warp10/src/main/java/io/warp10/script/mapper/MapperDayOfWeek.java
+++ b/warp10/src/main/java/io/warp10/script/mapper/MapperDayOfWeek.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2020  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -16,23 +16,17 @@
 
 package io.warp10.script.mapper;
 
-import io.warp10.continuum.store.Constants;
 import io.warp10.script.NamedWarpScriptFunction;
-import io.warp10.script.StackUtils;
-import io.warp10.script.WarpScriptAggregatorFunction;
-import io.warp10.script.WarpScriptMapperFunction;
-import io.warp10.script.WarpScriptStackFunction;
 import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptStack;
-
+import io.warp10.script.WarpScriptStackFunction;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 
 /**
  * Mapper which returns the day of the week of the tick for which it
  * is computed.
  */
-public class MapperDayOfWeek extends NamedWarpScriptFunction implements WarpScriptMapperFunction, WarpScriptAggregatorFunction {
+public class MapperDayOfWeek extends MapperDateTime {
   
   public static class Builder extends NamedWarpScriptFunction implements WarpScriptStackFunction {
     
@@ -48,47 +42,12 @@ public class MapperDayOfWeek extends NamedWarpScriptFunction implements WarpScri
     }
   }
 
-  private final DateTimeZone dtz;
-  
-  /**
-   * Default constructor, the timezone will be UTC
-   */
-  public MapperDayOfWeek(String name) {
-    super(name);
-    this.dtz = DateTimeZone.UTC; 
+  public MapperDayOfWeek(String name, Object timezone) throws WarpScriptException {
+    super(name, timezone);
   }
-  
-  public MapperDayOfWeek(String name, Object timezone) {
-    super(name);
-    if (timezone instanceof String) {
-      this.dtz = DateTimeZone.forID(timezone.toString());
-    } else if (timezone instanceof Number) {
-      this.dtz = DateTimeZone.forOffsetMillis(((Number) timezone).intValue());
-    } else {
-      this.dtz = DateTimeZone.UTC;
-    }
-  }
-  
-  @Override
-  public Object apply(Object[] args) throws WarpScriptException {
-    long tick = (long) args[0];
-    long[] locations = (long[]) args[4];
-    long[] elevations = (long[]) args[5];
 
-    long location = locations[0];
-    long elevation = elevations[0];
-
-    DateTime dt = new DateTime(tick / Constants.TIME_UNITS_PER_MS, this.dtz);
-        
-    return new Object[] { tick, location, elevation, dt.getDayOfWeek() };
-  }
-  
   @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append(StackUtils.toString(this.dtz.getID()));
-    sb.append(" ");
-    sb.append(this.getName());
-    return sb.toString();
+  public int getDateTimeInfo(DateTime dt) {
+    return dt.getDayOfWeek();
   }
 }

--- a/warp10/src/main/java/io/warp10/script/mapper/MapperHourOfDay.java
+++ b/warp10/src/main/java/io/warp10/script/mapper/MapperHourOfDay.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2020  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -16,24 +16,18 @@
 
 package io.warp10.script.mapper;
 
-import io.warp10.continuum.store.Constants;
 import io.warp10.script.NamedWarpScriptFunction;
-import io.warp10.script.StackUtils;
-import io.warp10.script.WarpScriptAggregatorFunction;
-import io.warp10.script.WarpScriptMapperFunction;
-import io.warp10.script.WarpScriptStackFunction;
 import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptStack;
-
+import io.warp10.script.WarpScriptStackFunction;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 
 /**
  * Mapper which returns the hour of the tick for which it
  * is computed.
  */
-public class MapperHourOfDay extends NamedWarpScriptFunction implements WarpScriptMapperFunction, WarpScriptAggregatorFunction {
-  
+public class MapperHourOfDay extends MapperDateTime {
+
   public static class Builder extends NamedWarpScriptFunction implements WarpScriptStackFunction {
     
     public Builder(String name) {
@@ -48,47 +42,12 @@ public class MapperHourOfDay extends NamedWarpScriptFunction implements WarpScri
     }
   }
 
-  private final DateTimeZone dtz;
-  
-  /**
-   * Default constructor, the timezone will be UTC
-   */
-  public MapperHourOfDay(String name) {
-    super(name);
-    this.dtz = DateTimeZone.UTC; 
+  public MapperHourOfDay(String name, Object timezone) throws WarpScriptException {
+    super(name, timezone);
   }
-  
-  public MapperHourOfDay(String name, Object timezone) {
-    super(name);
-    if (timezone instanceof String) {
-      this.dtz = DateTimeZone.forID(timezone.toString());
-    } else if (timezone instanceof Number) {
-      this.dtz = DateTimeZone.forOffsetMillis(((Number) timezone).intValue());
-    } else {
-      this.dtz = DateTimeZone.UTC;
-    }
-  }
-  
-  @Override
-  public Object apply(Object[] args) throws WarpScriptException {
-    long tick = (long) args[0];
-    long[] locations = (long[]) args[4];
-    long[] elevations = (long[]) args[5];
 
-    long location = locations[0];
-    long elevation = elevations[0];
-
-    DateTime dt = new DateTime(tick / Constants.TIME_UNITS_PER_MS, this.dtz);
-        
-    return new Object[] { tick, location, elevation, dt.getHourOfDay() };
-  }
-  
   @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append(StackUtils.toString(this.dtz.getID()));
-    sb.append(" ");
-    sb.append(this.getName());
-    return sb.toString();
+  public int getDateTimeInfo(DateTime dt) {
+    return dt.getHourOfDay();
   }
 }

--- a/warp10/src/main/java/io/warp10/script/mapper/MapperMinuteOfHour.java
+++ b/warp10/src/main/java/io/warp10/script/mapper/MapperMinuteOfHour.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2020  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -16,23 +16,17 @@
 
 package io.warp10.script.mapper;
 
-import io.warp10.continuum.store.Constants;
 import io.warp10.script.NamedWarpScriptFunction;
-import io.warp10.script.StackUtils;
-import io.warp10.script.WarpScriptAggregatorFunction;
-import io.warp10.script.WarpScriptMapperFunction;
-import io.warp10.script.WarpScriptStackFunction;
 import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptStack;
-
+import io.warp10.script.WarpScriptStackFunction;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 
 /**
  * Mapper which returns the minute of the tick for which it
  * is computed.
  */
-public class MapperMinuteOfHour extends NamedWarpScriptFunction implements WarpScriptMapperFunction, WarpScriptAggregatorFunction {
+public class MapperMinuteOfHour extends MapperDateTime {
   
   public static class Builder extends NamedWarpScriptFunction implements WarpScriptStackFunction {
     
@@ -48,47 +42,12 @@ public class MapperMinuteOfHour extends NamedWarpScriptFunction implements WarpS
     }
   }
 
-  private final DateTimeZone dtz;
-  
-  /**
-   * Default constructor, the timezone will be UTC
-   */
-  public MapperMinuteOfHour(String name) {
-    super(name);
-    this.dtz = DateTimeZone.UTC; 
+  public MapperMinuteOfHour(String name, Object timezone) throws WarpScriptException {
+    super(name, timezone);
   }
-  
-  public MapperMinuteOfHour(String name, Object timezone) {
-    super(name);
-    if (timezone instanceof String) {
-      this.dtz = DateTimeZone.forID(timezone.toString());
-    } else if (timezone instanceof Number) {
-      this.dtz = DateTimeZone.forOffsetMillis(((Number) timezone).intValue());
-    } else {
-      this.dtz = DateTimeZone.UTC;
-    }
-  }
-  
-  @Override
-  public Object apply(Object[] args) throws WarpScriptException {
-    long tick = (long) args[0];
-    long[] locations = (long[]) args[4];
-    long[] elevations = (long[]) args[5];
 
-    long location = locations[0];
-    long elevation = elevations[0];
-
-    DateTime dt = new DateTime(tick / Constants.TIME_UNITS_PER_MS, this.dtz);
-        
-    return new Object[] { tick, location, elevation, dt.getMinuteOfHour() };
-  }
-  
   @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append(StackUtils.toString(this.dtz.getID()));
-    sb.append(" ");
-    sb.append(this.getName());
-    return sb.toString();
+  public int getDateTimeInfo(DateTime dt) {
+    return dt.getMinuteOfHour();
   }
 }

--- a/warp10/src/main/java/io/warp10/script/mapper/MapperMonthOfYear.java
+++ b/warp10/src/main/java/io/warp10/script/mapper/MapperMonthOfYear.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2020  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -16,23 +16,17 @@
 
 package io.warp10.script.mapper;
 
-import io.warp10.continuum.store.Constants;
 import io.warp10.script.NamedWarpScriptFunction;
-import io.warp10.script.StackUtils;
-import io.warp10.script.WarpScriptAggregatorFunction;
-import io.warp10.script.WarpScriptMapperFunction;
-import io.warp10.script.WarpScriptStackFunction;
 import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptStack;
-
+import io.warp10.script.WarpScriptStackFunction;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 
 /**
  * Mapper which returns the month of the tick for which it
  * is computed.
  */
-public class MapperMonthOfYear extends NamedWarpScriptFunction implements WarpScriptMapperFunction, WarpScriptAggregatorFunction {
+public class MapperMonthOfYear extends MapperDateTime {
   
   public static class Builder extends NamedWarpScriptFunction implements WarpScriptStackFunction {
     
@@ -48,47 +42,12 @@ public class MapperMonthOfYear extends NamedWarpScriptFunction implements WarpSc
     }
   }
 
-  private final DateTimeZone dtz;
-  
-  /**
-   * Default constructor, the timezone will be UTC
-   */
-  public MapperMonthOfYear(String name) {
-    super(name);
-    this.dtz = DateTimeZone.UTC; 
+  public MapperMonthOfYear(String name, Object timezone) throws WarpScriptException {
+    super(name, timezone);
   }
-  
-  public MapperMonthOfYear(String name, Object timezone) {
-    super(name);
-    if (timezone instanceof String) {
-      this.dtz = DateTimeZone.forID(timezone.toString());
-    } else if (timezone instanceof Number) {
-      this.dtz = DateTimeZone.forOffsetMillis(((Number) timezone).intValue());
-    } else {
-      this.dtz = DateTimeZone.UTC;
-    }
-  }
-  
-  @Override
-  public Object apply(Object[] args) throws WarpScriptException {
-    long tick = (long) args[0];
-    long[] locations = (long[]) args[4];
-    long[] elevations = (long[]) args[5];
 
-    long location = locations[0];
-    long elevation = elevations[0];
-
-    DateTime dt = new DateTime(tick / Constants.TIME_UNITS_PER_MS, this.dtz);
-        
-    return new Object[] { tick, location, elevation, dt.getMonthOfYear() };
-  }
-  
   @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append(StackUtils.toString(this.dtz.getID()));
-    sb.append(" ");
-    sb.append(this.getName());
-    return sb.toString();
+  public int getDateTimeInfo(DateTime dt) {
+    return dt.getMonthOfYear();
   }
 }

--- a/warp10/src/main/java/io/warp10/script/mapper/MapperSecondOfMinute.java
+++ b/warp10/src/main/java/io/warp10/script/mapper/MapperSecondOfMinute.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2020  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -16,23 +16,17 @@
 
 package io.warp10.script.mapper;
 
-import io.warp10.continuum.store.Constants;
 import io.warp10.script.NamedWarpScriptFunction;
-import io.warp10.script.StackUtils;
-import io.warp10.script.WarpScriptAggregatorFunction;
-import io.warp10.script.WarpScriptMapperFunction;
-import io.warp10.script.WarpScriptStackFunction;
 import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptStack;
-
+import io.warp10.script.WarpScriptStackFunction;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 
 /**
  * Mapper which returns the second of the tick for which it
  * is computed.
  */
-public class MapperSecondOfMinute extends NamedWarpScriptFunction implements WarpScriptMapperFunction, WarpScriptAggregatorFunction {
+public class MapperSecondOfMinute extends MapperDateTime {
   
   public static class Builder extends NamedWarpScriptFunction implements WarpScriptStackFunction {
     
@@ -48,47 +42,12 @@ public class MapperSecondOfMinute extends NamedWarpScriptFunction implements War
     }
   }
 
-  private final DateTimeZone dtz;
-  
-  /**
-   * Default constructor, the timezone will be UTC
-   */
-  public MapperSecondOfMinute(String name) {
-    super(name);
-    this.dtz = DateTimeZone.UTC; 
+  public MapperSecondOfMinute(String name, Object timezone) throws WarpScriptException {
+    super(name, timezone);
   }
-  
-  public MapperSecondOfMinute(String name, Object timezone) {
-    super(name);
-    if (timezone instanceof String) {
-      this.dtz = DateTimeZone.forID(timezone.toString());
-    } else if (timezone instanceof Number) {
-      this.dtz = DateTimeZone.forOffsetMillis(((Number) timezone).intValue());
-    } else {
-      this.dtz = DateTimeZone.UTC;
-    }
-  }
-  
-  @Override
-  public Object apply(Object[] args) throws WarpScriptException {
-    long tick = (long) args[0];
-    long[] locations = (long[]) args[4];
-    long[] elevations = (long[]) args[5];
 
-    long location = locations[0];
-    long elevation = elevations[0];
-
-    DateTime dt = new DateTime(tick / Constants.TIME_UNITS_PER_MS, this.dtz);
-        
-    return new Object[] { tick, location, elevation, (double) dt.getSecondOfMinute() + ((double) (tick % Constants.TIME_UNITS_PER_S) / (double) Constants.TIME_UNITS_PER_S)};
-  }
-  
   @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append(StackUtils.toString(this.dtz.getID()));
-    sb.append(" ");
-    sb.append(this.getName());
-    return sb.toString();
+  public int getDateTimeInfo(DateTime dt) {
+    return dt.getSecondOfMinute();
   }
 }

--- a/warp10/src/main/java/io/warp10/script/mapper/MapperYear.java
+++ b/warp10/src/main/java/io/warp10/script/mapper/MapperYear.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2020  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -16,24 +16,17 @@
 
 package io.warp10.script.mapper;
 
-import io.warp10.continuum.gts.GeoTimeSerie.TYPE;
-import io.warp10.continuum.store.Constants;
 import io.warp10.script.NamedWarpScriptFunction;
-import io.warp10.script.StackUtils;
-import io.warp10.script.WarpScriptAggregatorFunction;
-import io.warp10.script.WarpScriptMapperFunction;
-import io.warp10.script.WarpScriptStackFunction;
 import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptStack;
-
+import io.warp10.script.WarpScriptStackFunction;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 
 /**
  * Mapper which returns the year of the tick for which it
  * is computed.
  */
-public class MapperYear extends NamedWarpScriptFunction implements WarpScriptMapperFunction, WarpScriptAggregatorFunction {
+public class MapperYear extends MapperDateTime {
   
   public static class Builder extends NamedWarpScriptFunction implements WarpScriptStackFunction {
     
@@ -49,48 +42,12 @@ public class MapperYear extends NamedWarpScriptFunction implements WarpScriptMap
     }
   }
 
-  private final DateTimeZone dtz;
-  
-  /**
-   * Default constructor, the timezone will be UTC
-   */
-  public MapperYear(String name) {
-    super(name);
-    this.dtz = DateTimeZone.UTC; 
+  public MapperYear(String name, Object timezone) throws WarpScriptException {
+    super(name, timezone);
   }
-  
-  public MapperYear(String name, Object timezone) {
-    super(name);
-    if (timezone instanceof String) {
-      this.dtz = DateTimeZone.forID(timezone.toString());
-    } else if (timezone instanceof Number) {
-      this.dtz = DateTimeZone.forOffsetMillis(((Number) timezone).intValue());
-    } else {
-      this.dtz = DateTimeZone.UTC;
-    }
-  }
-  
+
   @Override
-  public Object apply(Object[] args) throws WarpScriptException {
-    long tick = (long) args[0];
-    long[] locations = (long[]) args[4];
-    long[] elevations = (long[]) args[5];
-
-    long location = locations[0];
-    long elevation = elevations[0];
-
-    DateTime dt = new DateTime(tick / Constants.TIME_UNITS_PER_MS, this.dtz);
-        
-    return new Object[] { tick, location, elevation, dt.getYear() };
+  public int getDateTimeInfo(DateTime dt) {
+    return dt.getYear();
   }
-  
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append(StackUtils.toString(this.dtz.getID()));
-    sb.append(" ");
-    sb.append(this.getName());
-    return sb.toString();
-  }
-
 }


### PR DESCRIPTION
Previously those mappers accepted any parameter and defaulted to UTC. Now throw if it is not a valid timezone or offset.