### PR TITLE
Fix comparator to behave correctly with NaN and -0.0

### DIFF
--- a/warp10/src/main/java/io/warp10/script/functions/SORTBY.java
+++ b/warp10/src/main/java/io/warp10/script/functions/SORTBY.java
@@ -185,13 +185,7 @@ public class SORTBY extends NamedWarpScriptFunction implements WarpScriptStackFu
       comparator = new Comparator<Integer>() {
         @Override
         public int compare(Integer i1, Integer i2) {
-          if (lvalues[i1] < lvalues[i2]) {
-            return -1;
-          } else if (lvalues[i1] > lvalues[i2]) {
-            return 1;
-          } else {
-            return 0;
-          }
+          return Long.compare(lvalues[i1], lvalues[i2]);
         }
       };
     } else if ("DOUBLE".equals(valtype)) {
@@ -200,13 +194,7 @@ public class SORTBY extends NamedWarpScriptFunction implements WarpScriptStackFu
       comparator = new Comparator<Integer>() {
         @Override
         public int compare(Integer i1, Integer i2) {
-          if (dvalues[i1] < dvalues[i2]) {
-            return -1;
-          } else if (dvalues[i1] > dvalues[i2]) {
-            return 1;
-          } else {
-            return 0;
-          }
+          return Double.compare(dvalues[i1], dvalues[i2]);
         }
       };
     } else if ("STRING".equals(valtype)) {


### PR DESCRIPTION
The current logic with doubles fails with NaN or -0.0.
Also simplifies the code for longs.

The script
```
[
  0.0
  NaN
  -1.0
  1.0
  -0.0
]
<% %>
SORTBY

[
  0.0
  NaN
  -1.0
  1.0
  -0.0
]
LSORT
```

Returns before PR
`[[-1.0,-0.0,0.0,1.0,NaN],[0.0,NaN,-1.0,-0.0,1.0]]`
and after PR:
`[[-1.0,-0.0,0.0,1.0,NaN],[-1.0,-0.0,0.0,1.0,NaN]]`