### PR TITLE
Remove stacktrace and add clearer error message

### DIFF
--- a/warp10/src/main/java/io/warp10/standalone/WarpDB.java
+++ b/warp10/src/main/java/io/warp10/standalone/WarpDB.java
@@ -180,9 +180,8 @@ public class WarpDB extends Thread implements DB {
           throw new UnsatisfiedLinkError("Native LevelDB implementation disabled.");
         }
       } catch (NoClassDefFoundError|UnsatisfiedLinkError e) {
-        e.printStackTrace();
         if (!javadisabled) {
-          LOG.warn("WARNING: falling back to pure java implementation of LevelDB.");
+          LOG.warn("Falling back to pure java implementation of LevelDB because: " + e.getMessage());
           db = Iq80DBFactory.factory.open(new File(home), options);
         } else {
           throw new RuntimeException("No usable LevelDB implementation, aborting.");


### PR DESCRIPTION
Removed the stack trace because it gave the impression that Warp 10 failed to start or started in a bad state.

Instead change the log a bit so that for a `UnsatisfiedLinkError` it produces:
`WARN  standalone.WarpDB - Falling back to pure java implementation of LevelDB because: Native LevelDB implementation disabled.`

and for a `NoClassDefFoundError` it produces:
`WARN  standalone.WarpDB - Falling back to pure java implementation of LevelDB because: Could not load library. Reasons: [no leveldbjni64-2.7.2-39-g0b1bfad7 in java.library.path, no leveldbjni-2.7.2-39-g0b1bfad7 in java.library.path, no leveldbjni in java.library.path]`