### PR TITLE
Remove deprecated configuration keys from templates

### DIFF
--- a/etc/conf.templates/distributed/00-secrets.conf.template
+++ b/etc/conf.templates/distributed/00-secrets.conf.template
@@ -1,5 +1,5 @@
 //
-//   Copyright 2019  SenX S.A.S.
+//   Copyright 2019-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -29,12 +29,6 @@ warp.hash.class = hex:hhhhhh...
 // 128 bits SipHash key for verifying labels. Valid formats are hex:..., base64:... or, when using OSS, wrapped:....
 //
 warp.hash.labels = hex:hhhhhh...
-
-//
-// @deprecated
-// 128 bits SipHash key for verifying index names. Valid formats are hex:..., base64:... or, when using OSS, wrapped:....
-//
-warp.hash.index = hex:hhhhhh...
 
 //
 // 128 bits SipHash key for verifying tokens. Valid formats are hex:..., base64:... or, when using OSS, wrapped:....

--- a/etc/conf.templates/standalone/00-secrets.conf.template
+++ b/etc/conf.templates/standalone/00-secrets.conf.template
@@ -1,5 +1,5 @@
 //
-//   Copyright 2019  SenX S.A.S.
+//   Copyright 2019-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -29,12 +29,6 @@ warp.hash.class = hex:hhhhhh...
 // 128 bits SipHash key for verifying labels. Valid formats are hex:..., base64:... or, when using OSS, wrapped:....
 //
 warp.hash.labels = hex:hhhhhh...
-
-//
-// @deprecated
-// 128 bits SipHash key for verifying index names. Valid formats are hex:..., base64:... or, when using OSS, wrapped:....
-//
-warp.hash.index = hex:hhhhhh...
 
 //
 // 128 bits SipHash key for verifying tokens. Valid formats are hex:..., base64:... or, when using OSS, wrapped:....

--- a/etc/conf.templates/standalone/10-leveldb.conf.template
+++ b/etc/conf.templates/standalone/10-leveldb.conf.template
@@ -1,5 +1,5 @@
 //
-//   Copyright 2019  SenX S.A.S.
+//   Copyright 2019-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -66,13 +66,6 @@ leveldb.directory.syncrate = 1.0
 // Valid formats are hex:..., base64:... or, when using OSS, wrapped:....
 //
 #leveldb.data.aes = hex:hhhhhh...
-
-//
-// @deprecated
-// 128/192/256 bits AES key for encrypting index details in in LevelDB.
-// Valid formats are hex:..., base64:... or, when using OSS, wrapped:....
-//
-#leveldb.index.aes = hex:hhhhhh...
 
 //
 // Cache size for leveldb (in bytes)


### PR DESCRIPTION
These keys were spotted by @pi-r-p in https://github.com/senx/warp10-platform/pull/863#issuecomment-760789122