### PR TITLE
Add default value to $1 to avoid unbound variable error if no parameter

### DIFF
--- a/warp10/src/main/sh/warp10-standalone.sh
+++ b/warp10/src/main/sh/warp10-standalone.sh
@@ -577,7 +577,7 @@ repair() {
 }
 
 # See how we were called.
-case "$1" in
+case "${1:-}" in
   bootstrap)
   bootstrap
   ;;


### PR DESCRIPTION
Fixes #874 

`set -u` does not seems to pose any problem, but I only tested on Ubuntu 20.04. 
```
# Extract JAVA_OPTS before we switch to strict mode
JAVA_OPTS=${JAVA_OPTS:-}
```
Seems to indicate `set -u` could pose problem with default values.