### PR TITLE
Add LevelDB createIfMissing Warp 10 configuration

### DIFF
--- a/etc/conf.templates/standalone/10-leveldb.conf.template
+++ b/etc/conf.templates/standalone/10-leveldb.conf.template
@@ -1,5 +1,5 @@
 //
-//   Copyright 2019  SenX S.A.S.
+//   Copyright 2019-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -26,6 +26,17 @@
 // Directory where the leveldb files should be created
 //
 leveldb.home = ${standalone.home}/leveldb
+
+//
+// Whether to initialize LevelDB if not found in leveldb.home.
+// If false and LevelDB is not initialized, Warp 10 will throw an error and won't start. leveldb.home will still be created
+// as well as LOCK and LOG files.
+// If true and LevelDB is not initialized, all necessary LevelDB files will be created in leveldb.home and Warp 10 will
+// start as if LevelDB is already initialized.
+// This configuration has no effect if LevelDB is already initialized.
+// Defaults to false.
+//
+#leveldb.create.if.missing = false
 
 //
 // Flag to disable the native LevelDB implementation

--- a/etc/conf.templates/standalone/10-leveldb.conf.template
+++ b/etc/conf.templates/standalone/10-leveldb.conf.template
@@ -29,8 +29,7 @@ leveldb.home = ${standalone.home}/leveldb
 
 //
 // Whether to initialize LevelDB if not found in leveldb.home.
-// If false and LevelDB is not initialized, Warp 10 will throw an error and won't start. leveldb.home will still be created
-// as well as LOCK and LOG files.
+// If false and LevelDB is not initialized, Warp 10 will throw an error and won't start. leveldb.home will still be created.
 // If true and LevelDB is not initialized, all necessary LevelDB files will be created in leveldb.home and Warp 10 will
 // start as if LevelDB is already initialized.
 // This configuration has no effect if LevelDB is already initialized.

--- a/warp10/src/main/java/io/warp10/continuum/Configuration.java
+++ b/warp10/src/main/java/io/warp10/continuum/Configuration.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2020  SenX S.A.S.
+//   Copyright 2018-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -1461,6 +1461,11 @@ public class Configuration {
    * Directory where the leveldb files should be created
    */
   public static final String LEVELDB_HOME = "leveldb.home";
+
+  /**
+   * Create LevelDB if not already initialized
+   */
+  public static final String LEVELDB_CREATE_IF_MISSING = "leveldb.create.if.missing";
 
   /**
    * Maximum number of open files to use for LevelDB

--- a/warp10/src/main/java/io/warp10/standalone/Warp.java
+++ b/warp10/src/main/java/io/warp10/standalone/Warp.java
@@ -195,7 +195,7 @@ public class Warp extends WarpDist implements Runnable {
 
     Options options = new Options();
 
-    options.createIfMissing(false);
+    options.createIfMissing("true".equals(properties.getProperty(Configuration.LEVELDB_CREATE_IF_MISSING)));
 
     if (properties.containsKey(Configuration.LEVELDB_MAXOPENFILES)) {
       int maxOpenFiles = Integer.parseInt(properties.getProperty(Configuration.LEVELDB_MAXOPENFILES));


### PR DESCRIPTION
This can simplify tests, for instance, when tests have to be done on an empty LevelDB.

I'm not sure it should replace WarpInit however, because WarpInit makes additional checks (verifyChecksums and paranoidChecks).