### PR TITLE
Remove unused keys in keystore

### DIFF
--- a/crypto/src/main/java/io/warp10/crypto/KeyStore.java
+++ b/crypto/src/main/java/io/warp10/crypto/KeyStore.java
@@ -105,11 +105,6 @@ public interface KeyStore {
   public static final String SIPHASH_KAFKA_PLASMA_FRONTEND_IN = "warp.siphash.kafka.plasma.frontend.in";
 
   /**
-   * Name of key for computing MAC for kafka messages produced by plasma frontends
-   */
-  public static final String SIPHASH_KAFKA_PLASMA_FRONTEND_OUT = "warp.siphash.kafka.plasma.frontend.out";
-
-  /**
    * Name of key for computing MAC for WebCall requests in Kafka
    */
   public static final String SIPHASH_KAFKA_WEBCALL = "warp.siphash.kafka.webcall";
@@ -123,11 +118,6 @@ public interface KeyStore {
    * Name of key for computing MAC for fetch requests
    */
   public static final String SIPHASH_FETCH_PSK = "warp.siphash.fetch.psk";
-
-  /**
-   * Name of key for wrapping kafka run requests
-   */
-  public static final String AES_KAFKA_RUNNER = "warp.aes.kafka.runner";
 
   /**
    * Name of key for wrapping kafka data messages
@@ -153,11 +143,6 @@ public interface KeyStore {
    * Name of key for wrapping kafka messages consumed by plasma frontends
    */
   public static final String AES_KAFKA_PLASMA_FRONTEND_IN = "warp.aes.kafka.plasma.frontend.in";
-
-  /**
-   * Name of key for wrapping kafka messages produced by plasma frontends
-   */
-  public static final String AES_KAFKA_PLASMA_FRONTEND_OUT = "warp.aes.kafka.plasma.frontend.out";
 
   /**
    * Name of key for wrapping WebCall requests in Kafka

--- a/warp10/src/main/java/io/warp10/script/ScriptRunner.java
+++ b/warp10/src/main/java/io/warp10/script/ScriptRunner.java
@@ -845,7 +845,6 @@ public class ScriptRunner extends Thread {
   }
 
   private void extractKeys(Properties props) {
-    KeyStore.checkAndSetKey(keystore, KeyStore.AES_KAFKA_RUNNER, props, Configuration.RUNNER_KAFKA_AES, 128, 192, 256);
     KeyStore.checkAndSetKey(keystore, KeyStore.SIPHASH_KAFKA_RUNNER, props, Configuration.RUNNER_KAFKA_MAC, 128);
 
     this.keystore.forget();


### PR DESCRIPTION
`SIPHASH_KAFKA_PLASMA_FRONTEND_OUT` and `AES_KAFKA_PLASMA_FRONTEND_OUT` are not used because Plasma FE does not produce anything on Kafka.

`AES_KAFKA_RUNNER` is not used because the key which is really used is called `RUNNER_PSK`.