### PR TITLE
Try type resolver if typeofable fails

### DIFF
--- a/warp10/src/main/java/io/warp10/script/functions/TYPEOF.java
+++ b/warp10/src/main/java/io/warp10/script/functions/TYPEOF.java
@@ -182,6 +182,14 @@ public class TYPEOF extends NamedWarpScriptFunction implements WarpScriptStackFu
       try {
         return "X-" + ((Typeofable) c.getDeclaredConstructor().newInstance()).typeof();
       } catch (Exception e) {
+        if (null != resolvers) {
+          for (TypeResolver resolver: resolvers) {
+            String type = resolver.typeof(c);
+            if (null != type) {
+              return type;
+            }
+          }
+        }
         return defaultType(c);
       }
     } else {


### PR DESCRIPTION
An interface that extends typeofable will fail on "getDeclaredConstructor".
A typeResolver can be added by the extension that uses this interface to answer this.