### PR TITLE
Fix get/remove on Maps with wrong keys or replace with simplier parameter

### DIFF
--- a/warp10/src/main/java/io/warp10/script/ext/shm/SharedMemoryWarpScriptExtension.java
+++ b/warp10/src/main/java/io/warp10/script/ext/shm/SharedMemoryWarpScriptExtension.java
@@ -156,12 +156,12 @@ public class SharedMemoryWarpScriptExtension extends WarpScriptExtension impleme
         synchronized(locks) {
           long now = System.currentTimeMillis();
           
-          for (Map.Entry<String, Object> symbolAndObject: shmobjects.entrySet()) {
-            String symbol = symbolAndObject.getKey();
+          for (String symbol: shmobjects.keySet()) {
             // If SHM Object was not used for more than ttl, clear it
             // if its mutex is not currently held
             if (now - shmobjectUses.get(symbol) > ttl) {
-              ReentrantLock lock = locks.get(symbolAndObject.getValue());
+              String mutex = shmobjectLocks.get(symbol);
+              ReentrantLock lock = locks.get(mutex);
               if (!lock.isLocked()) {
                 shmobjects.remove(symbol);
                 shmobjectLocks.remove(symbol);

--- a/warp10/src/main/java/io/warp10/script/functions/ASREGS.java
+++ b/warp10/src/main/java/io/warp10/script/functions/ASREGS.java
@@ -235,7 +235,7 @@ public class ASREGS extends NamedWarpScriptFunction implements WarpScriptStackFu
             while (idx >= 0 && !(statements.get(idx) instanceof MARK)) {
               Object stmt = statements.get(idx);
               if (stmt instanceof String) {
-                Integer regno = varregs.get(statements.get(idx));
+                Integer regno = varregs.get(stmt);
                 if (null != regno) {
                   statements.set(idx, (long) regno);
                 }

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneMemoryStore.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneMemoryStore.java
@@ -560,7 +560,7 @@ public class StandaloneMemoryStore extends Thread implements StoreClient {
         synchronized(encoder) {
           if (0 == encoder.size()) {
             synchronized(this.series) {
-              this.series.remove(this.series.get(metadatas.get(idx)));
+              this.series.remove(metadatas.get(idx));
               // TODO(hbs): Still need to unregister properly the Metadata from the Directory. This is tricky since
               // the call to store is re-entrant but won't go through the register phase....
             }


### PR DESCRIPTION
- SHM lock used SHM stored object instead of associated mutex name
- ASREGS could simpply use already stored and type-checked key
- StandaloneMemoryStore, although rarely used, used value instead of key to remove entries