### PR TITLE
Fix DEDUP signature so that it reduces list nesting

### DIFF
--- a/warp10/src/main/java/io/warp10/script/functions/DEDUP.java
+++ b/warp10/src/main/java/io/warp10/script/functions/DEDUP.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2020  SenX S.A.S.
+//   Copyright 2018-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@ import io.warp10.script.ListRecursiveStackFunction;
 import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptMapperFunction;
 import io.warp10.script.WarpScriptStack;
+
+import java.util.List;
 
 /**
  * Remove duplicates from GTS instances.
@@ -56,7 +58,13 @@ public class DEDUP extends ListRecursiveStackFunction {
         @Override
         public Object applyOnElement(Object element) throws WarpScriptException {
           if (element instanceof GeoTimeSerie) {
-            return GTSHelper.map((GeoTimeSerie) element, macroOrMapper, 0, 0, 0, false, 1, false, macroOrMapper instanceof WarpScriptStack.Macro ? stack : null, null, true);
+            List<GeoTimeSerie> res = GTSHelper.map((GeoTimeSerie) element, macroOrMapper, 0, 0, 0, false, 1, false, macroOrMapper instanceof WarpScriptStack.Macro ? stack : null, null, true);
+
+            if (1 == res.size()) {
+              return res.get(0);
+            } else {
+              return res;
+            }
           } else {
             return UNHANDLED;
           }


### PR DESCRIPTION
When `DEDUP` is used with an aggregator or a macro (new in 2.7.0), it always generates a list of GTSs for each GTS. This is because this function is very similar to `MAP` so aggregators/macros can generate several GTSs. However, in the case the aggregator/macro returns a single GTS, `MAP` does not nest lists for simplicity.

This PR aims at replicating this behavior in `DEDUP`, avoiding list nesting when possible.

This does change the signature of `DEDUP`, however as this functionality is rather new and is already [documented as avoiding nesting](http://warp10.io/doc/DEDUP), this change may be considered as acceptable.

Signatures without this PR:
`GTS AGGREGATOR/MACRO` **`DEDUP`** `LIST<GTS>`
`LIST<GTS> AGGREGATOR/MACRO` **`DEDUP`** `LIST<LIST<GTS>>`

Signatures with this PR:
For an aggregator/macro generating a single GTS (most common case):
`GTS AGGREGATOR/MACRO` **`DEDUP`** `GTS`
`LIST<GTS> AGGREGATOR/MACRO` **`DEDUP`** `LIST<GTS>`
For an aggregator/macro generating multiple GTSs:
`GTS AGGREGATOR/MACRO` **`DEDUP`** `LIST<GTS>`
`LIST<GTS> AGGREGATOR/MACRO` **`DEDUP`** `LIST<LIST<GTS>>`