### PR TITLE
Precise error message when conf files contain invalid lines, fixes #872

### DIFF
--- a/warp10/src/main/java/io/warp10/WarpDist.java
+++ b/warp10/src/main/java/io/warp10/WarpDist.java
@@ -96,15 +96,25 @@ public class WarpDist {
   }
  
   public static void setProperties(String[] files) throws IOException {
-    WarpConfig.setProperties(files);
-    
-    properties = WarpConfig.getProperties();    
+    try {
+      WarpConfig.setProperties(false, files);
+
+      properties = WarpConfig.getProperties();
+    } catch (Throwable t) {
+      System.err.println(ThrowableUtils.getErrorMessage(t));
+      System.exit(-1);
+    }
   }
   
   public static void setProperties(String file) throws IOException {
-    WarpConfig.setProperties(file);
-    
-    properties = WarpConfig.getProperties();
+    try {
+      WarpConfig.setProperties(false, file);
+
+      properties = WarpConfig.getProperties();
+    } catch (Throwable t) {
+      System.err.println(ThrowableUtils.getErrorMessage(t));
+      System.exit(-1);
+    }
   }
   
   public static void setKeyStore(KeyStore ks) {


### PR DESCRIPTION
When a configuration file contain errors (multiple `=` or invalid url-encoding), starting Warp 10 produces a message similar to this:
`Found errors while reading /opt/warp10/etc/conf.d/70--extensions.conf. (Malformed lines [61, 80].)`

Fixes #872.