### PR TITLE
Fix and simplify condition for shrink in GTSHelper#chunk

### DIFF
--- a/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
+++ b/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
@@ -8525,11 +8525,7 @@ public class GTSHelper {
       // This will slow down the overlap computation but will save memory.
       //
       
-      if (0 == chunkgts.values) {
-        GTSHelper.shrink(chunkgts);
-      } else if (overlap <= 0 && gts.values > 0 && chunkgts.ticks.length - chunkgts.values > 0) {
-        GTSHelper.shrink(chunkgts);
-      } else if (overlap > 0 && chunkgts.values > 0 && chunkgts.ticks.length - chunkgts.values > 2 * overlaphint) {
+      if (0 == chunkgts.values || chunkgts.ticks.length - chunkgts.values > 2 * overlaphint) {
         GTSHelper.shrink(chunkgts);
       }
       


### PR DESCRIPTION
Original code is
```
      if (0 == chunkgts.values) {
        GTSHelper.shrink(chunkgts);
      } else if (overlap <= 0 && gts.values > 0 && chunkgts.ticks.length - chunkgts.values > 0) {
        GTSHelper.shrink(chunkgts);
      } else if (overlap > 0 && chunkgts.values > 0 && chunkgts.ticks.length - chunkgts.values > 2 * overlaphint) {
        GTSHelper.shrink(chunkgts);
      }
```

Fix `gts.values` to `chunkgts.values`

When `overlap <= 0`, we have `0 == overlaphint` so we can convert the code above to
```
      if (0 == chunkgts.values) {
        GTSHelper.shrink(chunkgts);
      } else if (overlap <= 0 && chunkgts.values > 0 && chunkgts.ticks.length - chunkgts.values > 2 * overlaphint) {
        GTSHelper.shrink(chunkgts);
      } else if (overlap > 0 && chunkgts.values > 0 && chunkgts.ticks.length - chunkgts.values > 2 * overlaphint) {
        GTSHelper.shrink(chunkgts);
      }
```

We can then remove the condition on `overlap` and also the condition on `chunkgts.values` because it is non-negative and in the `else` of `if (0 == chunkgts.values)`.

Then we can simplify to the version proposed by this PR.