### PR TITLE
Add conversion between GeoJSON, WKT and WKB formats

### DIFF
--- a/warp10/src/main/java/io/warp10/script/WarpScriptLib.java
+++ b/warp10/src/main/java/io/warp10/script/WarpScriptLib.java
@@ -368,8 +368,10 @@ public class WarpScriptLib {
   public static final String GEO_WKT_UNIFORM = "GEO.WKT.UNIFORM";
   public static final String GEO_WKB = "GEO.WKB";
   public static final String GEO_WKB_UNIFORM = "GEO.WKB.UNIFORM";
-  
+
   public static final String TOGEOJSON = "->GEOJSON";
+  public static final String TOWKT = "->WKT";
+  public static final String TOWKB = "->WKB";
   public static final String GEO_BUFFER = "GEO.BUFFER";
   public static final String GEO_JSON = "GEO.JSON";
   public static final String GEO_JSON_UNIFORM = "GEO.JSON.UNIFORM";
@@ -1931,6 +1933,8 @@ public class WarpScriptLib {
     addNamedWarpScriptFunction(new GeoJSON(GEO_JSON, false));
     addNamedWarpScriptFunction(new GeoJSON(GEO_JSON_UNIFORM, true));
     addNamedWarpScriptFunction(new TOGEOJSON(TOGEOJSON));
+    addNamedWarpScriptFunction(new TOWKT(TOWKT));
+    addNamedWarpScriptFunction(new TOWKB(TOWKB));
     addNamedWarpScriptFunction(new GEOOPTIMIZE(GEO_OPTIMIZE));
     addNamedWarpScriptFunction(new GEONORMALIZE(GEO_NORMALIZE));
     addNamedWarpScriptFunction(new GEOSHIFT(GEOSHIFT));

--- a/warp10/src/main/java/io/warp10/script/functions/TOGEOJSON.java
+++ b/warp10/src/main/java/io/warp10/script/functions/TOGEOJSON.java
@@ -21,10 +21,17 @@ import com.geoxp.GeoXPLib.GeoXPShape;
 import com.geoxp.geo.Coverage;
 import com.geoxp.geo.CoverageHelper;
 import com.geoxp.geo.HHCodeHelper;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.io.ParseException;
+import com.vividsolutions.jts.io.WKBReader;
+import com.vividsolutions.jts.io.WKTReader;
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptStack;
 import io.warp10.script.WarpScriptStackFunction;
+import org.wololo.geojson.GeoJSON;
+import org.wololo.jts2geojson.GeoJSONReader;
+import org.wololo.jts2geojson.GeoJSONWriter;
 
 public class TOGEOJSON extends NamedWarpScriptFunction implements WarpScriptStackFunction {
 
@@ -41,44 +48,86 @@ public class TOGEOJSON extends NamedWarpScriptFunction implements WarpScriptStac
     if (top instanceof Boolean) {
       allCells = (Boolean) top;
       top = stack.pop();
-    }
 
-    if (!(top instanceof GeoXPShape)) {
-      throw new WarpScriptException(getName() + " operates on a GEOSHAPE.");
-    }
-
-    GeoXPShape shape = (GeoXPShape) top;
-
-    if (allCells) {
-      long[] cells = GeoXPLib.getCells(shape);
-
-      StringBuilder sb = new StringBuilder();
-      sb.append("{\"type\":\"MultiPolygon\",\"coordinates\":[");
-      String prefix = "";
-
-      for (long cell: cells) {
-        int cellRes = ((int) (cell >>> 60)) << 1;
-        long hh = cell << 4;
-        double[] bbox = HHCodeHelper.getHHCodeBBox(hh, cellRes);
-        sb.append(prefix);
-        prefix = ",";
-        // Counterclockwise from sw, lon/lat
-        sb.append("[[[").append(bbox[1]).append(",").append(bbox[0]).append("],");// SW
-        sb.append("[").append(bbox[3]).append(",").append(bbox[0]).append("],"); // SE
-        sb.append("[").append(bbox[3]).append(",").append(bbox[2]).append("],"); // NE
-        sb.append("[").append(bbox[1]).append(",").append(bbox[2]).append("],"); // NW
-        sb.append("[").append(bbox[1]).append(",").append(bbox[0]).append("]]]"); // SW
+      if (!(top instanceof GeoXPShape)) {
+        throw new WarpScriptException(getName() + " operates on a GEOSHAPE when first given a BOOLEAN.");
       }
+    }
 
-      sb.append("]}");
+    if (top instanceof GeoXPShape) {
+      GeoXPShape shape = (GeoXPShape) top;
 
-      stack.push(sb.toString());
+      if (allCells) {
+        long[] cells = GeoXPLib.getCells(shape);
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\"type\":\"MultiPolygon\",\"coordinates\":[");
+        String prefix = "";
+
+        for (long cell: cells) {
+          int cellRes = ((int) (cell >>> 60)) << 1;
+          long hh = cell << 4;
+          double[] bbox = HHCodeHelper.getHHCodeBBox(hh, cellRes);
+          sb.append(prefix);
+          prefix = ",";
+          // Counterclockwise from sw, lon/lat
+          sb.append("[[[").append(bbox[1]).append(",").append(bbox[0]).append("],");// SW
+          sb.append("[").append(bbox[3]).append(",").append(bbox[0]).append("],"); // SE
+          sb.append("[").append(bbox[3]).append(",").append(bbox[2]).append("],"); // NE
+          sb.append("[").append(bbox[1]).append(",").append(bbox[2]).append("],"); // NW
+          sb.append("[").append(bbox[1]).append(",").append(bbox[0]).append("]]]"); // SW
+        }
+
+        sb.append("]}");
+
+        stack.push(sb.toString());
+      } else {
+        long[] cells = GeoXPLib.getCells(shape);
+        Coverage coverage = new Coverage(cells);
+        stack.push(CoverageHelper.toGeoJSON(coverage));
+      }
     } else {
-      long[] cells = GeoXPLib.getCells(shape);
-      Coverage coverage = new Coverage(cells);
-      stack.push(CoverageHelper.toGeoJSON(coverage));
+      try {
+        Geometry geometry = toGeometry(top);
+        GeoJSONWriter writer = new GeoJSONWriter();
+        GeoJSON json = writer.write(geometry);
+        stack.push(json.toString());
+      } catch (WarpScriptException wse) {
+        throw new WarpScriptException(getName() + " expects a GEOSHAPE, a WKT STRING or WKB BYTES.", wse);
+      } catch (ParseException pe) {
+        throw new WarpScriptException(getName() + " was given invalid input.", pe);
+      }
     }
 
     return stack;
+  }
+
+  public static Geometry toGeometry(Object geomObject) throws WarpScriptException, ParseException {
+
+    Geometry geometry;
+
+    if (geomObject instanceof byte[]) {
+      // WKB
+      WKBReader reader = new WKBReader();
+
+      geometry = reader.read((byte[]) geomObject);
+    } else if (geomObject instanceof String) {
+      String geomString = ((String) geomObject).trim();
+      if (geomString.startsWith("{")) {
+        // GeoJson
+        GeoJSONReader reader = new GeoJSONReader();
+
+        geometry = reader.read(geomString);
+      } else {
+        // WKT
+        WKTReader reader = new WKTReader();
+
+        geometry = reader.read(geomString);
+      }
+    } else {
+      throw new WarpScriptException("Unknown geometry format");
+    }
+
+    return geometry;
   }
 }

--- a/warp10/src/main/java/io/warp10/script/functions/TOGEOJSON.java
+++ b/warp10/src/main/java/io/warp10/script/functions/TOGEOJSON.java
@@ -125,7 +125,7 @@ public class TOGEOJSON extends NamedWarpScriptFunction implements WarpScriptStac
         geometry = reader.read(geomString);
       }
     } else {
-      throw new WarpScriptException("Unknown geometry format");
+      throw new WarpScriptException("Unknown geometry format.");
     }
 
     return geometry;

