### PR TITLE
Standalone Directory index by label feature

### DIFF
--- a/etc/conf.templates/distributed/00-warp.conf.template
+++ b/etc/conf.templates/distributed/00-warp.conf.template
@@ -139,13 +139,6 @@ warp.components =
 #warp.labels.maxsize = 2048
 
 //
-// Default priority order for matching labels when doing a FIND/FETCH.
-// Comma separated list of label names.
-// Defaults to .producer,.app,.owner
-//
-#warp.labels.priority =
-  
-//
 // Maximum length of attributes (names + values) - Defaults to 8192
 //
 #warp.attributes.maxsize = 8192

--- a/etc/conf.templates/distributed/00-warp.conf.template
+++ b/etc/conf.templates/distributed/00-warp.conf.template
@@ -1,5 +1,5 @@
 //
-//   Copyright 2019  SenX S.A.S.
+//   Copyright 2019-2020  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -137,6 +137,13 @@ warp.components =
 // Maximum length of labels (names + values) - Defaults to 2048
 //
 #warp.labels.maxsize = 2048
+
+//
+// Default priority order for matching labels when doing a FIND/FETCH.
+// Comma separated list of label names.
+// Defaults to .producer,.app,.owner
+//
+#warp.labels.priority =
   
 //
 // Maximum length of attributes (names + values) - Defaults to 8192

--- a/etc/conf.templates/distributed/20-warpscript.conf.template
+++ b/etc/conf.templates/distributed/20-warpscript.conf.template
@@ -222,3 +222,10 @@ warpscript.mobius.pool = 16
 // allow C style block comments. /**** valid block comment ****/
 //
 warpscript.comments.loose = true
+
+//
+// Default priority order for matching labels when doing a FIND/FETCH.
+// Comma separated list of label names.
+// Defaults to .producer,.app,.owner
+//
+#warp.labels.priority =

--- a/etc/conf.templates/standalone/00-warp.conf.template
+++ b/etc/conf.templates/standalone/00-warp.conf.template
@@ -1,5 +1,5 @@
 //
-//   Copyright 2019  SenX S.A.S.
+//   Copyright 2019-2020  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -219,6 +219,13 @@ plasma.frontend.websocket.maxmessagesize = 1048576
 //
 #warp.labels.maxsize = 2048
  
+//
+// Default priority order for matching labels when doing a FIND/FETCH.
+// Comma separated list of label names.
+// Defaults to .producer,.app,.owner
+//
+#warp.labels.priority =
+
 //
 // Maximum length of attributes (names + values) - Defaults to 8192
 //

--- a/etc/conf.templates/standalone/00-warp.conf.template
+++ b/etc/conf.templates/standalone/00-warp.conf.template
@@ -220,13 +220,6 @@ plasma.frontend.websocket.maxmessagesize = 1048576
 #warp.labels.maxsize = 2048
  
 //
-// Default priority order for matching labels when doing a FIND/FETCH.
-// Comma separated list of label names.
-// Defaults to .producer,.app,.owner
-//
-#warp.labels.priority =
-
-//
 // Maximum length of attributes (names + values) - Defaults to 8192
 //
 #warp.attributes.maxsize = 8192

--- a/etc/conf.templates/standalone/10-directory.conf.template
+++ b/etc/conf.templates/standalone/10-directory.conf.template
@@ -29,3 +29,19 @@ directory.stats.class.maxcardinality = 100
 // Maximum number of labels for which to report detailed stats in 'FINDSTATS'
 //
 directory.stats.labels.maxcardinality = 100
+
+
+//
+// Extra labels to build another directory index.
+// Memory hungry feature that can solve specific directory problems.
+// This extra label index only supports exact matches.
+// By default, there is no such index
+//
+# warp.indexed.labels = labelA, labelB
+
+//
+// If warp.indexed.labels feature is used, deleting series do not delete metadata from the extra indexes to save performances
+// Set the maximum of dead references in the index before compaction of the index.
+// Defaults to 1 000 000. 
+//
+# warp.indexed.labels.max.empty.meta = 10000000

--- a/etc/conf.templates/standalone/20-warpscript.conf.template
+++ b/etc/conf.templates/standalone/20-warpscript.conf.template
@@ -220,3 +220,10 @@ warpscript.runner.bootstrap.period = 120000
 // allow C style block comments. /**** valid block comment ****/
 //
 warpscript.comments.loose = true
+
+//
+// Default priority order for matching labels when doing a FIND/FETCH.
+// Comma separated list of label names.
+// Defaults to .producer,.app,.owner
+//
+#warp.labels.priority =

