### PR TITLE
Make memory store chunked by default in the conf file

### DIFF
--- a/etc/conf.templates/standalone/30-in-memory.conf.template
+++ b/etc/conf.templates/standalone/30-in-memory.conf.template
@@ -1,5 +1,5 @@
 //
-//   Copyright 2019  SenX S.A.S.
+//   Copyright 2019-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -102,10 +102,10 @@ in.memory = false
 //
 // When this is true, the depth of data retained is
 // configured using in.memory.chunk.count and in.memory.chunk.length
-// This configuration MUST be set starting with 2.1.
-// Set it to false if you are using the deprecated non chunked memory store.
 //
-#in.memory.chunked = true
+// This configuration MUST be set starting with 2.1.
+//
+in.memory.chunked = true
 
 //
 // Number of chunks to retain (defaults to 3)

--- a/warp10/src/main/java/io/warp10/standalone/Warp.java
+++ b/warp10/src/main/java/io/warp10/standalone/Warp.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2020  SenX S.A.S.
+//   Copyright 2018-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -327,7 +327,7 @@ public class Warp extends WarpDist implements Runnable {
       sdc.setActivityWindow(Long.parseLong(properties.getProperty(Configuration.INGRESS_ACTIVITY_WINDOW, "0")));
 
       if (null == properties.getProperty(Configuration.IN_MEMORY_CHUNKED)) {
-        throw new RuntimeException("Configuration key '" + Configuration.IN_MEMORY_CHUNKED + "' MUST now explicitely be set to 'true' or 'false' (if you wish to use the now deprecated non chunked memory store).");
+        throw new RuntimeException("Configuration key '" + Configuration.IN_MEMORY_CHUNKED + "' MUST now explicitly be set to 'true' or 'false' (if you wish to use the now deprecated non chunked memory store).");
       }
 
       if (!"false".equals(properties.getProperty(Configuration.IN_MEMORY_CHUNKED))) {


### PR DESCRIPTION
Non-chunked memory store has been deprecated for a long time now. Thus, it is reasonable to make chunked memory store a default in the configuration file.

Also make comment clearer and fix typo.