--- a/warp10/src/main/java/io/warp10/script/functions/TOWKB.java
+++ b/warp10/src/main/java/io/warp10/script/functions/TOWKB.java
@@ -1,0 +1,51 @@
+//
+//    Copyright 2020  SenX S.A.S.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+
+package io.warp10.script.functions;
+
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.io.ParseException;
+import com.vividsolutions.jts.io.WKBWriter;
+import io.warp10.script.NamedWarpScriptFunction;
+import io.warp10.script.WarpScriptException;
+import io.warp10.script.WarpScriptStack;
+import io.warp10.script.WarpScriptStackFunction;
+
+public class TOWKB extends NamedWarpScriptFunction implements WarpScriptStackFunction {
+
+  public TOWKB(String name) {
+    super(name);
+  }
+
+  @Override
+  public Object apply(WarpScriptStack stack) throws WarpScriptException {
+    Object geomObject = stack.pop();
+
+    try {
+      Geometry geometry = TOGEOJSON.toGeometry(geomObject);
+      WKBWriter writer = new WKBWriter();
+      byte[] wkb = writer.write(geometry);
+      stack.push(wkb);
+    } catch (WarpScriptException wse) {
+      throw new WarpScriptException(getName() + " expects a GEOSHAPE, a WKT STRING or WKB BYTES.", wse);
+    } catch (
+        ParseException pe) {
+      throw new WarpScriptException(getName() + " was given invalid input.", pe);
+    }
+
+    return stack;
+  }
+}

