### PR TITLE
Fix concurrency in StandaloneDirectoryClient

### DIFF
--- a/warp10/src/main/java/io/warp10/standalone/StandaloneDirectoryClient.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneDirectoryClient.java
@@ -119,10 +119,20 @@ public class StandaloneDirectoryClient implements DirectoryClient {
   private static final Comparator<String> CLASS_COMPARATOR = new Comparator<String>() {
     @Override
     public int compare(String o1, String o2) {
-      long id1 = classids.get(o1);
-      long id2 = classids.get(o2);
+      Long id1 = classids.get(o1);
+      Long id2 = classids.get(o2);
 
-      return Directory.ID_COMPARATOR.compare(id1, id2);
+      // A key may be missing during a find if a concurrent unregister is done.
+      if (null == id1) {
+        if (null == id2) {
+          return 0;
+        }
+        return -1;
+      } else if (null == id2) {
+        return 1;
+      } else {
+        return Directory.ID_COMPARATOR.compare(id1, id2);
+      }
     }
   };
 

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneDirectoryClient.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneDirectoryClient.java
@@ -605,7 +605,7 @@ public class StandaloneDirectoryClient implements DirectoryClient {
     } else {
       return (List<Metadata>) metadatas;
     }
-  };
+  }
 
   public void register(Metadata metadata) throws IOException {
 
@@ -681,19 +681,22 @@ public class StandaloneDirectoryClient implements DirectoryClient {
     }
   }
 
-  public synchronized void unregister(Metadata metadata) {
-    if (!classids.containsKey(metadata.getName())) {
-      return;
-    }
+  public void unregister(Metadata metadata) {
     // 128BITS
     long labelsId = GTSHelper.labelsId(this.labelsLongs, metadata.getLabels());
-    if (!metadatas.get(metadata.getName()).containsKey(labelsId)) {
-      return;
-    }
-    metadatas.get(metadata.getName()).remove(labelsId);
-    if (metadatas.get(metadata.getName()).isEmpty()) {
-      metadatas.remove(metadata.getName());
-      classids.remove(metadata.getName());
+
+    synchronized (metadatas) {
+      if (!classids.containsKey(metadata.getName())) {
+        return;
+      }
+      if (!metadatas.get(metadata.getName()).containsKey(labelsId)) {
+        return;
+      }
+      metadatas.get(metadata.getName()).remove(labelsId);
+      if (metadatas.get(metadata.getName()).isEmpty()) {
+        metadatas.remove(metadata.getName());
+        classids.remove(metadata.getName());
+      }
     }
 
     String app = metadata.getLabels().get(Constants.APPLICATION_LABEL);

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneDirectoryClient.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneDirectoryClient.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -112,7 +113,7 @@ public class StandaloneDirectoryClient implements DirectoryClient {
   private long LIMIT_CLASS_CARDINALITY = 100;
   private long LIMIT_LABELS_CARDINALITY = 100;
 
-  private static final Map<String,Long> classids = new HashMap<String,Long>();
+  private static final Map<String,Long> classids = new ConcurrentHashMap<String,Long>();
 
 
   private static final Comparator<String> CLASS_COMPARATOR = new Comparator<String>() {

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneDirectoryClient.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneDirectoryClient.java
@@ -707,14 +707,16 @@ public class StandaloneDirectoryClient implements DirectoryClient {
   }
 
   public void unregister(Metadata metadata) {
+    // Always compute the labelsId, even if the method early returns before needing it. This is because this operation
+    // can be CPU-intensive and if done inside the synchronized(metadatas) block, would block other threads also
+    // synchronizing on metadatas. As unregistering unknown metadata should be rare, this is an acceptable compromise.
     // 128BITS
-    long labelsId;
+    long labelsId = GTSHelper.labelsId(this.labelsLongs, metadata.getLabels());
 
     synchronized(metadatas) {
       if (!classids.containsKey(metadata.getName())) {
         return;
       }
-      labelsId = GTSHelper.labelsId(this.labelsLongs, metadata.getLabels());
       if (!metadatas.get(metadata.getName()).containsKey(labelsId)) {
         return;
       }


### PR DESCRIPTION
`classids` was a `HashMap` which is not thread safe although it is accessed by several threads. In particular, it resulted in `CLASS_COMPARATOR` to fail with NPE because the `get` couldn't find the key because of a concurrent `put`.

Also `unregister` is not synchronized anymore because it was the only synchronized method and no synchronization on `this` was done. On the contrary, critical parts are synchronized on `metadatas`, so the critical part in `unregister` is now synchronized on `metadatas` as well.