### PR TITLE
Fix case where MAXDEPTH is smaller than the array backing the stack

### DIFF
--- a/warp10/src/main/java/io/warp10/script/MemoryWarpScriptStack.java
+++ b/warp10/src/main/java/io/warp10/script/MemoryWarpScriptStack.java
@@ -1258,6 +1258,14 @@ public class MemoryWarpScriptStack implements WarpScriptStack, Progressable {
     
     if (WarpScriptStack.ATTRIBUTE_MAX_DEPTH.equals(key)) {
       this.maxdepth = ((Number) value).intValue();
+      // Check if the underlying array is already bigger than the requested maximum depth
+      if (elements.length > this.maxdepth) {
+        if (size + offset > maxdepth) {
+          throw new IndexOutOfBoundsException("The stack depth is over the requested maximum depth.");
+        } else {
+          elements = Arrays.copyOf(elements, maxdepth);
+        }
+      }
     } else if (WarpScriptStack.ATTRIBUTE_MAX_OPS.equals(key)) {
       this.maxops = ((Number) value).longValue();
     } else if (WarpScriptStack.ATTRIBUTE_RECURSION_MAXDEPTH.equals(key)) {

--- a/warp10/src/main/java/io/warp10/script/functions/MAXDEPTH.java
+++ b/warp10/src/main/java/io/warp10/script/functions/MAXDEPTH.java
@@ -49,7 +49,11 @@ public class MAXDEPTH extends NamedWarpScriptFunction implements WarpScriptStack
       throw new WarpScriptException(getName() + " cannot extend limit past " + stack.getAttribute(WarpScriptStack.ATTRIBUTE_MAX_DEPTH_HARD));
     }
 
-    stack.setAttribute(WarpScriptStack.ATTRIBUTE_MAX_DEPTH, (int) limit);
+    try {
+      stack.setAttribute(WarpScriptStack.ATTRIBUTE_MAX_DEPTH, (int) limit);
+    } catch (IndexOutOfBoundsException iobe) {
+      throw new WarpScriptException(getName() + " failed.", iobe);
+    }
     
     return stack;
   }


### PR DESCRIPTION
```
10 MAXDEPTH // Default size of the element backing MemoryWarpScript is 32
1 20
<% %>
FOR // Will fail with this PR but not without
```