### PR TITLE
Make metaset easier to use and avoid NPE when fetching without timespan

### DIFF
--- a/warp10/src/main/java/io/warp10/script/functions/FIND.java
+++ b/warp10/src/main/java/io/warp10/script/functions/FIND.java
@@ -445,6 +445,12 @@ public class FIND extends NamedWarpScriptFunction implements WarpScriptStackFunc
       if (!this.metaset) {
         stack.push(series);
       } else {
+        // Check that metadata are not empty
+        List<Metadata> metas = set.getMetadatas();
+        if (null == metas || metas.isEmpty()) {
+          throw new WarpScriptException(getName() + " couldn't find any metadata matching the given class and label selectors.");
+        }
+
         //
         // Encode the MetaSet
         //


### PR DESCRIPTION
As it is possible to fetch using both count and timespan, limits are applied even if the bounded parameters are not set.
It is also possible to fetch without a timespan(using only start and end) which resulted in a NPE before this PR.

It should be possible to allow preboundary and postboundary according to which limits are sets, the simpler case, for instance, is when no limit is set.