### PR TITLE
Add optional macro or mapper parameter for DEDUP to merge duplicate ticks

### DIFF
--- a/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
+++ b/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
@@ -5065,6 +5065,11 @@ public class GTSHelper {
 
   public static List<GeoTimeSerie> map(GeoTimeSerie gts, Object mapper, long prewindow, long postwindow, long occurrences, boolean reversed, int step, boolean overrideTick, WarpScriptStack stack,
                                        List<Long> outputTicks) throws WarpScriptException {
+    return map(gts, mapper, prewindow, postwindow, occurrences, reversed, step, overrideTick, stack, outputTicks, false);
+  }
+
+  public static List<GeoTimeSerie> map(GeoTimeSerie gts, Object mapper, long prewindow, long postwindow, long occurrences, boolean reversed, int step, boolean overrideTick, WarpScriptStack stack,
+                                       List<Long> outputTicks, boolean dedup) throws WarpScriptException {
 
     //
     // Make sure step is positive
@@ -5153,6 +5158,8 @@ public class GTSHelper {
 
     boolean hasSingleResult = true;
 
+    long lastTick = 0;
+
     while (idx < nticks) {
 
       if (hasOccurrences && 0 == occurrences) {
@@ -5183,6 +5190,17 @@ public class GTSHelper {
           }
         }
       }
+
+      //
+      // Skip tick if same as last one and must deduplicate
+      // dedup will behave strangely with step>1, pre>0, post>0 or non-null outputTicks, avoid these configurations.
+      //
+      if (dedup && 0 != idx && tick == lastTick) {
+        idx += step;
+        // Do not decrease occurences as duplicate ticks are considered one occurence in dedup mode.
+        continue;
+      }
+      lastTick = tick;
 
       //
       // Determine start/stop timestamp for extracting subserie

--- a/warp10/src/main/java/io/warp10/script/functions/DEDUP.java
+++ b/warp10/src/main/java/io/warp10/script/functions/DEDUP.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2020  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -18,24 +18,25 @@ package io.warp10.script.functions;
 
 import io.warp10.continuum.gts.GTSHelper;
 import io.warp10.continuum.gts.GeoTimeSerie;
-import io.warp10.script.ElementOrListStackFunction;
+import io.warp10.script.ListRecursiveStackFunction;
 import io.warp10.script.WarpScriptException;
+import io.warp10.script.WarpScriptMapperFunction;
 import io.warp10.script.WarpScriptStack;
 
 /**
  * Remove duplicates from GTS instances.
  * <p>
- * DEDUP expects no other parameter on the stack than the GTS instances
+ * DEDUP expects an optional mapper or macro (as MAP) and GTS instances
  */
-public class DEDUP extends ElementOrListStackFunction {
+public class DEDUP extends ListRecursiveStackFunction {
 
-  private final ElementStackFunction dedup = new ElementStackFunction() {
+  private final ElementStackFunction simpleDedup = new ElementStackFunction() {
     @Override
     public Object applyOnElement(Object element) throws WarpScriptException {
       if (element instanceof GeoTimeSerie) {
         return GTSHelper.dedup((GeoTimeSerie) element);
       } else {
-        throw new WarpScriptException(getName() + " expects a Geo Time Series instance or a list thereof under the top.");
+        return UNHANDLED;
       }
     }
   };
@@ -47,7 +48,28 @@ public class DEDUP extends ElementOrListStackFunction {
 
   @Override
   public ElementStackFunction generateFunction(WarpScriptStack stack) throws WarpScriptException {
-    return dedup;
+    Object peeked = stack.peek();
+    
+    if (peeked instanceof WarpScriptStack.Macro || peeked instanceof WarpScriptMapperFunction) {
+      Object macroOrMapper = stack.pop();
+      return new ElementStackFunction() {
+        @Override
+        public Object applyOnElement(Object element) throws WarpScriptException {
+          if (element instanceof GeoTimeSerie) {
+            return GTSHelper.map((GeoTimeSerie) element, macroOrMapper, 0, 0, 0, false, 1, false, macroOrMapper instanceof WarpScriptStack.Macro ? stack : null, null, true);
+          } else {
+            return UNHANDLED;
+          }
+        }
+      };
+    } else {
+      return simpleDedup;
+    }
+  }
+
+  @Override
+  public String getUnhandledErrorMessage() {
+    return getName() + " expects a Geo Time Series instance or a list thereof under an optional macro or mapper.";
   }
 
 }

--- a/warp10/src/main/java/io/warp10/script/functions/DEDUP.java
+++ b/warp10/src/main/java/io/warp10/script/functions/DEDUP.java
@@ -30,7 +30,7 @@ import io.warp10.script.WarpScriptStack;
  */
 public class DEDUP extends ListRecursiveStackFunction {
 
-  private final ElementStackFunction simpleDedup = new ElementStackFunction() {
+  private final ElementStackFunction SIMPLE_DEDUP = new ElementStackFunction() {
     @Override
     public Object applyOnElement(Object element) throws WarpScriptException {
       if (element instanceof GeoTimeSerie) {
@@ -63,7 +63,7 @@ public class DEDUP extends ListRecursiveStackFunction {
         }
       };
     } else {
-      return simpleDedup;
+      return SIMPLE_DEDUP;
     }
   }
 


### PR DESCRIPTION
This optional parameter can apply more complex strategies for merging duplicate ticks than just keeping the last tick.

The implementation is based on GTSHelper.map but does not expose this parameter in MAP. This is because deduping will behave strangely with step>1, pre>0, post>0 or when using outputTicks. This is why it was included in DEDUP and not MAP.

Example:
```
NEWGTS
0 NaN NaN NaN 0 ADDVALUE
1 NaN NaN NaN 1 ADDVALUE
1 NaN NaN NaN 2 ADDVALUE
1 NaN NaN NaN 3 ADDVALUE
2 NaN NaN NaN 4 ADDVALUE
3 NaN NaN NaN 5 ADDVALUE

mapper.median DEDUP
```
Gives
```
[[{"c":"","l":{},"a":{},"la":0,"v":[[0,0.0],[1,2.0],[2,4.0],[3,5.0]]}]]
```