### PR TITLE
Allow TOKENGEN and TOKENDUMP to be used always on custom keys without secret

### DIFF
--- a/token/src/main/java/io/warp10/quasar/encoder/QuasarTokenEncoder.java
+++ b/token/src/main/java/io/warp10/quasar/encoder/QuasarTokenEncoder.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2020  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -32,18 +32,20 @@ import io.warp10.quasar.token.thrift.data.WriteToken;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 public class QuasarTokenEncoder {
-
-  private final TSerializer serializer = new TSerializer(new TCompactProtocol.Factory());
 
   public String deliverReadToken(String appName, String producerUID, String ownerUID, java.util.List<java.lang.String> apps, long ttl, KeyStore keystore) throws TException {
     ReadToken token = getReadToken(appName, producerUID, Arrays.asList(ownerUID), null, apps, null, null, ttl);
     return cypherToken(token, keystore);
   }
 
-  public String deliverReadToken(String appName, String producerUID, String ownerUID, java.util.List<java.lang.String> apps,  Map<String, String> labels, long ttl, KeyStore keystore) throws TException {
+  public String deliverReadToken(String appName, String producerUID, String ownerUID, java.util.List<java.lang.String> apps, Map<String, String> labels, long ttl, KeyStore keystore) throws TException {
     ReadToken token = getReadToken(appName, producerUID, Arrays.asList(ownerUID), null, apps, labels, null, ttl);
     return cypherToken(token, keystore);
   }
@@ -175,6 +177,9 @@ public class QuasarTokenEncoder {
   }
   
   public String encryptToken(TBase<?, ?> token, byte[] tokenAESKey, byte[] tokenSipHashKey) throws TException {
+    // TSerializer is not thread-safe so we initialize one each time.
+    TSerializer serializer = new TSerializer(new TCompactProtocol.Factory());
+
     // Serialize the  thrift token into byte array
     byte[] serialized = serializer.serialize(token);
 

--- a/token/src/main/java/io/warp10/quasar/encoder/QuasarTokenEncoder.java
+++ b/token/src/main/java/io/warp10/quasar/encoder/QuasarTokenEncoder.java
@@ -40,27 +40,27 @@ import java.util.UUID;
 
 public class QuasarTokenEncoder {
 
-  public String deliverReadToken(String appName, String producerUID, String ownerUID, java.util.List<java.lang.String> apps, long ttl, KeyStore keystore) throws TException {
+  public String deliverReadToken(String appName, String producerUID, String ownerUID, List<String> apps, long ttl, KeyStore keystore) throws TException {
     ReadToken token = getReadToken(appName, producerUID, Arrays.asList(ownerUID), null, apps, null, null, ttl);
     return cypherToken(token, keystore);
   }
 
-  public String deliverReadToken(String appName, String producerUID, String ownerUID, java.util.List<java.lang.String> apps, Map<String, String> labels, long ttl, KeyStore keystore) throws TException {
+  public String deliverReadToken(String appName, String producerUID, String ownerUID, List<String> apps, Map<String, String> labels, long ttl, KeyStore keystore) throws TException {
     ReadToken token = getReadToken(appName, producerUID, Arrays.asList(ownerUID), null, apps, labels, null, ttl);
     return cypherToken(token, keystore);
   }
 
-  public String deliverReadToken(String appName, String producerUID, java.util.List<java.lang.String> owners, java.util.List<java.lang.String> apps, java.util.Map<java.lang.String, java.lang.String> hooks, long ttl, KeyStore keystore) throws TException {
+  public String deliverReadToken(String appName, String producerUID, List<String> owners, List<String> apps, Map<String, String> hooks, long ttl, KeyStore keystore) throws TException {
     ReadToken token = getReadToken(appName, producerUID, owners, null, apps, null, hooks, ttl);
     return cypherToken(token, keystore);
   }
 
-  public String deliverReadToken(String appName, String producerUID, java.util.List<java.lang.String> owners, java.util.List<java.lang.String> apps,  Map<String, String> labels, java.util.Map<java.lang.String, java.lang.String> hooks, long ttl, KeyStore keystore) throws TException {
+  public String deliverReadToken(String appName, String producerUID, List<String> owners, List<String> apps,  Map<String, String> labels, Map<String, String> hooks, long ttl, KeyStore keystore) throws TException {
     ReadToken token = getReadToken(appName, producerUID, owners, null, apps, labels, hooks, ttl);
     return cypherToken(token, keystore);
   }
 
-  public String deliverReadToken(String appName, String producerUID, java.util.List<java.lang.String> owners, java.util.List<java.lang.String> producers, java.util.List<java.lang.String> apps,  Map<String, String> labels, java.util.Map<java.lang.String, java.lang.String> hooks, long ttl, KeyStore keystore) throws TException {
+  public String deliverReadToken(String appName, String producerUID, List<String> owners, List<String> producers, List<String> apps,  Map<String, String> labels, Map<String, String> hooks, long ttl, KeyStore keystore) throws TException {
     ReadToken token = getReadToken(appName, producerUID, owners, producers, apps, labels, hooks, ttl);
     return cypherToken(token, keystore);
   }
@@ -77,7 +77,7 @@ public class QuasarTokenEncoder {
    * @return ReadToken thrift structure
    * @throws TException
    */
-  public ReadToken getReadToken(String appName, String producerUID, java.util.List<java.lang.String> owners, java.util.List<java.lang.String> producers, java.util.List<java.lang.String> apps,  Map<String, String> labels, java.util.Map<java.lang.String, java.lang.String> hooks, long ttl) throws TException {
+  public ReadToken getReadToken(String appName, String producerUID, List<String> owners, List<String> producers, List<String> apps,  Map<String, String> labels, Map<String, String> hooks, long ttl) throws TException {
     long currentTime = System.currentTimeMillis();
 
     // Generate the READ Tokens

--- a/warp10/src/main/java/io/warp10/continuum/Tokens.java
+++ b/warp10/src/main/java/io/warp10/continuum/Tokens.java
@@ -31,6 +31,7 @@ import java.util.UUID;
 import java.util.concurrent.locks.LockSupport;
 import java.util.regex.Pattern;
 
+import io.warp10.ThrowableUtils;
 import org.apache.thrift.TBase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -496,11 +497,11 @@ public class Tokens {
               if (!(params.containsKey(TOKENGEN.KEY_ID))) {
                 throw new WarpScriptException("Missing '" + TOKENGEN.KEY_ID + "' field in token spec.");
               }
-              TBase token = new TOKENGEN("TOKENGEN", Long.MAX_VALUE >> 4).tokenFromMap(params);
+              TBase token = TOKENGEN.tokenFromMap(params, "Token generation in token file", Long.MAX_VALUE >> 4);
               tokens.put(params.get(TOKENGEN.KEY_ID).toString(), token);
             }
           } catch (WarpScriptException wse) {
-            LOG.error("Error parsing token spec '" + line + "'.", wse);
+            LOG.error("Error parsing token spec in file " + path + " at line '" + line + "': " + ThrowableUtils.getErrorMessage(wse));
           }
           continue;
         }

--- a/warp10/src/main/java/io/warp10/script/ext/token/TOKENDUMP.java
+++ b/warp10/src/main/java/io/warp10/script/ext/token/TOKENDUMP.java
@@ -57,6 +57,12 @@ public class TOKENDUMP extends NamedWarpScriptFunction implements WarpScriptStac
    */
   private final boolean warpKeystore;
 
+  /**
+   * Create the TOKENDUMP function.
+   * @param name The name of the function.
+   * @param keystore The keystore containing the AES and SipHash keys to decode tokens when no such keys are given when applying this function.
+   * @param warpKeystore Whether the given keystore is that of a Warp/WarpDist instance. If true, a secret is needed to access the keystore keys.
+   */
   public TOKENDUMP(String name, KeyStore keystore, boolean warpKeystore) {
     super(name);
     if(null != keystore) {

--- a/warp10/src/main/java/io/warp10/script/ext/token/TOKENDUMP.java
+++ b/warp10/src/main/java/io/warp10/script/ext/token/TOKENDUMP.java
@@ -48,85 +48,93 @@ public class TOKENDUMP extends NamedWarpScriptFunction implements WarpScriptStac
 
   public static final String KEY_PARAMS = "params";
 
-  private byte[] tokenAESKey = null;
-  private byte[] tokenSipHashKey = null;
+  private final byte[] keystoreTokenAESKey;
+  private final byte[] keystoreTokenSipHashKey;
 
-  private boolean multikey = false;
+  /**
+   * Whether the keystore used to initialize the keys is that of a Warp/WarpDist instance.
+   * If true, a secret is needed to access the keystore keys.
+   */
+  private final boolean warpKeystore;
 
-  public TOKENDUMP(String name) {
+  public TOKENDUMP(String name, KeyStore keystore, boolean warpKeystore) {
     super(name);
-  }
-
-  public TOKENDUMP(String name, KeyStore keystore) {
-    super(name);
-    tokenAESKey = keystore.getKey(KeyStore.AES_TOKEN);
-    tokenSipHashKey = keystore.getKey(KeyStore.SIPHASH_TOKEN);
-  }
-
-  public TOKENDUMP(String name, boolean multikey) {
-    super(name);
-    this.multikey = multikey;
+    if(null != keystore) {
+      keystoreTokenAESKey = keystore.getKey(KeyStore.AES_TOKEN);
+      keystoreTokenSipHashKey = keystore.getKey(KeyStore.SIPHASH_TOKEN);
+    } else {
+      keystoreTokenAESKey = null;
+      keystoreTokenSipHashKey = null;
+    }
+    this.warpKeystore = warpKeystore;
   }
 
   @Override
   public Object apply(WarpScriptStack stack) throws WarpScriptException {
+    byte[] tokenAESKey = null;
+    byte[] tokenSipHashKey = null;
+    boolean customKeys = false;
 
-    byte[] AESKey = tokenAESKey;
-    byte[] SipHashKey = tokenSipHashKey;
+    // First, check if SipHash and AES keys are explicitly defined. In that case, no need for secret.
+    Object top = stack.pop();
+    if (top instanceof byte[]) {
+      customKeys = true;
 
-    if ((null == AESKey || null == SipHashKey) && !this.multikey) {
-      throw new WarpScriptException(getName() + " cannot be used in this context.");
+      tokenSipHashKey = (byte[]) top;
+
+      top = stack.pop();
+
+      if (!(top instanceof byte[])) {
+        throw new WarpScriptException(getName() + " expects a BYTES AES Key if a BYTES SipHash is given.");
+      }
+
+      tokenAESKey = (byte[]) top;
+
+      top = stack.pop();
     }
 
-    Object top = null;
+    if (null == tokenAESKey) { // in that case we have also null == tokenSipHashKey
+      // SipHash and AES keys are not explicitly defined, so we fall back to those of the keystore.
+      // Check the secret if needed before the fallback.
+      if (warpKeystore) {
+        String secret = TokenWarpScriptExtension.TOKEN_SECRET;
 
-    if (this.multikey) {
-      top = stack.pop();
-
-      if (!(top instanceof byte[])) {
-        throw new WarpScriptException(getName() + " expects a SipHash Key (a byte array).");
-      }
-
-      SipHashKey = (byte[]) top;
-
-      top = stack.pop();
-
-      if (!(top instanceof byte[])) {
-        throw new WarpScriptException(getName() + " expects an AES Key (byte array).");
-      }
-
-      AESKey = (byte[]) top;
-
-      top = stack.pop();
-    } else {
-      //
-      // A non null token secret was configured, check it
-      //
-      String secret = TokenWarpScriptExtension.TOKEN_SECRET;
-
-      top = stack.pop();
-
-      if (null != secret) {
-        if (!(top instanceof String)) {
-          throw new WarpScriptException(getName() + " expects a token secret on top of the stack.");
+        if (null == secret) {
+          throw new WarpScriptException(getName() + " expects a token secret to be set in the configuration.");
         }
+
+        if (!(top instanceof String)) {
+          throw new WarpScriptException(getName() + " expects a STRING token secret.");
+        }
+
         if (!secret.equals(top)) {
           throw new WarpScriptException(getName() + " invalid token secret.");
         }
+
         top = stack.pop();
+      }
+
+      // Fallback to keystore keys.
+      if (null == keystoreTokenAESKey || null == keystoreTokenSipHashKey) {
+        throw new WarpScriptException(getName() + " expects SipHash and AES keys to be explicitly defined.");
+      } else {
+        tokenAESKey = keystoreTokenAESKey;
+        tokenSipHashKey = keystoreTokenSipHashKey;
       }
     }
 
     if (!(top instanceof String)) {
-      throw new WarpScriptException(getName() + " expects a token on top of the stack.");
+      throw new WarpScriptException(getName() + " expects a STRING token.");
     }
 
-    String tokenstr = top.toString();
+    String tokenstr = (String) top;
 
     ReadToken rtoken = null;
     WriteToken wtoken = null;
 
-    if (!this.multikey) {
+    if (!customKeys && warpKeystore) {
+      // In that case, we don't even need tokenAESKey and tokenSipHashKey and use directly the Tokens class.
+      // It has the advantage of decoding tokens defined in files.
       try {
         rtoken = Tokens.extractReadToken(tokenstr);
       } catch (WarpScriptException wse) {
@@ -139,8 +147,8 @@ public class TOKENDUMP extends NamedWarpScriptFunction implements WarpScriptStac
     } else {
       byte[] token = OrderPreservingBase64.decode(tokenstr.getBytes(StandardCharsets.UTF_8));
 
-      long[] lkey = SipHashInline.getKey(SipHashKey);
-      QuasarTokenDecoder dec = new QuasarTokenDecoder(lkey[0], lkey[1], AESKey);
+      long[] lkey = SipHashInline.getKey(tokenSipHashKey);
+      QuasarTokenDecoder dec = new QuasarTokenDecoder(lkey[0], lkey[1], tokenAESKey);
 
       try {
         rtoken = dec.decodeReadToken(token);
@@ -153,7 +161,7 @@ public class TOKENDUMP extends NamedWarpScriptFunction implements WarpScriptStac
       }
     }
 
-    String ident = encoder.getTokenIdent(tokenstr, SipHashKey);
+    String ident = encoder.getTokenIdent(tokenstr, tokenSipHashKey);
 
     Map<Object, Object> result = new HashMap<Object, Object>();
     result.put(TOKENGEN.KEY_TOKEN, tokenstr);

--- a/warp10/src/main/java/io/warp10/script/ext/token/TOKENGEN.java
+++ b/warp10/src/main/java/io/warp10/script/ext/token/TOKENGEN.java
@@ -57,6 +57,8 @@ public class TOKENGEN extends NamedWarpScriptFunction implements WarpScriptStack
   public static final String KEY_PRODUCER = "producer";
   public static final String KEY_APPLICATIONS = "applications";
 
+  private static final long DEFAULT_TTL = 0;
+
   private final byte[] keystoreTokenAESKey;
   private final byte[] keystoreTokenSipHashKey;
 
@@ -66,6 +68,12 @@ public class TOKENGEN extends NamedWarpScriptFunction implements WarpScriptStack
    */
   private final boolean warpKeystore;
 
+  /**
+   * Create the TOKENGEN function.
+   * @param name The name of the function.
+   * @param keystore The keystore containing the AES and SipHash keys to decode tokens when no such keys are given when applying this function.
+   * @param warpKeystore Whether the given keystore is that of a Warp/WarpDist instance. If true, a secret is needed to access the keystore keys.
+   */
   public TOKENGEN(String name, KeyStore keystore, boolean warpKeystore) {
     super(name);
     if (null != keystore) {
@@ -136,7 +144,7 @@ public class TOKENGEN extends NamedWarpScriptFunction implements WarpScriptStack
     Map<Object, Object> params = (Map<Object, Object>) top;
 
     try {
-      TBase token = tokenFromMap(params, getName(), 0L);
+      TBase token = tokenFromMap(params, getName(), DEFAULT_TTL);
 
       String tokenstr = encoder.encryptToken(token, tokenAESKey, tokenSipHashKey);
       String ident = encoder.getTokenIdent(tokenstr, tokenSipHashKey);
@@ -188,7 +196,7 @@ public class TOKENGEN extends NamedWarpScriptFunction implements WarpScriptStack
         }
       } else if (null != params.get(KEY_EXPIRY)) {
         rtoken.setExpiryTimestamp(((Number) params.get(KEY_EXPIRY)).longValue());
-      } else if (0 == defaultTtl) {
+      } else if (0L == defaultTtl) {
         throw new WarpScriptException(name + " missing '" + KEY_TTL + "' or '" + KEY_EXPIRY + "'.");
       } else {
         rtoken.setExpiryTimestamp(rtoken.getIssuanceTimestamp() + defaultTtl);
@@ -198,7 +206,7 @@ public class TOKENGEN extends NamedWarpScriptFunction implements WarpScriptStack
         if (!(params.get(KEY_OWNERS) instanceof List)) {
           throw new WarpScriptException(name + " expects '" + KEY_OWNERS + "' to be a list of UUIDs.");
         }
-        for (Object uuid : (List) params.get(KEY_OWNERS)) {
+        for (Object uuid: (List) params.get(KEY_OWNERS)) {
           rtoken.addToOwners(encoder.toByteBuffer(uuid.toString()));
         }
         if (0 == rtoken.getOwnersSize()) {
@@ -212,7 +220,7 @@ public class TOKENGEN extends NamedWarpScriptFunction implements WarpScriptStack
         if (!(params.get(KEY_PRODUCERS) instanceof List)) {
           throw new WarpScriptException(name + " expects '" + KEY_PRODUCERS + "' to be a list of UUIDs.");
         }
-        for (Object uuid : (List) params.get(KEY_PRODUCERS)) {
+        for (Object uuid: (List) params.get(KEY_PRODUCERS)) {
           rtoken.addToProducers(encoder.toByteBuffer(uuid.toString()));
         }
         if (0 == rtoken.getProducersSize()) {
@@ -226,7 +234,7 @@ public class TOKENGEN extends NamedWarpScriptFunction implements WarpScriptStack
         if (!(params.get(KEY_APPLICATIONS) instanceof List)) {
           throw new WarpScriptException(name + " expects '" + KEY_APPLICATIONS + "' to be a list of application names.");
         }
-        for (Object app : (List) params.get(KEY_APPLICATIONS)) {
+        for (Object app: (List) params.get(KEY_APPLICATIONS)) {
           rtoken.addToApps(app.toString());
         }
         if (0 == rtoken.getAppsSize()) {
@@ -240,7 +248,7 @@ public class TOKENGEN extends NamedWarpScriptFunction implements WarpScriptStack
         if (!(params.get(KEY_ATTRIBUTES) instanceof Map)) {
           throw new WarpScriptException(name + " expects '" + KEY_ATTRIBUTES + "' to be a map.");
         }
-        for (Entry<Object, Object> entry : ((Map<Object, Object>) params.get(KEY_ATTRIBUTES)).entrySet()) {
+        for (Entry<Object, Object> entry: ((Map<Object, Object>) params.get(KEY_ATTRIBUTES)).entrySet()) {
           if (!(entry.getKey() instanceof String) || !(entry.getValue() instanceof String)) {
             throw new WarpScriptException(name + " expects '" + KEY_ATTRIBUTES + "' to be a map of STRING keys and values.");
           }
@@ -252,7 +260,7 @@ public class TOKENGEN extends NamedWarpScriptFunction implements WarpScriptStack
         if (!(params.get(KEY_LABELS) instanceof Map)) {
           throw new WarpScriptException(name + " expects '" + KEY_LABELS + "' to be a map.");
         }
-        for (Entry<Object, Object> entry : ((Map<Object, Object>) params.get(KEY_LABELS)).entrySet()) {
+        for (Entry<Object, Object> entry: ((Map<Object, Object>) params.get(KEY_LABELS)).entrySet()) {
           if (!(entry.getKey() instanceof String) || !(entry.getValue() instanceof String)) {
             throw new WarpScriptException(name + " expects '" + KEY_LABELS + "' to be a map of STRING keys and values.");
           }
@@ -307,7 +315,7 @@ public class TOKENGEN extends NamedWarpScriptFunction implements WarpScriptStack
         if (!(params.get(KEY_ATTRIBUTES) instanceof Map)) {
           throw new WarpScriptException(name + " expects '" + KEY_ATTRIBUTES + "' to be a map.");
         }
-        for (Entry<Object, Object> entry : ((Map<Object, Object>) params.get(KEY_ATTRIBUTES)).entrySet()) {
+        for (Entry<Object, Object> entry: ((Map<Object, Object>) params.get(KEY_ATTRIBUTES)).entrySet()) {
           if (!(entry.getKey() instanceof String) || !(entry.getValue() instanceof String)) {
             throw new WarpScriptException(name + " expects '" + KEY_ATTRIBUTES + "' to be a map of STRING keys and values.");
           }
@@ -319,7 +327,7 @@ public class TOKENGEN extends NamedWarpScriptFunction implements WarpScriptStack
         if (!(params.get(KEY_LABELS) instanceof Map)) {
           throw new WarpScriptException(name + " expects '" + KEY_LABELS + "' to be a map.");
         }
-        for (Entry<Object, Object> entry : ((Map<Object, Object>) params.get(KEY_LABELS)).entrySet()) {
+        for (Entry<Object, Object> entry: ((Map<Object, Object>) params.get(KEY_LABELS)).entrySet()) {
           if (!(entry.getKey() instanceof String) || !(entry.getValue() instanceof String)) {
             throw new WarpScriptException(name + " expects '" + KEY_LABELS + "' to be a map of STRING keys and values.");
           }

--- a/warp10/src/main/java/io/warp10/script/ext/token/TOKENGEN.java
+++ b/warp10/src/main/java/io/warp10/script/ext/token/TOKENGEN.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2019  SenX S.A.S.
+//   Copyright 2019-2020  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ import java.util.Map.Entry;
 
 public class TOKENGEN extends NamedWarpScriptFunction implements WarpScriptStackFunction {
 
-  private final QuasarTokenEncoder encoder = new QuasarTokenEncoder();
+  private final static QuasarTokenEncoder encoder = new QuasarTokenEncoder();
 
   public static final String KEY_TOKEN = "token";
   public static final String KEY_IDENT = "ident";
@@ -57,78 +57,75 @@ public class TOKENGEN extends NamedWarpScriptFunction implements WarpScriptStack
   public static final String KEY_PRODUCER = "producer";
   public static final String KEY_APPLICATIONS = "applications";
 
-  private long DEFAULT_TTL = 0;
+  private final byte[] keystoreTokenAESKey;
+  private final byte[] keystoreTokenSipHashKey;
 
-  private byte[] tokenAESKey = null;
-  private byte[] tokenSipHashKey = null;
-  private boolean multikey = false;
+  /**
+   * Whether the keystore used to initialize the keys is that of a Warp/WarpDist instance.
+   * If true, a secret is needed to access the keystore keys.
+   */
+  private final boolean warpKeystore;
 
-  public TOKENGEN(String name) {
+  public TOKENGEN(String name, KeyStore keystore, boolean warpKeystore) {
     super(name);
-  }
-
-  public TOKENGEN(String name, KeyStore keystore) {
-    super(name);
-    tokenAESKey = keystore.getKey(KeyStore.AES_TOKEN);
-    tokenSipHashKey = keystore.getKey(KeyStore.SIPHASH_TOKEN);
-  }
-
-  public TOKENGEN(String name, long ttl) {
-    super(name);
-    this.DEFAULT_TTL = ttl;
-  }
-
-  public TOKENGEN(String name, boolean multikey) {
-    super(name);
-    this.multikey = multikey;
+    if (null != keystore) {
+      keystoreTokenAESKey = keystore.getKey(KeyStore.AES_TOKEN);
+      keystoreTokenSipHashKey = keystore.getKey(KeyStore.SIPHASH_TOKEN);
+    } else {
+      keystoreTokenAESKey = null;
+      keystoreTokenSipHashKey = null;
+    }
+    this.warpKeystore = warpKeystore;
   }
 
   @Override
   public Object apply(WarpScriptStack stack) throws WarpScriptException {
+    byte[] tokenAESKey = null;
+    byte[] tokenSipHashKey = null;
 
-    byte[] AESKey = this.tokenAESKey;
-    byte[] SipHashKey = this.tokenSipHashKey;
+    // First, check if SipHash and AES keys are explicitly defined. In that case, no need for secret.
+    Object top = stack.pop();
+    if (top instanceof byte[]) {
+      tokenSipHashKey = (byte[]) top;
 
-    if ((null == AESKey || null == SipHashKey) && !this.multikey) {
-      throw new WarpScriptException(getName() + " cannot be used in this context.");
+      top = stack.pop();
+
+      if (!(top instanceof byte[])) {
+        throw new WarpScriptException(getName() + " expects a BYTES AES Key if a BYTES SipHash is given.");
+      }
+
+      tokenAESKey = (byte[]) top;
+
+      top = stack.pop();
     }
 
-    Object top = null;
+    if (null == tokenAESKey) { // in that case we have also null == tokenSipHashKey
+      // SipHash and AES keys are not explicitly defined, so we fall back to those of the keystore.
+      // Check the secret if needed before the fallback.
+      if (warpKeystore) {
+        String secret = TokenWarpScriptExtension.TOKEN_SECRET;
 
-    if (multikey) {
-      top = stack.pop();
-
-      if (!(top instanceof byte[])) {
-        throw new WarpScriptException(getName() + " expects a SipHash Key (a byte array).");
-      }
-
-      SipHashKey = (byte[]) top;
-
-      top = stack.pop();
-
-      if (!(top instanceof byte[])) {
-        throw new WarpScriptException(getName() + " expects an AES Key (byte array).");
-      }
-
-      AESKey = (byte[]) top;
-
-      top = stack.pop();
-    } else {
-      //
-      // If a non null token secret was configured and no keys are specified, check it
-      //
-
-      top = stack.pop();
-      String secret = TokenWarpScriptExtension.TOKEN_SECRET;
-
-      if (null != secret) {
-        if (!(top instanceof String)) {
-          throw new WarpScriptException(getName() + " expects a token secret on top of the stack.");
+        if (null == secret) {
+          throw new WarpScriptException(getName() + " expects a token secret to be set in the configuration.");
         }
+
+        if (!(top instanceof String)) {
+          throw new WarpScriptException(getName() + " expects a STRING token secret.");
+        }
+
         if (!secret.equals(top)) {
           throw new WarpScriptException(getName() + " invalid token secret.");
         }
+
         top = stack.pop();
+      }
+
+      // Fallback to keystore keys.
+      if (null == keystoreTokenAESKey || null == keystoreTokenSipHashKey) {
+        throw new WarpScriptException(getName() + " expects SipHash and AES keys to be explicitly defined.");
+      } else {
+        tokenAESKey = keystoreTokenAESKey;
+        tokenSipHashKey = keystoreTokenSipHashKey;
       }
     }
 
@@ -139,10 +136,10 @@ public class TOKENGEN extends NamedWarpScriptFunction implements WarpScriptStack
     Map<Object, Object> params = (Map<Object, Object>) top;
 
     try {
-      TBase token = tokenFromMap(params);
+      TBase token = tokenFromMap(params, getName(), 0L);
 
-      String tokenstr = encoder.encryptToken(token, AESKey, SipHashKey);
-      String ident = encoder.getTokenIdent(tokenstr, SipHashKey);
+      String tokenstr = encoder.encryptToken(token, tokenAESKey, tokenSipHashKey);
+      String ident = encoder.getTokenIdent(tokenstr, tokenSipHashKey);
 
       Map<Object, Object> result = new HashMap<Object, Object>();
       result.put(KEY_TOKEN, tokenstr);
@@ -158,7 +155,7 @@ public class TOKENGEN extends NamedWarpScriptFunction implements WarpScriptStack
     return stack;
   }
 
-  public TBase tokenFromMap(Map params) throws WarpScriptException {
+  public static TBase tokenFromMap(Map params, String name, long defaultTtl) throws WarpScriptException {
     TBase token = null;
 
     if (TokenType.READ.toString().equals(params.get(KEY_TYPE))) {
@@ -168,11 +165,11 @@ public class TOKENGEN extends NamedWarpScriptFunction implements WarpScriptStack
       if (null != params.get(KEY_OWNER)) {
         rtoken.setBilledId(encoder.toByteBuffer(params.get(KEY_OWNER).toString()));
       } else {
-        throw new WarpScriptException(getName() + " missing '" + KEY_OWNER + "'.");
+        throw new WarpScriptException(name + " missing '" + KEY_OWNER + "'.");
       }
 
       if (null == params.get(KEY_APPLICATION)) {
-        throw new WarpScriptException(getName() + " missing '" + KEY_APPLICATION + "'.");
+        throw new WarpScriptException(name + " missing '" + KEY_APPLICATION + "'.");
       }
       rtoken.setAppName(params.get(KEY_APPLICATION).toString());
 
@@ -191,17 +188,17 @@ public class TOKENGEN extends NamedWarpScriptFunction implements WarpScriptStack
         }
       } else if (null != params.get(KEY_EXPIRY)) {
         rtoken.setExpiryTimestamp(((Number) params.get(KEY_EXPIRY)).longValue());
-      } else if (0 == DEFAULT_TTL) {
-        throw new WarpScriptException(getName() + " missing '" + KEY_TTL + "' or '" + KEY_EXPIRY + "'.");
+      } else if (0 == defaultTtl) {
+        throw new WarpScriptException(name + " missing '" + KEY_TTL + "' or '" + KEY_EXPIRY + "'.");
       } else {
-        rtoken.setExpiryTimestamp(rtoken.getIssuanceTimestamp() + DEFAULT_TTL);
+        rtoken.setExpiryTimestamp(rtoken.getIssuanceTimestamp() + defaultTtl);
       }
 
       if (null != params.get(KEY_OWNERS)) {
         if (!(params.get(KEY_OWNERS) instanceof List)) {
-          throw new WarpScriptException(getName() + " expects '" + KEY_OWNERS + "' to be a list of UUIDs.");
+          throw new WarpScriptException(name + " expects '" + KEY_OWNERS + "' to be a list of UUIDs.");
         }
-        for (Object uuid: (List) params.get(KEY_OWNERS)) {
+        for (Object uuid : (List) params.get(KEY_OWNERS)) {
           rtoken.addToOwners(encoder.toByteBuffer(uuid.toString()));
         }
         if (0 == rtoken.getOwnersSize()) {
@@ -213,9 +210,9 @@ public class TOKENGEN extends NamedWarpScriptFunction implements WarpScriptStack
 
       if (null != params.get(KEY_PRODUCERS)) {
         if (!(params.get(KEY_PRODUCERS) instanceof List)) {
-          throw new WarpScriptException(getName() + " expects '" + KEY_PRODUCERS + "' to be a list of UUIDs.");
+          throw new WarpScriptException(name + " expects '" + KEY_PRODUCERS + "' to be a list of UUIDs.");
         }
-        for (Object uuid: (List) params.get(KEY_PRODUCERS)) {
+        for (Object uuid : (List) params.get(KEY_PRODUCERS)) {
           rtoken.addToProducers(encoder.toByteBuffer(uuid.toString()));
         }
         if (0 == rtoken.getProducersSize()) {
@@ -227,9 +224,9 @@ public class TOKENGEN extends NamedWarpScriptFunction implements WarpScriptStack
 
       if (null != params.get(KEY_APPLICATIONS)) {
         if (!(params.get(KEY_APPLICATIONS) instanceof List)) {
-          throw new WarpScriptException(getName() + " expects '" + KEY_APPLICATIONS + "' to be a list of application names.");
+          throw new WarpScriptException(name + " expects '" + KEY_APPLICATIONS + "' to be a list of application names.");
         }
-        for (Object app: (List) params.get(KEY_APPLICATIONS)) {
+        for (Object app : (List) params.get(KEY_APPLICATIONS)) {
           rtoken.addToApps(app.toString());
         }
         if (0 == rtoken.getAppsSize()) {
@@ -241,11 +238,11 @@ public class TOKENGEN extends NamedWarpScriptFunction implements WarpScriptStack
 
       if (null != params.get(KEY_ATTRIBUTES)) {
         if (!(params.get(KEY_ATTRIBUTES) instanceof Map)) {
-          throw new WarpScriptException(getName() + " expects '" + KEY_ATTRIBUTES + "' to be a map.");
+          throw new WarpScriptException(name + " expects '" + KEY_ATTRIBUTES + "' to be a map.");
         }
-        for (Entry<Object, Object> entry: ((Map<Object, Object>) params.get(KEY_ATTRIBUTES)).entrySet()) {
+        for (Entry<Object, Object> entry : ((Map<Object, Object>) params.get(KEY_ATTRIBUTES)).entrySet()) {
           if (!(entry.getKey() instanceof String) || !(entry.getValue() instanceof String)) {
-            throw new WarpScriptException(getName() + " expects '" + KEY_ATTRIBUTES + "' to be a map of STRING keys and values.");
+            throw new WarpScriptException(name + " expects '" + KEY_ATTRIBUTES + "' to be a map of STRING keys and values.");
           }
           rtoken.putToAttributes(entry.getKey().toString(), entry.getValue().toString());
         }
@@ -253,11 +250,11 @@ public class TOKENGEN extends NamedWarpScriptFunction implements WarpScriptStack
 
       if (null != params.get(KEY_LABELS)) {
         if (!(params.get(KEY_LABELS) instanceof Map)) {
-          throw new WarpScriptException(getName() + " expects '" + KEY_LABELS + "' to be a map.");
+          throw new WarpScriptException(name + " expects '" + KEY_LABELS + "' to be a map.");
         }
-        for (Entry<Object, Object> entry: ((Map<Object, Object>) params.get(KEY_LABELS)).entrySet()) {
+        for (Entry<Object, Object> entry : ((Map<Object, Object>) params.get(KEY_LABELS)).entrySet()) {
           if (!(entry.getKey() instanceof String) || !(entry.getValue() instanceof String)) {
-            throw new WarpScriptException(getName() + " expects '" + KEY_LABELS + "' to be a map of STRING keys and values.");
+            throw new WarpScriptException(name + " expects '" + KEY_LABELS + "' to be a map of STRING keys and values.");
           }
           rtoken.putToLabels(entry.getKey().toString(), entry.getValue().toString());
         }
@@ -269,7 +266,7 @@ public class TOKENGEN extends NamedWarpScriptFunction implements WarpScriptStack
       wtoken.setTokenType(TokenType.WRITE);
 
       if (null == params.get(KEY_APPLICATION)) {
-        throw new WarpScriptException(getName() + " missing '" + KEY_APPLICATION + "'.");
+        throw new WarpScriptException(name + " missing '" + KEY_APPLICATION + "'.");
       }
       wtoken.setAppName(params.get(KEY_APPLICATION).toString());
 
@@ -288,31 +285,31 @@ public class TOKENGEN extends NamedWarpScriptFunction implements WarpScriptStack
         }
       } else if (null != params.get(KEY_EXPIRY)) {
         wtoken.setExpiryTimestamp(((Number) params.get(KEY_EXPIRY)).longValue());
-      } else if (0 == DEFAULT_TTL) {
-        throw new WarpScriptException(getName() + " missing '" + KEY_TTL + "' or '" + KEY_EXPIRY + "'.");
+      } else if (0L == defaultTtl) {
+        throw new WarpScriptException(name + " missing '" + KEY_TTL + "' or '" + KEY_EXPIRY + "'.");
       } else {
-        wtoken.setExpiryTimestamp(wtoken.getIssuanceTimestamp() + DEFAULT_TTL);
+        wtoken.setExpiryTimestamp(wtoken.getIssuanceTimestamp() + defaultTtl);
       }
 
       if (null != params.get(KEY_OWNER)) {
         wtoken.setOwnerId(encoder.toByteBuffer(params.get(KEY_OWNER).toString()));
       } else {
-        throw new WarpScriptException(getName() + " missing '" + KEY_OWNER + "'.");
+        throw new WarpScriptException(name + " missing '" + KEY_OWNER + "'.");
       }
 
       if (null != params.get(KEY_PRODUCER)) {
         wtoken.setProducerId(encoder.toByteBuffer(params.get(KEY_PRODUCER).toString()));
       } else {
-        throw new WarpScriptException(getName() + " missing '" + KEY_PRODUCER + "'.");
+        throw new WarpScriptException(name + " missing '" + KEY_PRODUCER + "'.");
       }
 
       if (null != params.get(KEY_ATTRIBUTES)) {
         if (!(params.get(KEY_ATTRIBUTES) instanceof Map)) {
-          throw new WarpScriptException(getName() + " expects '" + KEY_ATTRIBUTES + "' to be a map.");
+          throw new WarpScriptException(name + " expects '" + KEY_ATTRIBUTES + "' to be a map.");
         }
-        for (Entry<Object, Object> entry: ((Map<Object, Object>) params.get(KEY_ATTRIBUTES)).entrySet()) {
+        for (Entry<Object, Object> entry : ((Map<Object, Object>) params.get(KEY_ATTRIBUTES)).entrySet()) {
           if (!(entry.getKey() instanceof String) || !(entry.getValue() instanceof String)) {
-            throw new WarpScriptException(getName() + " expects '" + KEY_ATTRIBUTES + "' to be a map of STRING keys and values.");
+            throw new WarpScriptException(name + " expects '" + KEY_ATTRIBUTES + "' to be a map of STRING keys and values.");
           }
           wtoken.putToAttributes(entry.getKey().toString(), entry.getValue().toString());
         }
@@ -320,11 +317,11 @@ public class TOKENGEN extends NamedWarpScriptFunction implements WarpScriptStack
 
       if (null != params.get(KEY_LABELS)) {
         if (!(params.get(KEY_LABELS) instanceof Map)) {
-          throw new WarpScriptException(getName() + " expects '" + KEY_LABELS + "' to be a map.");
+          throw new WarpScriptException(name + " expects '" + KEY_LABELS + "' to be a map.");
         }
-        for (Entry<Object, Object> entry: ((Map<Object, Object>) params.get(KEY_LABELS)).entrySet()) {
+        for (Entry<Object, Object> entry : ((Map<Object, Object>) params.get(KEY_LABELS)).entrySet()) {
           if (!(entry.getKey() instanceof String) || !(entry.getValue() instanceof String)) {
-            throw new WarpScriptException(getName() + " expects '" + KEY_LABELS + "' to be a map of STRING keys and values.");
+            throw new WarpScriptException(name + " expects '" + KEY_LABELS + "' to be a map of STRING keys and values.");
           }
           wtoken.putToLabels(entry.getKey().toString(), entry.getValue().toString());
         }
@@ -332,7 +329,7 @@ public class TOKENGEN extends NamedWarpScriptFunction implements WarpScriptStack
 
       token = wtoken;
     } else {
-      throw new WarpScriptException(getName() + " expects a key '" + KEY_TYPE + "' with value READ or WRITE in the parameter map.");
+      throw new WarpScriptException(name + " expects a key '" + KEY_TYPE + "' with value READ or WRITE in the parameter map.");
     }
 
     return token;


### PR DESCRIPTION
This PR allows the signatures
```
$map $aes $hash TOKENGEN
$token $aes $hash TOKENDUMP
```
to be used in any configuration, without secret.

If AES and SipHash keys are not specified, the behavior is the same as before, ie if keystore is that of a Warp/WarpDist instance, a secret is mandatory both in the conf and in the signatures, else no secret is necessary.

Also fixed a potential bug with non-thread safe `TSerializer` and improved error messages.