--- a/warp10/src/main/java/io/warp10/script/functions/TOWKB.java
+++ b/warp10/src/main/java/io/warp10/script/functions/TOWKB.java
@@ -36,7 +36,7 @@ public class TOWKB extends NamedWarpScriptFunction implements WarpScriptStackFun
 
   @Override
   public Object apply(WarpScriptStack stack) throws WarpScriptException {
-    // The the top of the stack is either a GeoXPShape or a Boolean, then we apply GEOJSON to convert it to
+    // The top of the stack is either a GeoXPShape or a Boolean, then we apply GEOJSON to convert it to
     // GeoJSON before converting it to WKB. This is a quick and easy way of converting GeoXPShape to WKB.
     Object peeked = stack.peek();
 

--- a/warp10/src/main/java/io/warp10/script/functions/TOWKB.java
+++ b/warp10/src/main/java/io/warp10/script/functions/TOWKB.java
@@ -16,6 +16,7 @@
 
 package io.warp10.script.functions;
 
+import com.geoxp.GeoXPLib;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.io.ParseException;
 import com.vividsolutions.jts.io.WKBWriter;
@@ -26,12 +27,23 @@ import io.warp10.script.WarpScriptStackFunction;
 
 public class TOWKB extends NamedWarpScriptFunction implements WarpScriptStackFunction {
 
+  private TOGEOJSON togeojson;
+
   public TOWKB(String name) {
     super(name);
+    togeojson = new TOGEOJSON(name);
   }
 
   @Override
   public Object apply(WarpScriptStack stack) throws WarpScriptException {
+    // The the top of the stack is either a GeoXPShape or a Boolean, then we apply GEOJSON to convert it to
+    // GeoJSON before converting it to WKB. This is a quick and easy way of converting GeoXPShape to WKB.
+    Object peeked = stack.peek();
+
+    if (peeked instanceof GeoXPLib.GeoXPShape || peeked instanceof Boolean) {
+      togeojson.apply(stack);
+    }
+
     Object geomObject = stack.pop();
 
     try {

--- a/warp10/src/main/java/io/warp10/script/functions/TOWKT.java
+++ b/warp10/src/main/java/io/warp10/script/functions/TOWKT.java
@@ -16,6 +16,7 @@
 
 package io.warp10.script.functions;
 
+import com.geoxp.GeoXPLib;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.io.ParseException;
 import io.warp10.script.NamedWarpScriptFunction;
@@ -25,12 +26,23 @@ import io.warp10.script.WarpScriptStackFunction;
 
 public class TOWKT extends NamedWarpScriptFunction implements WarpScriptStackFunction {
 
+  private TOGEOJSON togeojson;
+
   public TOWKT(String name) {
     super(name);
+    togeojson = new TOGEOJSON(name);
   }
 
   @Override
   public Object apply(WarpScriptStack stack) throws WarpScriptException {
+    // The the top of the stack is either a GeoXPShape or a Boolean, then we apply GEOJSON to convert it to
+    // GeoJSON before converting it to WKT. This is a quick and easy way of converting GeoXPShape to WKT.
+    Object peeked = stack.peek();
+
+    if (peeked instanceof GeoXPLib.GeoXPShape || peeked instanceof Boolean) {
+      togeojson.apply(stack);
+    }
+
     Object geomObject = stack.pop();
 
     try {

--- a/warp10/src/main/java/io/warp10/script/functions/TOWKT.java
+++ b/warp10/src/main/java/io/warp10/script/functions/TOWKT.java
@@ -1,0 +1,48 @@
+//
+//    Copyright 2020  SenX S.A.S.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+
+package io.warp10.script.functions;
+
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.io.ParseException;
+import io.warp10.script.NamedWarpScriptFunction;
+import io.warp10.script.WarpScriptException;
+import io.warp10.script.WarpScriptStack;
+import io.warp10.script.WarpScriptStackFunction;
+
+public class TOWKT extends NamedWarpScriptFunction implements WarpScriptStackFunction {
+
+  public TOWKT(String name) {
+    super(name);
+  }
+
+  @Override
+  public Object apply(WarpScriptStack stack) throws WarpScriptException {
+    Object geomObject = stack.pop();
+
+    try {
+      Geometry geometry = TOGEOJSON.toGeometry(geomObject);
+
+      stack.push(geometry.toText());
+    } catch (WarpScriptException wse) {
+      throw new WarpScriptException(getName() + " expects a GEOSHAPE, a WKT STRING or WKB BYTES.", wse);
+    } catch (ParseException pe) {
+      throw new WarpScriptException(getName() + " was given invalid input.", pe);
+    }
+
+    return stack;
+  }
+}

--- a/warp10/src/main/java/io/warp10/script/functions/TOWKT.java
+++ b/warp10/src/main/java/io/warp10/script/functions/TOWKT.java
@@ -35,7 +35,7 @@ public class TOWKT extends NamedWarpScriptFunction implements WarpScriptStackFun
 
   @Override
   public Object apply(WarpScriptStack stack) throws WarpScriptException {
-    // The the top of the stack is either a GeoXPShape or a Boolean, then we apply GEOJSON to convert it to
+    // The top of the stack is either a GeoXPShape or a Boolean, then we apply GEOJSON to convert it to
     // GeoJSON before converting it to WKT. This is a quick and easy way of converting GeoXPShape to WKT.
     Object peeked = stack.peek();
 


### PR DESCRIPTION
Modifies ->GEOJSON to convert WKT and WKB to GEOJSON.

Adds ->WKT and ->WKB to convert GEOJSON, WKT and WKB to WKT and WKB respectively.

For now, ->WKT and ->WKB cannot convert a GEOSHAPE to WKT and WKB. Three solutions:
- We leave as it is, it the user want to do that, he/she converts first to GEOJSON and then to WKT/WKB
- ->WKT and ->WKB function internally convert to GEOJSON and then to the desired output format (easier for the user)
- Add methods in GeoXPLib to convert a Coverage to WKT or WKB (this one is trickier) and use that in the fonctions.