### PR TITLE
Add Presize for bilinear resizing and small fixes

### DIFF
--- a/warp10/src/main/java/io/warp10/script/WarpScriptLib.java
+++ b/warp10/src/main/java/io/warp10/script/WarpScriptLib.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2019  SenX S.A.S.
+//   Copyright 2019-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -211,6 +211,7 @@ import io.warp10.script.processing.image.Pimage;
 import io.warp10.script.processing.image.PimageMode;
 import io.warp10.script.processing.image.PnoTint;
 import io.warp10.script.processing.image.Ppixels;
+import io.warp10.script.processing.image.Presize;
 import io.warp10.script.processing.image.Pset;
 import io.warp10.script.processing.image.Psize;
 import io.warp10.script.processing.image.Ptint;
@@ -1008,6 +1009,7 @@ public class WarpScriptLib {
   public static final String PDECODE = "Pdecode";
   public static final String PIMAGE = "Pimage";
   public static final String PSIZE = "Psize";
+  public static final String PRESIZE = "Presize";
   public static final String PMASK = "Pmask";
   public static final String PIMAGEMODE = "PimageMode";
   public static final String PTINT = "Ptint";
@@ -2187,6 +2189,7 @@ public class WarpScriptLib {
     addNamedWarpScriptFunction(new Pimage(PIMAGE));
     addNamedWarpScriptFunction(new PimageMode(PIMAGEMODE));
     addNamedWarpScriptFunction(new Psize(PSIZE));
+    addNamedWarpScriptFunction(new Presize(PRESIZE));
     addNamedWarpScriptFunction(new Pmask(PMASK));
     addNamedWarpScriptFunction(new Ptint(PTINT));
     addNamedWarpScriptFunction(new PnoTint(PNOTINT));

--- a/warp10/src/main/java/io/warp10/script/processing/image/Presize.java
+++ b/warp10/src/main/java/io/warp10/script/processing/image/Presize.java
@@ -20,8 +20,12 @@ import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptStack;
 import io.warp10.script.WarpScriptStackFunction;
+import io.warp10.script.functions.TYPEOF;
 import processing.core.PImage;
 
+/**
+ * Resize a PImage using bilinear interpolation.
+ */
 public class Presize extends NamedWarpScriptFunction implements WarpScriptStackFunction {
 
   public Presize(String name) {
@@ -66,7 +70,7 @@ public class Presize extends NamedWarpScriptFunction implements WarpScriptStackF
     long PIXEL_LIMIT = (long) stack.getAttribute(WarpScriptStack.ATTRIBUTE_MAX_PIXELS);
 
     if ((long) width * height > PIXEL_LIMIT) {
-      throw new WarpScriptException(getName() + " only allows graphics or images with a total number of pixels less than " + PIXEL_LIMIT + " requested size was " + width + "x" + height + " (" + ((long) width * height) + ").");
+      throw new WarpScriptException(getName() + " only allows " + TYPEOF.TYPE_PGRAPHICSIMAGE + " or " + TYPEOF.TYPE_PIMAGE + " with a total number of pixels less than " + PIXEL_LIMIT + " requested size was " + width + "x" + height + " (" + ((long) width * height) + ").");
     }
 
     top = stack.pop();
@@ -76,7 +80,7 @@ public class Presize extends NamedWarpScriptFunction implements WarpScriptStackF
       img.resize(width, height);
       stack.push(img);
     } else {
-      throw new WarpScriptException(getName() + " expects an image or a PGraphics instance.");
+      throw new WarpScriptException(getName() + " expects a " + TYPEOF.TYPE_PIMAGE + " or a " + TYPEOF.TYPE_PGRAPHICSIMAGE + " instance.");
     }
 
     return stack;

--- a/warp10/src/main/java/io/warp10/script/processing/image/Presize.java
+++ b/warp10/src/main/java/io/warp10/script/processing/image/Presize.java
@@ -1,0 +1,84 @@
+//
+//   Copyright 2021  SenX S.A.S.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+package io.warp10.script.processing.image;
+
+import io.warp10.script.NamedWarpScriptFunction;
+import io.warp10.script.WarpScriptException;
+import io.warp10.script.WarpScriptStack;
+import io.warp10.script.WarpScriptStackFunction;
+import processing.core.PImage;
+
+public class Presize extends NamedWarpScriptFunction implements WarpScriptStackFunction {
+
+  public Presize(String name) {
+    super(name);
+  }
+
+  @Override
+  public Object apply(WarpScriptStack stack) throws WarpScriptException {
+
+    Object top = stack.pop();
+
+    if (!(top instanceof Long)) {
+      throw new WarpScriptException(getName() + " expects a height in pixel.");
+    }
+
+    int height = -1;
+    try {
+      height = Math.toIntExact((Long) top);
+      if (height < 0) {
+        throw new IllegalArgumentException();
+      }
+    } catch (ArithmeticException | IllegalArgumentException e) {
+      throw new WarpScriptException(getName() + " expects the height to be positive and less than " + Integer.MAX_VALUE + ".");
+    }
+
+    top = stack.pop();
+
+    if (!(top instanceof Long)) {
+      throw new WarpScriptException(getName() + " expects a width in pixel.");
+    }
+
+    int width = -1;
+    try {
+      width = Math.toIntExact((Long) top);
+      if (width < 0) {
+        throw new IllegalArgumentException();
+      }
+    } catch (ArithmeticException | IllegalArgumentException e) {
+      throw new WarpScriptException(getName() + " expects the height to be positive and less than " + Integer.MAX_VALUE + ".");
+    }
+
+    long PIXEL_LIMIT = (long) stack.getAttribute(WarpScriptStack.ATTRIBUTE_MAX_PIXELS);
+
+    if ((long) width * height > PIXEL_LIMIT) {
+      throw new WarpScriptException(getName() + " only allows graphics or images with a total number of pixels less than " + PIXEL_LIMIT + " requested size was " + width + "x" + height + " (" + ((long) width * height) + ").");
+    }
+
+    top = stack.pop();
+
+    if (top instanceof PImage) { // PGraphics extends PImage
+      PImage img = (PImage) top;
+      img.resize(width, height);
+      stack.push(img);
+    } else {
+      throw new WarpScriptException(getName() + " expects an image or a PGraphics instance.");
+    }
+
+    return stack;
+  }
+}

--- a/warp10/src/main/java/io/warp10/script/processing/image/Psize.java
+++ b/warp10/src/main/java/io/warp10/script/processing/image/Psize.java
@@ -20,6 +20,7 @@ import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptStack;
 import io.warp10.script.WarpScriptStackFunction;
+import io.warp10.script.functions.TYPEOF;
 import processing.core.PImage;
 
 public class Psize extends NamedWarpScriptFunction implements WarpScriptStackFunction {
@@ -38,7 +39,7 @@ public class Psize extends NamedWarpScriptFunction implements WarpScriptStackFun
       stack.push((long) pi.pixelWidth);
       stack.push((long) pi.pixelHeight);
     } else {
-      throw new WarpScriptException(getName() + " expects a PImage or a PGraphics instance.");
+      throw new WarpScriptException(getName() + " expects a " + TYPEOF.TYPE_PIMAGE + " or a " + TYPEOF.TYPE_PGRAPHICSIMAGE + " instance.");
     }
 
     return stack;

--- a/warp10/src/main/java/io/warp10/script/processing/image/Psize.java
+++ b/warp10/src/main/java/io/warp10/script/processing/image/Psize.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2020  SenX S.A.S.
+//   Copyright 2020-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -20,32 +20,27 @@ import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptStack;
 import io.warp10.script.WarpScriptStackFunction;
-import processing.core.PGraphics;
 import processing.core.PImage;
 
 public class Psize extends NamedWarpScriptFunction implements WarpScriptStackFunction {
-  
+
   public Psize(String name) {
     super(name);
   }
-  
+
   @Override
   public Object apply(WarpScriptStack stack) throws WarpScriptException {
-    
+
     Object top = stack.pop();
-    
-    if (top instanceof PGraphics) {
-      PGraphics pg = (PGraphics) top;
-      stack.push((long) pg.pixelWidth);
-      stack.push((long) pg.pixelHeight);
-    } else if (top instanceof PImage) {
-      PImage pi = (PImage) top;      
+
+    if (top instanceof PImage) { // PGraphics extends PImage
+      PImage pi = (PImage) top;
       stack.push((long) pi.pixelWidth);
       stack.push((long) pi.pixelHeight);
     } else {
-      throw new WarpScriptException(getName() + " expects an image or a PGraphics instance.");
+      throw new WarpScriptException(getName() + " expects a PImage or a PGraphics instance.");
     }
-        
+
     return stack;
   }
 }

--- a/warp10/src/main/java/io/warp10/script/processing/rendering/PGraphics.java
+++ b/warp10/src/main/java/io/warp10/script/processing/rendering/PGraphics.java
@@ -23,6 +23,7 @@ import io.warp10.script.WarpScriptStack;
 
 import java.awt.image.BufferedImage;
 
+import io.warp10.script.functions.TYPEOF;
 import processing.awt.PGraphicsJava2D;
 import processing.core.PApplet;
 import processing.opengl.PGraphics3D;
@@ -77,9 +78,9 @@ public class PGraphics extends NamedWarpScriptFunction implements WarpScriptStac
     int width = ((Number) top).intValue();
 
     long PIXEL_LIMIT = (long) stack.getAttribute(WarpScriptStack.ATTRIBUTE_MAX_PIXELS);
-    
+
     if ((long) width * height > PIXEL_LIMIT) {
-      throw new WarpScriptException(getName() + " only allows graphics with a total number of pixels less than " + PIXEL_LIMIT + " requested size was " + width + "x" + height + " (" + ((long) width * height) + ").");
+      throw new WarpScriptException(getName() + " only allows " + TYPEOF.TYPE_PGRAPHICSIMAGE + " with a total number of pixels less than " + PIXEL_LIMIT + " requested size was " + width + "x" + height + " (" + ((long) width * height) + ").");
     }
 
     // Disable async saving of frame in case we want to save a frame to a file

--- a/warp10/src/main/java/io/warp10/script/processing/rendering/PGraphics.java
+++ b/warp10/src/main/java/io/warp10/script/processing/rendering/PGraphics.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -78,8 +78,8 @@ public class PGraphics extends NamedWarpScriptFunction implements WarpScriptStac
 
     long PIXEL_LIMIT = (long) stack.getAttribute(WarpScriptStack.ATTRIBUTE_MAX_PIXELS);
     
-    if (width * height > PIXEL_LIMIT) {
-      throw new WarpScriptException(getName() + " only allows graphics with a total number of pixels less than " + PIXEL_LIMIT + " requested size was " + width + "x" + height + " (" + (width * height) + ").");
+    if ((long) width * height > PIXEL_LIMIT) {
+      throw new WarpScriptException(getName() + " only allows graphics with a total number of pixels less than " + PIXEL_LIMIT + " requested size was " + width + "x" + height + " (" + ((long) width * height) + ").");
     }
 
     // Disable async saving of frame in case we want to save a frame to a file


### PR DESCRIPTION
With a very large Warp 10 logo scaled to 1/20:

Only `Pimage`:
![pimage](https://user-images.githubusercontent.com/22769955/104482135-e17ec800-55c6-11eb-92f4-c8e2611f58a3.png)

`'ADD' Pblend` on a black background:
![pblend](https://user-images.githubusercontent.com/22769955/104482151-e3e12200-55c6-11eb-8770-14f98b16d6fd.png)

`Preszie` + `Pimage`:
![presize](https://user-images.githubusercontent.com/22769955/104482169-e5aae580-55c6-11eb-8559-c1a0cee1f5fd.png)
