### PR TITLE
Fix token expiry test

### DIFF
--- a/token/src/test/java/io/warp10/token/test/TestWriteToken.java
+++ b/token/src/test/java/io/warp10/token/test/TestWriteToken.java
@@ -115,7 +115,7 @@ public class TestWriteToken extends TokenTestCase {
 
     final QuasarTokenFilter tokenFilter = new QuasarTokenFilter(getConfig(), getKeyStore());
 
-    Thread.sleep(1);
+    Thread.sleep(2);
 
     try {
       tokenFilter.getWriteToken(writeToken);


### PR DESCRIPTION
The `testTokenExpired` fails sometimes because:
- The token is created with `issuance = System.currentTimeMillis()` and `ttl = 1 ms`.
- A sleep of 1 ms is done
- The validity of the token is checked with `(issuance + ttl) < System.currentTimeMillis()` which fails sometimes, because `(issuance + ttl) == System.currentTimeMillis()`