### PR TITLE
Modify custom JSON serialization

### DIFF
--- a/warp10/src/main/java/io/warp10/json/BytesSerializer.java
+++ b/warp10/src/main/java/io/warp10/json/BytesSerializer.java
@@ -17,10 +17,8 @@
 package io.warp10.json;
 
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
-import io.warp10.script.WarpScriptStack;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;

--- a/warp10/src/main/java/io/warp10/json/GTSEncoderSerializer.java
+++ b/warp10/src/main/java/io/warp10/json/GTSEncoderSerializer.java
@@ -17,7 +17,6 @@
 package io.warp10.json;
 
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import com.geoxp.GeoXPLib;

--- a/warp10/src/main/java/io/warp10/json/JsonUtils.java
+++ b/warp10/src/main/java/io/warp10/json/JsonUtils.java
@@ -107,9 +107,27 @@ public class JsonUtils {
 
   public interface JsonTransformer {
     class TransformationResult {
-      public final boolean transformed;
-      public final Object result;
-      public final boolean raw;
+
+      /**
+       * Whether the transformer managed to transform the given object or not.
+       * If false, result and raw fields are ignored.
+       */
+      private final boolean transformed;
+
+      /**
+       * The result of the transformation.
+       * If raw, the result must be a String and will be added as is in the resulting JSON.
+       * If not raw, the result should be an Object which can be JSONified. Typically Maps, Lists, String, Numbers, Booleans
+       * or even other Objects which are known to have serializer (GTS, Bytes, ...) or handled by other transformers.
+       */
+      private final Object result;
+
+      /**
+       * Whether the result is to be added as is in the resulting JSON.
+       * If true, result must be a String.
+       * If false, result can be any Object which will be JSONified.
+       */
+      private final boolean raw;
 
       public TransformationResult(boolean transformed, Object result, boolean raw) {
         this.transformed = transformed;
@@ -124,8 +142,8 @@ public class JsonUtils {
      * This allows the JSON serialization to ask for the conversion of un-serializable objects to serializable ones.
      * If it is not handled, TransformationResult#result is ignored, so it can be safely set to null.
      *
-     * @param original
-     * @return
+     * @param original The object to be transformed.
+     * @return The result of the transformation.
      */
     TransformationResult transform(Object original);
   }
@@ -227,7 +245,7 @@ public class JsonUtils {
   }
 
   /**
-   * Add a transformer to convert un-serializable objects to serializable ones.
+   * Add a transformer to convert un-serializable objects to serializable ones or raw Strings included in the JSON.
    *
    * @param transformer The transformer instance.
    */

--- a/warp10/src/main/java/io/warp10/json/JsonUtils.java
+++ b/warp10/src/main/java/io/warp10/json/JsonUtils.java
@@ -31,11 +31,6 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.BeanSerializer;
 import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
 import com.fasterxml.jackson.databind.ser.impl.UnknownSerializer;
-import io.warp10.continuum.gts.GTSEncoder;
-import io.warp10.continuum.gts.GeoTimeSerie;
-import io.warp10.continuum.store.thrift.data.Metadata;
-import io.warp10.script.NamedWarpScriptFunction;
-import io.warp10.script.WarpScriptStack;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -57,33 +52,35 @@ public class JsonUtils {
   }
 
   /**
-   * Used to swap UnknownSerializer and BeanSerializer for CustomEncodersSerializer.
+   * Used to swap UnknownSerializer and BeanSerializer for CustomSerializer.
    */
   public static class NotSerializedToCustomSerializedModifier extends BeanSerializerModifier {
     @Override
     public JsonSerializer<?> modifySerializer(SerializationConfig config, BeanDescription beanDesc, JsonSerializer<?> serializer) {
       if (serializer instanceof UnknownSerializer || serializer instanceof BeanSerializer) {
-        return customEncodersSerializer;
+        return CUSTOM_SERIALIZER;
       } else {
         return serializer;
       }
     }
   }
 
-  public static class CustomEncodersSerializer extends JsonSerializer<Object> {
+  /**
+   * Handles custom serialization based on transformers.
+   */
+  public static class CustomSerializer extends JsonSerializer<Object> {
     @Override
     public void serialize(Object value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
-      if (null != encoders && !encoders.isEmpty()) {
-        StringBuilder sb = new StringBuilder();
-        boolean encoded = false;
-        for (JsonEncoder encoder: encoders) {
-          encoded = encoder.addElement(sb, value);
-          if (encoded) {
+      if (null != transformers && !transformers.isEmpty()) {
+        JsonTransformer.TransformationResult transfRes = null;
+        for (JsonTransformer transformer: transformers) {
+          transfRes = transformer.transform(value);
+          if (null != transfRes && transfRes.transformed) {
             break;
           }
         }
-        if (encoded) {
-          gen.writeRaw(sb.toString());
+        if (null != transfRes && transfRes.transformed) {
+          gen.writeObject(transfRes.result);
         } else {
           // No custom encoders able to encode this object, write null.
           gen.writeNull();
@@ -95,20 +92,39 @@ public class JsonUtils {
     }
   }
 
-  public static final NullKeySerializer nullKeySerializer = new NullKeySerializer();
-  public static final CustomEncodersSerializer customEncodersSerializer = new CustomEncodersSerializer();
+  private static final NullKeySerializer NULL_KEY_SERIALIZER = new NullKeySerializer();
+  private static final CustomSerializer CUSTOM_SERIALIZER = new CustomSerializer();
 
   //
   // ObjectMapper instances are thread-safe, so we can safely use a single static instance.
   //
-  private static final ObjectMapper strictMapper;
-  private static final ObjectMapper looseMapper;
+  private static final ObjectMapper STRICT_MAPPER;
+  private static final ObjectMapper LOOSE_MAPPER;
 
-  public interface JsonEncoder {
-    boolean addElement(StringBuilder sb, Object o);
+  public interface JsonTransformer {
+    class TransformationResult {
+      public final boolean transformed;
+      public final Object result;
+
+      public TransformationResult(boolean transformed, Object result) {
+        this.transformed = transformed;
+        this.result = result;
+      }
+    }
+
+    /**
+     * Asks a JsonTransformer implementation if the given object is handled (TransformationResult#transformed=true)
+     * and if it is, the result of the transformation (TransformationResult#result).
+     * This allows the JSON serialization to ask for the conversion of un-serializable objects to serializable ones.
+     * If it is not handled, TransformationResult#result is ignored, so it can be safely set to null.
+     *
+     * @param original
+     * @return
+     */
+    TransformationResult transform(Object original);
   }
 
-  private static List<JsonEncoder> encoders;
+  private static List<JsonTransformer> transformers;
 
   static {
     //
@@ -141,17 +157,17 @@ public class JsonUtils {
     // Configure strict mapper
     //
     builder.enable(JsonWriteFeature.WRITE_NAN_AS_STRINGS);
-    strictMapper = new ObjectMapper(builder.build());
-    strictMapper.getSerializerProvider().setNullKeySerializer(nullKeySerializer);
-    strictMapper.registerModule(module);
+    STRICT_MAPPER = new ObjectMapper(builder.build());
+    STRICT_MAPPER.getSerializerProvider().setNullKeySerializer(NULL_KEY_SERIALIZER);
+    STRICT_MAPPER.registerModule(module);
 
     //
     // Configure loose mapper
     //
     builder.disable(JsonWriteFeature.WRITE_NAN_AS_STRINGS);
-    looseMapper = new ObjectMapper(builder.build());
-    looseMapper.getSerializerProvider().setNullKeySerializer(nullKeySerializer);
-    looseMapper.registerModule(module);
+    LOOSE_MAPPER = new ObjectMapper(builder.build());
+    LOOSE_MAPPER.getSerializerProvider().setNullKeySerializer(NULL_KEY_SERIALIZER);
+    LOOSE_MAPPER.registerModule(module);
   }
 
   //
@@ -159,7 +175,7 @@ public class JsonUtils {
   //
 
   public static Object jsonToObject(String json) throws JsonProcessingException {
-    return strictMapper.readValue(json, Object.class);
+    return STRICT_MAPPER.readValue(json, Object.class);
   }
 
   //
@@ -195,20 +211,25 @@ public class JsonUtils {
 
     try {
       if (isStrict) {
-        strictMapper.writeValue(writer, o);
+        STRICT_MAPPER.writeValue(writer, o);
       } else {
-        looseMapper.writeValue(writer, o);
+        LOOSE_MAPPER.writeValue(writer, o);
       }
     } catch (BoundedWriter.WriterBoundReachedException wbre) {
       throw new IOException("Resulting JSON is too big.", wbre);
     }
   }
 
-  public static synchronized void addEncoder(JsonEncoder encoder) {
-    if (null == encoders) {
-      encoders = new ArrayList<JsonEncoder>();
+  /**
+   * Add a transformer to convert un-serializable objects to serializable ones.
+   *
+   * @param transformer The transformer instance.
+   */
+  public static synchronized void addTransformer(JsonTransformer transformer) {
+    if (null == transformers) {
+      transformers = new ArrayList<JsonTransformer>();
     }
-    encoders.add(encoder);
+    transformers.add(transformer);
   }
 
 }

--- a/warp10/src/main/java/io/warp10/json/JsonUtils.java
+++ b/warp10/src/main/java/io/warp10/json/JsonUtils.java
@@ -80,7 +80,11 @@ public class JsonUtils {
           }
         }
         if (null != transfRes && transfRes.transformed) {
-          gen.writeObject(transfRes.result);
+          if (transfRes.raw && transfRes.result instanceof String) {
+            gen.writeRawValue((String) transfRes.result);
+          } else {
+            gen.writeObject(transfRes.result);
+          }
         } else {
           // No custom encoders able to encode this object, write null.
           gen.writeNull();
@@ -105,10 +109,12 @@ public class JsonUtils {
     class TransformationResult {
       public final boolean transformed;
       public final Object result;
+      public final boolean raw;
 
-      public TransformationResult(boolean transformed, Object result) {
+      public TransformationResult(boolean transformed, Object result, boolean raw) {
         this.transformed = transformed;
         this.result = result;
+        this.raw = raw;
       }
     }
 

--- a/warp10/src/main/java/io/warp10/json/MacroSerializer.java
+++ b/warp10/src/main/java/io/warp10/json/MacroSerializer.java
@@ -17,7 +17,6 @@
 package io.warp10.json;
 
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import io.warp10.script.WarpScriptStack;

--- a/warp10/src/main/java/io/warp10/json/MetadataSerializer.java
+++ b/warp10/src/main/java/io/warp10/json/MetadataSerializer.java
@@ -17,7 +17,6 @@
 package io.warp10.json;
 
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import io.warp10.continuum.store.thrift.data.Metadata;


### PR DESCRIPTION
Current custom JSON serialization is not working and could be more practical.

#798 proposed to expose Jackson API but it is preferable not to in case we want to change the JSON serialization/deserialization library.

This PR changes the current API to register custom serialization, making it simpler to use while not exposing Jackson.
The idea is to allow the registration of "transformers" whose role is to convert un-serializable objects to serializable ones. Typically they will create a Map corresponding to the fields of the Object.

Example of use:
```
JsonUtils.addTransformer(new JsonUtils.JsonTransformer() {
      @Override
      public TransformationResult transform(Object o) {
        if (o instanceof CustomObject) {
          HashMap<String, Object> coRepresentation = new HashMap<String, Object>();
          coRepresentation.put("CustomObject", ((CustomObject) o).children);
          return new TransformationResult(true, coRepresentation);
        } else {
          return new TransformationResult(false, null);
        }
      }
    });
```