--- a/warp10/src/main/java/io/warp10/continuum/Configuration.java
+++ b/warp10/src/main/java/io/warp10/continuum/Configuration.java
@@ -1675,6 +1675,13 @@ public class Configuration {
   public static final String WARP_LABELS_MAXSIZE = "warp.labels.maxsize";
   
   /**
+   * Default priority order for matching labels when doing a FIND/FETCH.
+   * Comma separated list of label names.
+   * Defaults to .producer,.app,.owner
+   */
+  public static final String WARP_LABELS_PRIORITY = "warp.labels.priority";
+  
+  /**
    * Maximum length of attributes (names + values) - Defaults to 8192
    */
   public static final String WARP_ATTRIBUTES_MAXSIZE = "warp.attributes.maxsize";

--- a/warp10/src/main/java/io/warp10/continuum/Configuration.java
+++ b/warp10/src/main/java/io/warp10/continuum/Configuration.java
@@ -1673,14 +1673,29 @@ public class Configuration {
    * Maximum length of labels (names + values) - Defaults to 2048
    */
   public static final String WARP_LABELS_MAXSIZE = "warp.labels.maxsize";
-  
+
   /**
    * Default priority order for matching labels when doing a FIND/FETCH.
    * Comma separated list of label names.
    * Defaults to .producer,.app,.owner
    */
   public static final String WARP_LABELS_PRIORITY = "warp.labels.priority";
-  
+
+  /**
+   * Extra labels to build a directory index.
+   * Memory hungry feature that can solve specific directory problems.
+   * This extra label index only supports exact matches.
+   * Defaults to none.
+   */
+  public static final String WARP_INDEXED_LABELS = "warp.indexed.labels";
+
+  /**
+   * If warp.indexed.labels feature is used, delete a series do not delete metadata from the index.
+   * Set the maximum of dead references in the index before compaction of the indexes.
+   * Defaults to 100 000
+   */
+  public static final String WARP_LABEL_INDEX_MAX_EMPTY_META = "warp.indexed.labels.max.empty.meta";
+
   /**
    * Maximum length of attributes (names + values) - Defaults to 8192
    */

--- a/warp10/src/main/java/io/warp10/continuum/Configuration.java
+++ b/warp10/src/main/java/io/warp10/continuum/Configuration.java
@@ -1694,7 +1694,7 @@ public class Configuration {
    * Set the maximum of dead references in the index before compaction of the indexes.
    * Defaults to 100 000
    */
-  public static final String WARP_LABEL_INDEX_MAX_EMPTY_META = "warp.indexed.labels.max.empty.meta";
+  public static final String WARP_INDEXED_LABELS_MAX_EMPTY_META = "warp.indexed.labels.max.empty.meta";
 
   /**
    * Maximum length of attributes (names + values) - Defaults to 8192

--- a/warp10/src/main/java/io/warp10/continuum/Tokens.java
+++ b/warp10/src/main/java/io/warp10/continuum/Tokens.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2020  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -345,11 +346,11 @@ public class Tokens {
    */
   public static Map<String,String> labelSelectorsFromReadToken(ReadToken rtoken) {
     
-    Map<String,String> labelSelectors = new HashMap<String,String>();
+    Map<String,String> labelSelectors = new LinkedHashMap<String,String>();
     
     List<String> owners = new ArrayList<String>();
     List<String> producers = new ArrayList<String>();
-    Map<String, String> labels = new HashMap<String, String>();
+    Map<String, String> labels = new LinkedHashMap<String, String>();
 
     if (rtoken.getLabelsSize() > 0) {
       labels = rtoken.getLabels();
@@ -377,6 +378,27 @@ public class Tokens {
       for (ByteBuffer bb: rtoken.getProducers()) {
         producers.add(Tokens.getUUID(bb));
       }      
+    }
+    
+    if (!producers.isEmpty()) {
+      if (1 == producers.size()) {
+        labelSelectors.put(Constants.PRODUCER_LABEL, "=" + producers.get(0));        
+      } else {
+        StringBuilder sb = new StringBuilder();
+                
+        sb.append("~^(");
+        boolean first = true;
+        for (String producer: producers) {
+          if (!first) {
+            sb.append("|");
+          }
+          sb.append(producer);
+          first = false;
+        }
+        sb.append(")$");
+        
+        labelSelectors.put(Constants.PRODUCER_LABEL, sb.toString());
+      }
     }
     
     if (rtoken.getAppsSize() > 0) {
@@ -418,27 +440,6 @@ public class Tokens {
         sb.append(")$");
         
         labelSelectors.put(Constants.OWNER_LABEL, sb.toString());
-      }
-    }
-    
-    if (!producers.isEmpty()) {
-      if (1 == producers.size()) {
-        labelSelectors.put(Constants.PRODUCER_LABEL, "=" + producers.get(0));        
-      } else {
-        StringBuilder sb = new StringBuilder();
-                
-        sb.append("~^(");
-        boolean first = true;
-        for (String producer: producers) {
-          if (!first) {
-            sb.append("|");
-          }
-          sb.append(producer);
-          first = false;
-        }
-        sb.append(")$");
-        
-        labelSelectors.put(Constants.PRODUCER_LABEL, sb.toString());
       }
     }
 

--- a/warp10/src/main/java/io/warp10/continuum/Tokens.java
+++ b/warp10/src/main/java/io/warp10/continuum/Tokens.java
@@ -344,16 +344,15 @@ public class Tokens {
    * those, thus leading potentially to data exposure
    * 
    */
-  public static Map<String,String> labelSelectorsFromReadToken(ReadToken rtoken) {
+  public static LinkedHashMap<String,String> labelSelectorsFromReadToken(ReadToken rtoken) {
     
-    Map<String,String> labelSelectors = new LinkedHashMap<String,String>();
+    LinkedHashMap<String,String> labelSelectors = new LinkedHashMap<String,String>();
     
     List<String> owners = new ArrayList<String>();
     List<String> producers = new ArrayList<String>();
-    Map<String, String> labels = new LinkedHashMap<String, String>();
 
     if (rtoken.getLabelsSize() > 0) {
-      labels = rtoken.getLabels();
+      Map<String,String> labels = rtoken.getLabels();
       if (!labels.isEmpty()) {
         for (Map.Entry<String, String> entry : labels.entrySet()) {
           switch (entry.getKey()) {

--- a/warp10/src/main/java/io/warp10/continuum/egress/StreamingMetadataIterator.java
+++ b/warp10/src/main/java/io/warp10/continuum/egress/StreamingMetadataIterator.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2020  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -16,16 +16,6 @@
 
 package io.warp10.continuum.egress;
 
-import io.warp10.WarpURLEncoder;
-import io.warp10.continuum.Configuration;
-import io.warp10.continuum.gts.GTSHelper;
-import io.warp10.continuum.store.Constants;
-import io.warp10.continuum.store.MetadataIterator;
-import io.warp10.continuum.store.thrift.data.DirectoryRequest;
-import io.warp10.continuum.store.thrift.data.Metadata;
-import io.warp10.crypto.OrderPreservingBase64;
-import io.warp10.crypto.SipHashInline;
-
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -35,12 +25,21 @@ import java.net.Proxy;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Map.Entry;
+import java.util.NoSuchElementException;
 
 import org.apache.thrift.TDeserializer;
 import org.apache.thrift.protocol.TCompactProtocol;
+
+import io.warp10.WarpURLEncoder;
+import io.warp10.continuum.Configuration;
+import io.warp10.continuum.gts.GTSHelper;
+import io.warp10.continuum.store.Constants;
+import io.warp10.continuum.store.MetadataIterator;
+import io.warp10.continuum.store.thrift.data.DirectoryRequest;
+import io.warp10.continuum.store.thrift.data.Metadata;
+import io.warp10.crypto.OrderPreservingBase64;
+import io.warp10.crypto.SipHashInline;
 
 public class StreamingMetadataIterator extends MetadataIterator {
   
@@ -142,7 +141,7 @@ public class StreamingMetadataIterator extends MetadataIterator {
           selector.append(WarpURLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8));
         }
         first = false;
-      }
+      }        
       
       selector.append("}");
 

--- a/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
+++ b/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
@@ -3604,7 +3604,7 @@ public class GTSHelper {
     // Loop over the tokens
     //
     
-    Map<String,String> result = new HashMap<String,String>(tokens.length);
+    Map<String,String> result = new LinkedHashMap<String,String>(tokens.length);
     
     for (String token: tokens) {
       

--- a/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
+++ b/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
@@ -3592,7 +3592,7 @@ public class GTSHelper {
    * @param selectors Selectors following the syntax NAME&lt;TYPE&gt;VALUE,NAME&lt;TYPE&gt;VALUE,... to be parsed.
    * @return A map from label name to selector.
    */
-  public static final Map<String,String> parseLabelsSelectors(String selectors) throws ParseException {
+  public static final LinkedHashMap<String,String> parseLabelsSelectors(String selectors) throws ParseException {
     //
     // Split selectors on ',' boundaries
     //
@@ -3604,7 +3604,7 @@ public class GTSHelper {
     // Loop over the tokens
     //
     
-    Map<String,String> result = new LinkedHashMap<String,String>(tokens.length);
+    LinkedHashMap<String,String> result = new LinkedHashMap<String,String>(tokens.length);
     
     for (String token: tokens) {
       

--- a/warp10/src/main/java/io/warp10/continuum/store/Constants.java
+++ b/warp10/src/main/java/io/warp10/continuum/store/Constants.java
@@ -463,6 +463,11 @@ public class Constants {
   public static final boolean DELETE_METAONLY_SUPPORT;
   
   public static final boolean DELETE_ACTIVITY_SUPPORT;
+
+  /**
+   * Default value for maximum number of null metadata in label indexes
+   */
+  public static final String DIRECTORY_DEFAULT_LABEL_INDEX_MAX_EMPTY_META = "1000000";
   
   static {
     String tu = WarpConfig.getProperty(Configuration.WARP_TIME_UNITS);

--- a/warp10/src/main/java/io/warp10/continuum/store/Directory.java
+++ b/warp10/src/main/java/io/warp10/continuum/store/Directory.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2020  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -2074,7 +2074,7 @@ public class Directory extends AbstractHandler implements DirectoryService.Iface
           classSmartPattern = new SmartPattern(Pattern.compile(request.getClassSelector().get(i).substring(1)));
         }
         
-        Map<String,SmartPattern> labelPatterns = new HashMap<String,SmartPattern>();
+        Map<String,SmartPattern> labelPatterns = new LinkedHashMap<String,SmartPattern>();
         
         if (null != missingLabels) {
           missingLabels.clear();          
@@ -2134,31 +2134,7 @@ public class Directory extends AbstractHandler implements DirectoryService.Iface
         List<String> labelNames = new ArrayList<String>(labelPatterns.size());
         List<SmartPattern> labelSmartPatterns = new ArrayList<SmartPattern>(labelPatterns.size());
         String[] labelValues = null;
-        
-        //
-        // Put producer/app/owner first
-        //
-        
-        if (labelPatterns.containsKey(Constants.PRODUCER_LABEL)) {
-          labelNames.add(Constants.PRODUCER_LABEL);
-          labelSmartPatterns.add(labelPatterns.get(Constants.PRODUCER_LABEL));
-          labelPatterns.remove(Constants.PRODUCER_LABEL);
-        }
-        if (labelPatterns.containsKey(Constants.APPLICATION_LABEL)) {
-          labelNames.add(Constants.APPLICATION_LABEL);
-          labelSmartPatterns.add(labelPatterns.get(Constants.APPLICATION_LABEL));
-          labelPatterns.remove(Constants.APPLICATION_LABEL);
-        }
-        if (labelPatterns.containsKey(Constants.OWNER_LABEL)) {
-          labelNames.add(Constants.OWNER_LABEL);
-          labelSmartPatterns.add(labelPatterns.get(Constants.OWNER_LABEL));
-          labelPatterns.remove(Constants.OWNER_LABEL);
-        }
-        
-        //
-        // Now add the other labels
-        //
-        
+                
         for(Entry<String,SmartPattern> entry: labelPatterns.entrySet()) {
           labelNames.add(entry.getKey());
           labelSmartPatterns.add(entry.getValue());
@@ -2463,7 +2439,7 @@ public class Directory extends AbstractHandler implements DirectoryService.Iface
           classSmartPattern = new SmartPattern(Pattern.compile(request.getClassSelector().get(i).substring(1)));
         }
         
-        Map<String,SmartPattern> labelPatterns = new HashMap<String,SmartPattern>();
+        Map<String,SmartPattern> labelPatterns = new LinkedHashMap<String,SmartPattern>();
 
         if (null != missingLabels) {
           missingLabels.clear();
@@ -2525,34 +2501,7 @@ public class Directory extends AbstractHandler implements DirectoryService.Iface
         List<String> labelNames = new ArrayList<String>(labelPatterns.size());
         List<SmartPattern> labelSmartPatterns = new ArrayList<SmartPattern>(labelPatterns.size());
         List<String> labelValues = new ArrayList<String>(labelPatterns.size());
-        
-        //
-        // Put producer/app/owner first
-        //
-        
-        if (labelPatterns.containsKey(Constants.PRODUCER_LABEL)) {
-          labelNames.add(Constants.PRODUCER_LABEL);
-          labelSmartPatterns.add(labelPatterns.get(Constants.PRODUCER_LABEL));
-          labelPatterns.remove(Constants.PRODUCER_LABEL);   
-          labelValues.add(null);
-        }
-        if (labelPatterns.containsKey(Constants.APPLICATION_LABEL)) {
-          labelNames.add(Constants.APPLICATION_LABEL);
-          labelSmartPatterns.add(labelPatterns.get(Constants.APPLICATION_LABEL));
-          labelPatterns.remove(Constants.APPLICATION_LABEL);
-          labelValues.add(null);
-        }
-        if (labelPatterns.containsKey(Constants.OWNER_LABEL)) {
-          labelNames.add(Constants.OWNER_LABEL);
-          labelSmartPatterns.add(labelPatterns.get(Constants.OWNER_LABEL));
-          labelPatterns.remove(Constants.OWNER_LABEL);
-          labelValues.add(null);
-        }
-        
-        //
-        // Now add the other labels
-        //
-        
+                
         for(Entry<String,SmartPattern> entry: labelPatterns.entrySet()) {
           labelNames.add(entry.getKey());
           labelSmartPatterns.add(entry.getValue());
@@ -3022,7 +2971,7 @@ public class Directory extends AbstractHandler implements DirectoryService.Iface
         classSmartPattern = new SmartPattern(Pattern.compile(classSelector.substring(1)));
       }
         
-      Map<String,SmartPattern> labelPatterns = new HashMap<String,SmartPattern>();
+      Map<String,SmartPattern> labelPatterns = new LinkedHashMap<String,SmartPattern>();
         
       for (Entry<String,String> entry: labelsSelector.entrySet()) {
         String label = entry.getKey();
@@ -3079,34 +3028,7 @@ public class Directory extends AbstractHandler implements DirectoryService.Iface
       List<String> labelNames = new ArrayList<String>(labelPatterns.size());
       List<SmartPattern> labelSmartPatterns = new ArrayList<SmartPattern>(labelPatterns.size());
       List<String> labelValues = new ArrayList<String>(labelPatterns.size());
-      
-      //
-      // Put producer/app/owner first
-      //
-      
-      if (labelPatterns.containsKey(Constants.PRODUCER_LABEL)) {
-        labelNames.add(Constants.PRODUCER_LABEL);
-        labelSmartPatterns.add(labelPatterns.get(Constants.PRODUCER_LABEL));
-        labelPatterns.remove(Constants.PRODUCER_LABEL);
-        labelValues.add(null);        
-      }
-      if (labelPatterns.containsKey(Constants.APPLICATION_LABEL)) {
-        labelNames.add(Constants.APPLICATION_LABEL);
-        labelSmartPatterns.add(labelPatterns.get(Constants.APPLICATION_LABEL));
-        labelPatterns.remove(Constants.APPLICATION_LABEL);        
-        labelValues.add(null);        
-      }
-      if (labelPatterns.containsKey(Constants.OWNER_LABEL)) {
-        labelNames.add(Constants.OWNER_LABEL);
-        labelSmartPatterns.add(labelPatterns.get(Constants.OWNER_LABEL));
-        labelPatterns.remove(Constants.OWNER_LABEL);        
-        labelValues.add(null);        
-      }
-      
-      //
-      // Now add the other labels
-      //
-      
+            
       for(Entry<String,SmartPattern> entry: labelPatterns.entrySet()) {
         labelNames.add(entry.getKey());
         labelSmartPatterns.add(entry.getValue());

--- a/warp10/src/main/java/io/warp10/script/functions/FETCH.java
+++ b/warp10/src/main/java/io/warp10/script/functions/FETCH.java
@@ -359,7 +359,7 @@ public class FETCH extends NamedWarpScriptFunction implements WarpScriptStackFun
             ordered.put(entry.getKey(), entry.getValue());
           }
 
-          lblsSels.add((Map<String,String>) ordered);
+          lblsSels.add(ordered);
         }
       } else {
         clsSels.add(params.get(PARAM_CLASS).toString());
@@ -375,10 +375,7 @@ public class FETCH extends NamedWarpScriptFunction implements WarpScriptStackFun
         if (params.containsKey(PARAM_LABELS_PRIORITY)) {
           order = (List<String>) params.get(PARAM_LABELS_PRIORITY);
         } else {
-          order = new ArrayList<String>(3);
-          order.add(Constants.PRODUCER_LABEL);
-          order.add(Constants.APPLICATION_LABEL);
-          order.add(Constants.OWNER_LABEL);
+          order = FIND.DEFAULT_LABELS_PRIORITY;
         }
         Map<String,String> ordered = new LinkedHashMap<String,String>(labelSelectors.size());
         for (String label: order) {

--- a/warp10/src/main/java/io/warp10/script/functions/FETCH.java
+++ b/warp10/src/main/java/io/warp10/script/functions/FETCH.java
@@ -24,9 +24,11 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.zip.GZIPInputStream;
@@ -120,6 +122,7 @@ public class FETCH extends NamedWarpScriptFunction implements WarpScriptStackFun
   public static final String PARAM_BOUNDARY = "boundary";
   public static final String PARAM_SKIP = "skip";
   public static final String PARAM_SAMPLE = "sample";
+  public static final String PARAM_LABELS_PRIORITY = "priority";
   
   public static final String POSTFETCH_HOOK = "postfetch";
 
@@ -259,7 +262,7 @@ public class FETCH extends NamedWarpScriptFunction implements WarpScriptStackFun
       // Build a selector
       for (Metadata m: metas) {
         if (null == m.getLabels()) {
-          m.setLabels(new HashMap<String,String>());
+          m.setLabels(new LinkedHashMap<String,String>());
         }
         
         //
@@ -335,16 +338,62 @@ public class FETCH extends NamedWarpScriptFunction implements WarpScriptStackFun
           labelSelectors.remove(Constants.OWNER_LABEL);
           labelSelectors.remove(Constants.APPLICATION_LABEL);
           labelSelectors.putAll(Tokens.labelSelectorsFromReadToken(rtoken));
-          lblsSels.add((Map<String,String>) labelSelectors);
+          
+          // Re-order the labels
+          List<String> order = null;
+          if (params.containsKey(PARAM_LABELS_PRIORITY)) {
+            order = (List<String>) params.get(PARAM_LABELS_PRIORITY);
+          } else {
+            order = FIND.DEFAULT_LABELS_PRIORITY;
+          }
+          Map<String,String> ordered = new LinkedHashMap<String,String>(labelSelectors.size());
+          for (String label: order) {
+            if (labelSelectors.containsKey(label)) {
+              ordered.put(label, labelSelectors.get(label));
+            }
+          }
+          for (Entry<String,String> entry: labelSelectors.entrySet()) {
+            if (order.contains(entry.getKey())) {
+              continue;
+            }
+            ordered.put(entry.getKey(), entry.getValue());
+          }
+
+          lblsSels.add((Map<String,String>) ordered);
         }
       } else {
+        clsSels.add(params.get(PARAM_CLASS).toString());
+
         Map<String,String> labelSelectors = (Map<String,String>) params.get(PARAM_LABELS);
         labelSelectors.remove(Constants.PRODUCER_LABEL);
         labelSelectors.remove(Constants.OWNER_LABEL);
         labelSelectors.remove(Constants.APPLICATION_LABEL);
         labelSelectors.putAll(Tokens.labelSelectorsFromReadToken(rtoken));
-        clsSels.add(params.get(PARAM_CLASS).toString());
-        lblsSels.add(labelSelectors);
+
+        // Re-order the labels
+        List<String> order = null;
+        if (params.containsKey(PARAM_LABELS_PRIORITY)) {
+          order = (List<String>) params.get(PARAM_LABELS_PRIORITY);
+        } else {
+          order = new ArrayList<String>(3);
+          order.add(Constants.PRODUCER_LABEL);
+          order.add(Constants.APPLICATION_LABEL);
+          order.add(Constants.OWNER_LABEL);
+        }
+        Map<String,String> ordered = new LinkedHashMap<String,String>(labelSelectors.size());
+        for (String label: order) {
+          if (labelSelectors.containsKey(label)) {
+            ordered.put(label, labelSelectors.get(label));
+          }
+        }
+        for (Entry<String,String> entry: labelSelectors.entrySet()) {
+          if (order.contains(entry.getKey())) {
+            continue;
+          }
+          ordered.put(entry.getKey(), entry.getValue());
+        }
+
+        lblsSels.add((Map<String,String>) ordered);
       }      
            
       DirectoryRequest drequest = new DirectoryRequest();
@@ -358,7 +407,7 @@ public class FETCH extends NamedWarpScriptFunction implements WarpScriptStackFun
       if (params.containsKey(PARAM_QUIET_AFTER)) {
         drequest.setQuietAfter((long) params.get(PARAM_QUIET_AFTER));
       }
-
+      
       try {
         metadatas = directoryClient.find(drequest);
         iter = metadatas.iterator();
@@ -643,7 +692,7 @@ public class FETCH extends NamedWarpScriptFunction implements WarpScriptStackFun
               gts.getMetadata().putToAttributes(Constants.UUID_ATTRIBUTE, uuid.toString());
             }
             
-            Map<String,String> labels = new HashMap<String, String>();
+            Map<String,String> labels = new LinkedHashMap<String, String>();
             labels.putAll(gts.getMetadata().getLabels());
             
             if (!Constants.EXPOSE_OWNER_PRODUCER && !expose) {
@@ -736,7 +785,7 @@ public class FETCH extends NamedWarpScriptFunction implements WarpScriptStackFun
     //
     
     MetaSet metaset = null;
-    
+        
     if (map.containsKey(PARAM_METASET)) {
       
       if (null == AES_METASET) {
@@ -1067,6 +1116,18 @@ public class FETCH extends NamedWarpScriptFunction implements WarpScriptStackFun
       params.put(PARAM_SAMPLE, sample);
     }
 
+    if (map.containsKey(PARAM_LABELS_PRIORITY)) {
+      Object o = map.get(PARAM_LABELS_PRIORITY);
+      if (!(o instanceof List)) {
+        throw new WarpScriptException(getName() + " Invalid type for parameter '" + PARAM_LABELS_PRIORITY + "', expected a LIST.");
+      }
+      List<String> prio = new ArrayList<String>();
+      for (Object oo: (List<Object>) o) {
+        prio.add(String.valueOf(oo));
+      }
+      params.put(PARAM_LABELS_PRIORITY, prio);
+    }
+    
     return params;
   }
 

--- a/warp10/src/main/java/io/warp10/script/functions/FIND.java
+++ b/warp10/src/main/java/io/warp10/script/functions/FIND.java
@@ -381,7 +381,7 @@ public class FIND extends NamedWarpScriptFunction implements WarpScriptStackFunc
             sel.putAll(Tokens.labelSelectorsFromReadToken(rtoken));
 
             // Re-order the labels
-            Map<String,String> ordered = new LinkedHashMap<String,String>(labelSelectors.size());
+            Map<String,String> ordered = new LinkedHashMap<String,String>(null != labelSelectors ? labelSelectors.size() : 1);
             for (String label: order) {
               if (sel.containsKey(label)) {
                 ordered.put(label, sel.get(label));

--- a/warp10/src/main/java/io/warp10/script/functions/FIND.java
+++ b/warp10/src/main/java/io/warp10/script/functions/FIND.java
@@ -208,7 +208,7 @@ public class FIND extends NamedWarpScriptFunction implements WarpScriptStackFunc
     
     DirectoryRequest drequest = null;
     
-    List<String> order = null;
+    List<String> order = DEFAULT_LABELS_PRIORITY;
     
     if (mapparams) {
       top = stack.pop();
@@ -336,10 +336,7 @@ public class FIND extends NamedWarpScriptFunction implements WarpScriptStackFunc
       clsSels.add(classSelector);
       
       // Re-order the labels
-      if (null == order) {
-        order = DEFAULT_LABELS_PRIORITY;
-      }
-      Map<String,String> ordered = new LinkedHashMap<String,String>(labelSelectors.size());
+      Map<String,String> ordered = new LinkedHashMap<String,String>(labelSelectors.size() > 0 ? labelSelectors.size() : 1);
       for (String label: order) {
         if (labelSelectors.containsKey(label)) {
           ordered.put(label, labelSelectors.get(label));
@@ -371,7 +368,7 @@ public class FIND extends NamedWarpScriptFunction implements WarpScriptStackFunc
         drequest.setLabelsSelectors(lblsSels);
       } else {
         // Fix labels
-        
+
         if (drequest.isSetLabelsSelectors()) {
           for (int i = 0; i < drequest.getLabelsSelectorsSize(); i++) {
             Map<String,String> sel = drequest.getLabelsSelectors().get(i);

--- a/warp10/src/main/java/io/warp10/script/functions/PARSESELECTOR.java
+++ b/warp10/src/main/java/io/warp10/script/functions/PARSESELECTOR.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2020  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneDirectoryClient.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneDirectoryClient.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2020  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -16,27 +16,6 @@
 
 package io.warp10.standalone;
 
-import io.warp10.SmartPattern;
-import io.warp10.WarpConfig;
-import io.warp10.continuum.Configuration;
-import io.warp10.continuum.DirectoryUtil;
-import io.warp10.continuum.egress.ThriftDirectoryClient;
-import io.warp10.continuum.gts.GTSHelper;
-import io.warp10.continuum.sensision.SensisionConstants;
-import io.warp10.continuum.store.Constants;
-import io.warp10.continuum.store.Directory;
-import io.warp10.continuum.store.DirectoryClient;
-import io.warp10.continuum.store.MetadataIterator;
-import io.warp10.continuum.store.thrift.data.DirectoryRequest;
-import io.warp10.continuum.store.thrift.data.DirectoryStatsRequest;
-import io.warp10.continuum.store.thrift.data.DirectoryStatsResponse;
-import io.warp10.continuum.store.thrift.data.Metadata;
-import io.warp10.crypto.CryptoUtils;
-import io.warp10.crypto.KeyStore;
-import io.warp10.crypto.SipHashInline;
-import io.warp10.script.HyperLogLogPlus;
-import io.warp10.sensision.Sensision;
-
 import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
@@ -48,10 +27,10 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -81,6 +60,26 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.MapMaker;
+
+import io.warp10.SmartPattern;
+import io.warp10.WarpConfig;
+import io.warp10.continuum.Configuration;
+import io.warp10.continuum.egress.ThriftDirectoryClient;
+import io.warp10.continuum.gts.GTSHelper;
+import io.warp10.continuum.sensision.SensisionConstants;
+import io.warp10.continuum.store.Constants;
+import io.warp10.continuum.store.Directory;
+import io.warp10.continuum.store.DirectoryClient;
+import io.warp10.continuum.store.MetadataIterator;
+import io.warp10.continuum.store.thrift.data.DirectoryRequest;
+import io.warp10.continuum.store.thrift.data.DirectoryStatsRequest;
+import io.warp10.continuum.store.thrift.data.DirectoryStatsResponse;
+import io.warp10.continuum.store.thrift.data.Metadata;
+import io.warp10.crypto.CryptoUtils;
+import io.warp10.crypto.KeyStore;
+import io.warp10.crypto.SipHashInline;
+import io.warp10.script.HyperLogLogPlus;
+import io.warp10.sensision.Sensision;
 
 public class StandaloneDirectoryClient implements DirectoryClient {
   
@@ -407,7 +406,7 @@ public class StandaloneDirectoryClient implements DirectoryClient {
         classSmartPattern = new SmartPattern(Pattern.compile(classExpr.get(i).substring(1)));
       }
       
-      Map<String,SmartPattern> labelPatterns = new HashMap<String,SmartPattern>();
+      Map<String,SmartPattern> labelPatterns = new LinkedHashMap<String,SmartPattern>();
       
       if (null != missingLabels) {
         missingLabels.clear();
@@ -450,30 +449,6 @@ public class StandaloneDirectoryClient implements DirectoryClient {
       List<String> labelNames = new ArrayList<String>(labelPatterns.size());
       List<SmartPattern> labelSmartPatterns = new ArrayList<SmartPattern>(labelPatterns.size());
       String[] labelValues = null;
-      
-      //
-      // Put producer/app/owner first
-      //
-      
-      if (labelPatterns.containsKey(Constants.PRODUCER_LABEL)) {
-        labelNames.add(Constants.PRODUCER_LABEL);
-        labelSmartPatterns.add(labelPatterns.get(Constants.PRODUCER_LABEL));
-        labelPatterns.remove(Constants.PRODUCER_LABEL);
-      }
-      if (labelPatterns.containsKey(Constants.APPLICATION_LABEL)) {
-        labelNames.add(Constants.APPLICATION_LABEL);
-        labelSmartPatterns.add(labelPatterns.get(Constants.APPLICATION_LABEL));
-        labelPatterns.remove(Constants.APPLICATION_LABEL);
-      }
-      if (labelPatterns.containsKey(Constants.OWNER_LABEL)) {
-        labelNames.add(Constants.OWNER_LABEL);
-        labelSmartPatterns.add(labelPatterns.get(Constants.OWNER_LABEL));
-        labelPatterns.remove(Constants.OWNER_LABEL);
-      }
-      
-      //
-      // Now add the other labels
-      //
       
       for(Entry<String,SmartPattern> entry: labelPatterns.entrySet()) {
         labelNames.add(entry.getKey());
@@ -1023,7 +998,7 @@ public class StandaloneDirectoryClient implements DirectoryClient {
           classSmartPattern = new SmartPattern(Pattern.compile(request.getClassSelector().get(i).substring(1)));
         }
         
-        Map<String,SmartPattern> labelPatterns = new HashMap<String,SmartPattern>();
+        Map<String,SmartPattern> labelPatterns = new LinkedHashMap<String,SmartPattern>();
         
         if (null != missingLabels) {
           missingLabels.clear();
@@ -1086,33 +1061,6 @@ public class StandaloneDirectoryClient implements DirectoryClient {
         List<String> labelNames = new ArrayList<String>(labelPatterns.size());
         List<SmartPattern> labelSmartPatterns = new ArrayList<SmartPattern>(labelPatterns.size());
         List<String> labelValues = new ArrayList<String>(labelPatterns.size());
-        
-        //
-        // Put producer/app/owner first
-        //
-        
-        if (labelPatterns.containsKey(Constants.PRODUCER_LABEL)) {
-          labelNames.add(Constants.PRODUCER_LABEL);
-          labelSmartPatterns.add(labelPatterns.get(Constants.PRODUCER_LABEL));
-          labelPatterns.remove(Constants.PRODUCER_LABEL);   
-          labelValues.add(null);
-        }
-        if (labelPatterns.containsKey(Constants.APPLICATION_LABEL)) {
-          labelNames.add(Constants.APPLICATION_LABEL);
-          labelSmartPatterns.add(labelPatterns.get(Constants.APPLICATION_LABEL));
-          labelPatterns.remove(Constants.APPLICATION_LABEL);
-          labelValues.add(null);
-        }
-        if (labelPatterns.containsKey(Constants.OWNER_LABEL)) {
-          labelNames.add(Constants.OWNER_LABEL);
-          labelSmartPatterns.add(labelPatterns.get(Constants.OWNER_LABEL));
-          labelPatterns.remove(Constants.OWNER_LABEL);
-          labelValues.add(null);
-        }
-        
-        //
-        // Now add the other labels
-        //
         
         for(Entry<String,SmartPattern> entry: labelPatterns.entrySet()) {
           labelNames.add(entry.getKey());


### PR DESCRIPTION
Use case : several millions of GTS with different classnames, same .app, several labels by GTS. 

User wants to find `.*{serialNumber=X}`. User only know the serialNumber, not the other labels.

This feature allows to build an index of one or several labels (serialNumber in the example).
It speeds up FIND, FETCH, DELETE operations. 
