### PR TITLE
More precise offset for ParseException thrown by GTSHelper.parseValue

### DIFF
--- a/warp10/src/main/java/io/warp10/script/functions/PARSEVALUE.java
+++ b/warp10/src/main/java/io/warp10/script/functions/PARSEVALUE.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2019  SenX S.A.S.
+//   Copyright 2019-2020  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.

--- a/warp10/src/main/java/io/warp10/script/functions/PARSEVALUE.java
+++ b/warp10/src/main/java/io/warp10/script/functions/PARSEVALUE.java
@@ -32,18 +32,19 @@ public class PARSEVALUE extends NamedWarpScriptFunction implements WarpScriptSta
   @Override
   public Object apply(WarpScriptStack stack) throws WarpScriptException {
     Object top = stack.pop();
-    
+
     if (!(top instanceof String)) {
       throw new WarpScriptException(getName() + " operates on a STRING.");
     }
-    
+
+    String value = top.toString().trim();
+
     try {
-      String value = top.toString().trim();      
       stack.push(GTSHelper.parseValue(value));
     } catch (ParseException pe) {
-      throw new WarpScriptException(getName() + " encountered an exception while parsing.", pe);
+      throw new WarpScriptException(getName() + " encountered a parse error at index " + pe.getErrorOffset() + " for '" + value + "'.", pe);
     }
-    
+
     return stack;
   }
 }


### PR DESCRIPTION
Allows more precise message for parsing errors, mostly useful for debugging multivalues errors.

Executing
```
<'
1// a{} [ 1 [ [ hex:1 ] ] ]
'>
PARSE
```
gives `Exception at '=>PARSE<=' in section [TOP] (PARSE could not parse at index 16 in '1// a{} [ 1 [ [ hex:1 ] ] ]' (Cannot parse value. (Odd number of hexadecimal digits.)))`

Executing
```
<'
[ 1 [ [ hex:1 ] ] ]
'>
PARSEVALUE
```
gives `Exception at '=>PARSEVALUE<=' in section [TOP] (PARSEVALUE encountered a parse error at index 8 for '[ 1 [ [ hex:1 ] ] ]'. (Cannot parse value. (Odd number of hexadecimal digits.)))`

Sending
```
curl -H "X-Warp10-Token:WRITETOKEN" --data-binary "1// a{} [ 1 [ hex:1 ] ]" http://127.0.0.1:8080/api/v0/update
```
gives `Error when updating data: Parse error at index 14 in &apos;1// a{} [ 1 [ hex:1 ] ]&apos; (Cannot parse value. (Odd number of hexadecimal digits.))`