### PR TITLE
Add SHMDEFINED which tells if a symbol is defined in SHM

### DIFF
--- a/warp10/src/main/java/io/warp10/script/ext/shm/SHMDEFINED.java
+++ b/warp10/src/main/java/io/warp10/script/ext/shm/SHMDEFINED.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2020  SenX S.A.S.
+//   Copyright 2020  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ public class SHMDEFINED extends NamedWarpScriptFunction implements WarpScriptSta
     Object top = stack.pop();
     
     if (!(top instanceof String)) {
-      throw new WarpScriptException(getName() + " expects a symbol name on top of the stack.");
+      throw new WarpScriptException(getName() + " expects a symbol name.");
     }
 
     String symbol = (String) top;

--- a/warp10/src/main/java/io/warp10/script/ext/shm/SHMDEFINED.java
+++ b/warp10/src/main/java/io/warp10/script/ext/shm/SHMDEFINED.java
@@ -16,45 +16,27 @@
 
 package io.warp10.script.ext.shm;
 
-import java.util.concurrent.locks.ReentrantLock;
-
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptStack;
 import io.warp10.script.WarpScriptStackFunction;
 
-public class SHMSTORE extends NamedWarpScriptFunction implements WarpScriptStackFunction {
-  public SHMSTORE(String name) {
+public class SHMDEFINED extends NamedWarpScriptFunction implements WarpScriptStackFunction {
+  public SHMDEFINED(String name) {
     super(name);
   }
 
   @Override
-  public Object apply(WarpScriptStack stack) throws WarpScriptException {    
-    Object mutexo = stack.getAttribute(MUTEX.MUTEX_ATTRIBUTE + stack.getUUID());
-    
-    if (null == mutexo) {
-      throw new WarpScriptException(getName() + " can only be called when in a MUTEX section.");
-    }
-    
-    String mutex = String.valueOf(mutexo);
-    
+  public Object apply(WarpScriptStack stack) throws WarpScriptException {
     Object top = stack.pop();
     
     if (!(top instanceof String)) {
       throw new WarpScriptException(getName() + " expects a symbol name on top of the stack.");
     }
-    
+
     String symbol = (String) top;
     
-    top = stack.pop();
-    
-    ReentrantLock lock = SharedMemoryWarpScriptExtension.getLock(mutex);
-    
-    if (!lock.isHeldByCurrentThread()) {
-      throw new WarpScriptException(getName() + " expects the mutex '" + mutex + "' to be held when calling " + getName());
-    }
-    
-    SharedMemoryWarpScriptExtension.store(symbol, mutex, top);
+    stack.push(SharedMemoryWarpScriptExtension.defined(symbol));
 
     return stack;
   }

--- a/warp10/src/main/java/io/warp10/script/ext/shm/SHMLOAD.java
+++ b/warp10/src/main/java/io/warp10/script/ext/shm/SHMLOAD.java
@@ -31,7 +31,7 @@ public class SHMLOAD extends NamedWarpScriptFunction implements WarpScriptStackF
     Object top = stack.pop();
     
     if (!(top instanceof String)) {
-      throw new WarpScriptException(getName() + " expects a symbol name on top of the stack.");
+      throw new WarpScriptException(getName() + " expects a symbol name.");
     }
     
     String symbol = (String) top;

--- a/warp10/src/main/java/io/warp10/script/ext/shm/SHMLOAD.java
+++ b/warp10/src/main/java/io/warp10/script/ext/shm/SHMLOAD.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2020  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ public class SHMLOAD extends NamedWarpScriptFunction implements WarpScriptStackF
       throw new WarpScriptException(getName() + " expects a symbol name on top of the stack.");
     }
     
-    String symbol = String.valueOf(top);
+    String symbol = (String) top;
     
     stack.push(SharedMemoryWarpScriptExtension.load(symbol));
 

--- a/warp10/src/main/java/io/warp10/script/ext/shm/SHMSTORE.java
+++ b/warp10/src/main/java/io/warp10/script/ext/shm/SHMSTORE.java
@@ -41,7 +41,7 @@ public class SHMSTORE extends NamedWarpScriptFunction implements WarpScriptStack
     Object top = stack.pop();
     
     if (!(top instanceof String)) {
-      throw new WarpScriptException(getName() + " expects a symbol name on top of the stack.");
+      throw new WarpScriptException(getName() + " expects a symbol name.");
     }
     
     String symbol = (String) top;


### PR DESCRIPTION
Currently, to check if a SHM symbol exists, we have to use `SHMLOAD` and `TRY` to catch the exception if the symbol is not defined. This strategy has to be used everywhere as the symbol may have expired because of the TTL.

This "better ask for forgiveness than permission" method is usually not the way to go in Java and thus in WarpScript. `SHMDEFINED` used in conjunction with `IFT` fixes that. When the symbol does not exist, this method is ~5x faster, when it exists, it is marginally slower.