### PR TITLE
Add streamDelimiter parameter to HTTP definitions to stream the POST payload to the macro

### DIFF
--- a/warp10/src/main/java/io/warp10/plugins/http/HTTPWarp10Plugin.java
+++ b/warp10/src/main/java/io/warp10/plugins/http/HTTPWarp10Plugin.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2020  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.

--- a/warp10/src/main/java/io/warp10/plugins/http/HTTPWarp10Plugin.java
+++ b/warp10/src/main/java/io/warp10/plugins/http/HTTPWarp10Plugin.java
@@ -112,7 +112,7 @@ public class HTTPWarp10Plugin extends AbstractWarp10Plugin implements Runnable {
   /**
    * Map of uri to stream delimiter.
    */
-  private Map<String, Byte> streamDelimiter = new HashMap<String, Byte>();
+  private Map<String, Byte> streamDelimiters = new HashMap<String, Byte>();
 
   /**
    * Map of filename to uri
@@ -248,7 +248,7 @@ public class HTTPWarp10Plugin extends AbstractWarp10Plugin implements Runnable {
           String uri = uris.remove(spec);
           this.macros.remove(uri);
           this.parsePayloads.remove(uri);
-          this.streamDelimiter.remove(uri);
+          this.streamDelimiters.remove(uri);
           this.sizes.remove(spec);
           this.prefixes.remove(uri);
         }
@@ -259,7 +259,7 @@ public class HTTPWarp10Plugin extends AbstractWarp10Plugin implements Runnable {
         for (String uri: inactiveURIs) {
           this.macros.remove(uri);
           this.parsePayloads.remove(uri);
-          this.streamDelimiter.remove(uri);
+          this.streamDelimiters.remove(uri);
           this.prefixes.remove(uri);
         }        
       } catch (Throwable t) {
@@ -318,7 +318,7 @@ public class HTTPWarp10Plugin extends AbstractWarp10Plugin implements Runnable {
       if (null != oldpath) {
         this.macros.remove(oldpath);
         this.parsePayloads.remove(oldpath);
-        this.streamDelimiter.remove(oldpath);
+        this.streamDelimiters.remove(oldpath);
         this.prefixes.remove(oldpath);
       }
       this.macros.put(String.valueOf(config.get(PARAM_PATH)), (Macro) config.get(PARAM_MACRO));
@@ -328,7 +328,7 @@ public class HTTPWarp10Plugin extends AbstractWarp10Plugin implements Runnable {
         if (delimiter.length > 1) {
           throw new RuntimeException("Stream delimiter must be one byte long.");
         }
-        this.streamDelimiter.put(String.valueOf(config.get(PARAM_PATH)), delimiter[0]);
+        this.streamDelimiters.put(String.valueOf(config.get(PARAM_PATH)), delimiter[0]);
       }
       if (Boolean.TRUE.equals(config.get(PARAM_PREFIX))) {
         prefixes.add(String.valueOf(config.get(PARAM_PATH)));
@@ -411,7 +411,7 @@ public class HTTPWarp10Plugin extends AbstractWarp10Plugin implements Runnable {
   }
 
   public Byte streamDelimiter(String uri) {
-    return this.streamDelimiter.get(uri);
+    return this.streamDelimiters.get(uri);
   }
   
   public boolean isLcHeaders() {

--- a/warp10/src/main/java/io/warp10/plugins/http/HTTPWarp10Plugin.java
+++ b/warp10/src/main/java/io/warp10/plugins/http/HTTPWarp10Plugin.java
@@ -57,6 +57,7 @@ public class HTTPWarp10Plugin extends AbstractWarp10Plugin implements Runnable {
   private static final String PARAM_MACRO = "macro";
   private static final String PARAM_PREFIX = "prefix";
   private static final String PARAM_PARSE_PAYLOAD = "parsePayload";
+  private static final String PARAM_STREAMS_DELIMITER = "streamDelimiter";
 
   private static final String CONF_HTTP_HOST = "http.host";
   private static final String CONF_HTTP_PORT = "http.port";
@@ -107,6 +108,11 @@ public class HTTPWarp10Plugin extends AbstractWarp10Plugin implements Runnable {
    * Map of uri to parse payloads
    */
   private Map<String, Boolean> parsePayloads = new HashMap<String, Boolean>();
+
+  /**
+   * Map of uri to stream delimiter.
+   */
+  private Map<String, Byte> streamDelimiter = new HashMap<String, Byte>();
 
   /**
    * Map of filename to uri
@@ -242,6 +248,7 @@ public class HTTPWarp10Plugin extends AbstractWarp10Plugin implements Runnable {
           String uri = uris.remove(spec);
           this.macros.remove(uri);
           this.parsePayloads.remove(uri);
+          this.streamDelimiter.remove(uri);
           this.sizes.remove(spec);
           this.prefixes.remove(uri);
         }
@@ -252,6 +259,7 @@ public class HTTPWarp10Plugin extends AbstractWarp10Plugin implements Runnable {
         for (String uri: inactiveURIs) {
           this.macros.remove(uri);
           this.parsePayloads.remove(uri);
+          this.streamDelimiter.remove(uri);
           this.prefixes.remove(uri);
         }        
       } catch (Throwable t) {
@@ -310,10 +318,18 @@ public class HTTPWarp10Plugin extends AbstractWarp10Plugin implements Runnable {
       if (null != oldpath) {
         this.macros.remove(oldpath);
         this.parsePayloads.remove(oldpath);
+        this.streamDelimiter.remove(oldpath);
         this.prefixes.remove(oldpath);
       }
       this.macros.put(String.valueOf(config.get(PARAM_PATH)), (Macro) config.get(PARAM_MACRO));
       this.parsePayloads.put(String.valueOf(config.get(PARAM_PATH)), (Boolean) config.getOrDefault(PARAM_PARSE_PAYLOAD, true));
+      byte[] delimiter = ((byte[]) config.getOrDefault(PARAM_STREAMS_DELIMITER, null));
+      if (null != delimiter) {
+        if (delimiter.length > 1) {
+          throw new RuntimeException("Stream delimiter must be one byte long.");
+        }
+        this.streamDelimiter.put(String.valueOf(config.get(PARAM_PATH)), delimiter[0]);
+      }
       if (Boolean.TRUE.equals(config.get(PARAM_PREFIX))) {
         prefixes.add(String.valueOf(config.get(PARAM_PATH)));
       }
@@ -392,6 +408,10 @@ public class HTTPWarp10Plugin extends AbstractWarp10Plugin implements Runnable {
 
   public boolean isParsePayload(String uri) {
     return this.parsePayloads.get(uri);
+  }
+
+  public Byte streamDelimiter(String uri) {
+    return this.streamDelimiter.get(uri);
   }
   
   public boolean isLcHeaders() {

--- a/warp10/src/main/java/io/warp10/plugins/http/WarpScriptHandler.java
+++ b/warp10/src/main/java/io/warp10/plugins/http/WarpScriptHandler.java
@@ -16,13 +16,16 @@
 package io.warp10.plugins.http;
 
 import io.warp10.WarpConfig;
+import io.warp10.continuum.store.DirectoryClient;
+import io.warp10.continuum.store.StoreClient;
 import io.warp10.script.MemoryWarpScriptStack;
 import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptStack;
 import io.warp10.script.WarpScriptStack.Macro;
 import io.warp10.script.WarpScriptStackRegistry;
-
+import io.warp10.warp.sdk.AbstractWarp10Plugin;
 import org.apache.commons.io.IOUtils;
+import org.apache.http.entity.ContentType;
 import org.eclipse.jetty.http.MimeTypes;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.AbstractHandler;
@@ -30,7 +33,9 @@ import org.eclipse.jetty.server.handler.AbstractHandler;
 import javax.servlet.DispatcherType;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.util.ArrayList;
@@ -42,21 +47,26 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.UUID;
+import java.util.zip.GZIPInputStream;
 
 public class WarpScriptHandler extends AbstractHandler {
 
   private final HTTPWarp10Plugin plugin;
   private final Properties properties;
+  private final StoreClient storeClient;
+  private final DirectoryClient directoryClient;
 
   public WarpScriptHandler(HTTPWarp10Plugin plugin) {
     this.plugin = plugin;
     this.properties = WarpConfig.getProperties();
+    this.storeClient = AbstractWarp10Plugin.getExposedStoreClient();
+    this.directoryClient = AbstractWarp10Plugin.getExposedDirectoryClient();
   }
 
   @Override
   public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException {
     // Only handle REQUEST
-    if(DispatcherType.REQUEST != baseRequest.getDispatcherType()){
+    if (DispatcherType.REQUEST != baseRequest.getDispatcherType()) {
       baseRequest.setHandled(true);
       return;
     }
@@ -70,7 +80,7 @@ public class WarpScriptHandler extends AbstractHandler {
 
     baseRequest.setHandled(true);
 
-    MemoryWarpScriptStack stack = new MemoryWarpScriptStack(HTTPWarp10Plugin.getExposedStoreClient(), HTTPWarp10Plugin.getExposedDirectoryClient(), this.properties);
+    MemoryWarpScriptStack stack = new MemoryWarpScriptStack(this.storeClient, this.directoryClient, this.properties);
 
     try {
       WarpConfig.setThreadProperty(WarpConfig.THREAD_PROPERTY_SESSION, UUID.randomUUID().toString());
@@ -103,14 +113,29 @@ public class WarpScriptHandler extends AbstractHandler {
       }
       params.put("headers", headers);
 
-      // Get the payload if the content-type is not application/x-www-form-urlencoded or we do not want to parse the payload
-      if (!MimeTypes.Type.FORM_ENCODED.is(request.getContentType()) || !plugin.isParsePayload(prefix)) {
-        byte[] payload = IOUtils.toByteArray(request.getInputStream());
-        if (0 < payload.length) {
-          params.put("payload", payload);
+      // We have to get the input stream before getting the parameters, else we won't be able to read it!
+      InputStream inputStream = null;
+
+      // The input stream is handled very differently if the WarpScript is expecting a splitted stream or not.
+      if (null == plugin.streamDelimiter(prefix)) {
+        // Get the payload if the content-type is not application/x-www-form-urlencoded or we do not want to parse the payload
+        if ((!MimeTypes.Type.FORM_ENCODED.is(request.getContentType()) || !plugin.isParsePayload(prefix))) {
+          // Ready all the stream and store the payload.
+          byte[] payload = IOUtils.toByteArray(request.getInputStream());
+          if (0 < payload.length) {
+            params.put("payload", payload);
+          }
+        }
+      } else {
+        // The input stream will be splitted and given to the macro later.
+        if (null != request.getHeader("Content-Type") && "application/gzip".equals(request.getHeader("Content-Type"))) {
+          inputStream = new GZIPInputStream(request.getInputStream());
+        } else {
+          inputStream = request.getInputStream();
         }
       }
 
+      // Get the parameters in the URL and payload if we want to parse the x-www-form-urlencoded payload.
       Map<String, List<String>> httpparams = new HashMap<String, List<String>>();
       Map<String, String[]> pmap = request.getParameterMap();
       for (Entry<String, String[]> param: pmap.entrySet()) {
@@ -119,8 +144,51 @@ public class WarpScriptHandler extends AbstractHandler {
       params.put("params", httpparams);
 
       try {
-        stack.push(params);
-        stack.exec(macro);
+        if (null == plugin.streamDelimiter(prefix)) {
+          // Not streaming, only push params and exec the macro.
+          stack.push(params);
+          stack.exec(macro);
+        } else {
+          Byte splitByte = plugin.streamDelimiter(prefix);
+          ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+          int readCount;
+          byte[] buffer = new byte[1024];
+
+          // Read the stream by chunks until end of stream.
+          while ((readCount = inputStream.read(buffer)) != -1) {
+            int offset = 0;
+
+            // Split the chunk.
+            while (true) {
+              int indexOfSplit = indexOf(buffer, splitByte, offset, readCount);
+              if (-1 == indexOfSplit) {
+                // No delimiter found, add to output stream and continue reading the input stream.
+                outputStream.write(buffer, offset, readCount - offset);
+                break;
+              } else {
+                // Delimiter found, add split to output stream, which may not be empty because of code above.
+                outputStream.write(buffer, offset, indexOfSplit - offset);
+
+                // Push params, payload and execute macro.
+                stack.push(params);
+                stack.push(outputStream.toByteArray());
+                stack.exec(macro);
+
+                // Empty output stream.
+                outputStream.reset();
+              }
+
+              // Update offet, add 1 to also ignore delimiter.
+              offset = indexOfSplit + 1;
+            }
+          }
+
+          // End of stream, push null payload.
+          stack.push(params);
+          stack.push(null);
+          stack.exec(macro);
+        }
 
         Object top = stack.pop();
 
@@ -166,10 +234,19 @@ public class WarpScriptHandler extends AbstractHandler {
         }
       } catch (WarpScriptException wse) {
         throw new IOException(wse);
-      }      
+      }
     } finally {
       WarpConfig.clearThreadProperties();
       WarpScriptStackRegistry.unregister(stack);
-    }    
+    }
+  }
+
+  private static int indexOf(byte[] array, byte target, int start, int end) {
+    for (int i = start; i < end; i++) {
+      if (array[i] == target) {
+        return i;
+      }
+    }
+    return -1;
   }
 }

--- a/warp10/src/main/java/io/warp10/plugins/http/WarpScriptHandler.java
+++ b/warp10/src/main/java/io/warp10/plugins/http/WarpScriptHandler.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2020  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ import io.warp10.script.WarpScriptStack.Macro;
 import io.warp10.script.WarpScriptStackRegistry;
 import io.warp10.warp.sdk.AbstractWarp10Plugin;
 import org.apache.commons.io.IOUtils;
-import org.apache.http.entity.ContentType;
 import org.eclipse.jetty.http.MimeTypes;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.AbstractHandler;


### PR DESCRIPTION
On 100s MB files, there is no noticeable difference in speed between the previous method (all the data in the request payload) and the stream method. However, the memory consumption of the stream method is, as expected, lower.

Example of a script to read [IBTrACS](https://www.ncdc.noaa.gov/ibtracs/) CSV files by splitting the stream on new lines.

```
{
  'path' '/ibtracs'
  'prefix' false
  'streamDelimiter' '%0A' 'UTF-8' ->BYTES
  'macro' 
  <% 
    'payload' STORE
    'request' STORE

    $payload ISNULL NOT
    <% 
    $payload 'UTF-8' BYTES->
    'row' STORE

      <%
        $row ',' 13 SPLIT
        'row_split' STORE
        
        $row_split 0 GET 'id' STORE

        $row_split 6 GET TRIM ' ' 'T' REPLACE 'z' +
        TOTIMESTAMP 'ts' STORE

        $row_split 8 GET TODOUBLE 'lat' STORE
        $row_split 9 GET TODOUBLE 'lon' STORE

        $row_split 10 GET TRIM
        DUP SIZE 0 >
        <% TODOUBLE %>
        <% DROP -1 %>
        IFTE
        'wind' STORE

        $row_split 11 GET TRIM
        DUP SIZE 0 >
        <% TODOUBLE %>
        <% DROP -1 %>
        IFTE
        'pressure' STORE

        T 'valid_input' STORE
      %>
      <%
        // Ingore invalid input
        F 'valid_input' STORE
      %>
      <% %>
      TRY
      
      $valid_input
      <%
        // Last id is stored in register 0
        PUSHR0 $id !=
        <%
          // No previous encoders or current encoder is for another id
          PUSHR0 ISNULL NOT
          <%
            // Pool of encoders stored in register 1.
            PUSHR1 ISNULL
            <% [] POPR1 %>
            IFT

            PUSHR1
            $wind_encoder +! 
            $pressure_encoder +!
            
            SIZE 1000 > // UPDATE every 1000 encoders
            <%
              PUSHR1 $request 'params' GET 'token' GET 0 GET UPDATE
              [] POPR1
            %>
            IFT
          %>
          <%
            $request 'params' GET 'token' GET 0 GET
            'token' STORE
          %>
          IFTE

          $row_split 5 GET 'name' STORE 

          NEWENCODER
          'stream.wind' RENAME
          { 'id' $id } RELABEL
          { 'name' $name } SETATTRIBUTES
          'wind_encoder' STORE
          NEWENCODER
          'stream.pressure' RENAME
          { 'id' $id } RELABEL
          { 'name' $name } SETATTRIBUTES
          'pressure_encoder' STORE

          $id POPR0
        %>
        IFT

        $wind_encoder
        $ts $lat $lon NaN $wind ADDVALUE
        DROP

        $pressure_encoder
        $ts $lat $lon NaN $pressure ADDVALUE
        DROP
      %>
      IFT
    %>
    <%
      PUSHR1 $request 'params' GET 'token' GET 0 GET UPDATE

      {
        'status' 200
      } 
    %>
    IFTE
  %>
  ASREGS
}
```