### PR TITLE
Uniformize and improve error messages for ATC Exceptions

### DIFF
--- a/warp10/src/main/java/io/warp10/script/WarpScriptLib.java
+++ b/warp10/src/main/java/io/warp10/script/WarpScriptLib.java
@@ -1546,7 +1546,7 @@ public class WarpScriptLib {
     //
 
     addNamedWarpScriptFunction(new RETURN(RETURN));
-    addNamedWarpScriptFunction(new NRETURN(NRETURN));
+    addNamedWarpScriptFunction(new RETURN(NRETURN, true));
 
     //
     // GTS standalone functions

--- a/warp10/src/main/java/io/warp10/script/WarpScriptReturnException.java
+++ b/warp10/src/main/java/io/warp10/script/WarpScriptReturnException.java
@@ -18,8 +18,6 @@ package io.warp10.script;
 
 public class WarpScriptReturnException extends WarpScriptStopException {
   
-  private int n;
-  
   public WarpScriptReturnException(String message) {
     super(message);
   }

--- a/warp10/src/main/java/io/warp10/script/functions/BREAK.java
+++ b/warp10/src/main/java/io/warp10/script/functions/BREAK.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -17,19 +17,26 @@
 package io.warp10.script.functions;
 
 import io.warp10.script.NamedWarpScriptFunction;
-import io.warp10.script.WarpScriptStackFunction;
 import io.warp10.script.WarpScriptException;
+import io.warp10.script.WarpScriptLib;
 import io.warp10.script.WarpScriptLoopBreakException;
 import io.warp10.script.WarpScriptStack;
+import io.warp10.script.WarpScriptStackFunction;
 
 public class BREAK extends NamedWarpScriptFunction implements WarpScriptStackFunction {
-  
+
+  public static String[] loopNames = new String[]{WarpScriptLib.FOR, WarpScriptLib.FOREACH, WarpScriptLib.FORSTEP, WarpScriptLib.WHILE, WarpScriptLib.UNTIL};
+
+  // The stack trace is not used so it can be instantiated once.
+  private final WarpScriptLoopBreakException ex;
+
   public BREAK(String name) {
     super(name);
+    ex = new WarpScriptLoopBreakException("Exception at " + name + ": must be used in a one of " + String.join(", ", loopNames) + " loop.");
   }
-  
+
   @Override
   public Object apply(WarpScriptStack stack) throws WarpScriptException {
-    throw new WarpScriptLoopBreakException("BREAK");
+    throw ex;
   }
 }

--- a/warp10/src/main/java/io/warp10/script/functions/CONTINUE.java
+++ b/warp10/src/main/java/io/warp10/script/functions/CONTINUE.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -17,19 +17,23 @@
 package io.warp10.script.functions;
 
 import io.warp10.script.NamedWarpScriptFunction;
-import io.warp10.script.WarpScriptStackFunction;
 import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptLoopContinueException;
 import io.warp10.script.WarpScriptStack;
+import io.warp10.script.WarpScriptStackFunction;
 
 public class CONTINUE extends NamedWarpScriptFunction implements WarpScriptStackFunction {
-  
+
+  // The stack trace is not used so it can be instantiated once.
+  private final WarpScriptLoopContinueException ex;
+
   public CONTINUE(String name) {
     super(name);
+    ex = new WarpScriptLoopContinueException("Exception at " + name + ": must be used in a one of " + String.join(", ", BREAK.loopNames) + " loop.");
   }
-  
+
   @Override
   public Object apply(WarpScriptStack stack) throws WarpScriptException {
-    throw new WarpScriptLoopContinueException("CONTINUE");
+    throw ex;
   }
 }

--- a/warp10/src/main/java/io/warp10/script/functions/NRETURN.java
+++ b/warp10/src/main/java/io/warp10/script/functions/NRETURN.java
@@ -35,7 +35,7 @@ public class NRETURN extends NamedWarpScriptFunction implements WarpScriptStackF
 
   public NRETURN(String name) {
     super(name);
-    ex = new WarpScriptReturnException("name");
+    ex = new WarpScriptReturnException(name);
   }
 
   @Override
@@ -43,7 +43,7 @@ public class NRETURN extends NamedWarpScriptFunction implements WarpScriptStackF
     Object top = stack.pop();
 
     if (!(top instanceof Long)) {
-      throw new WarpScriptException(getName() + " expects a number of levels on top of the stack.");
+      throw new WarpScriptException(getName() + " expects a number of levels.");
     }
 
     stack.getCounter(WarpScriptStack.COUNTER_RETURN_DEPTH).set(((Number) top).longValue());

--- a/warp10/src/main/java/io/warp10/script/functions/NRETURN.java
+++ b/warp10/src/main/java/io/warp10/script/functions/NRETURN.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -17,30 +17,35 @@
 package io.warp10.script.functions;
 
 import io.warp10.script.NamedWarpScriptFunction;
-import io.warp10.script.WarpScriptStackFunction;
 import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptReturnException;
 import io.warp10.script.WarpScriptStack;
+import io.warp10.script.WarpScriptStackFunction;
 
 /**
  * Exit up to N levels of macros
+ *
+ * @deprecated Use RETURN with multi parameter to true.
  */
+@Deprecated
 public class NRETURN extends NamedWarpScriptFunction implements WarpScriptStackFunction {
-  
+
+  // The stack trace is not used so it can be instantiated once.
+  private final WarpScriptReturnException ex;
+
   public NRETURN(String name) {
     super(name);
+    ex = new WarpScriptReturnException("name");
   }
-  
-  private final WarpScriptReturnException ex = new WarpScriptReturnException("NRETURN");
-  
+
   @Override
   public Object apply(WarpScriptStack stack) throws WarpScriptException {
     Object top = stack.pop();
-    
+
     if (!(top instanceof Long)) {
       throw new WarpScriptException(getName() + " expects a number of levels on top of the stack.");
     }
-    
+
     stack.getCounter(WarpScriptStack.COUNTER_RETURN_DEPTH).set(((Number) top).longValue());
     throw ex;
   }

--- a/warp10/src/main/java/io/warp10/script/functions/RETURN.java
+++ b/warp10/src/main/java/io/warp10/script/functions/RETURN.java
@@ -49,7 +49,7 @@ public class RETURN extends NamedWarpScriptFunction implements WarpScriptStackFu
       Object top = stack.pop();
 
       if (!(top instanceof Long)) {
-        throw new WarpScriptException(getName() + " expects a number of levels on top of the stack.");
+        throw new WarpScriptException(getName() + " expects a number of levels.");
       }
 
       levels = ((Number) top).longValue();

--- a/warp10/src/main/java/io/warp10/script/functions/RETURN.java
+++ b/warp10/src/main/java/io/warp10/script/functions/RETURN.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -17,25 +17,45 @@
 package io.warp10.script.functions;
 
 import io.warp10.script.NamedWarpScriptFunction;
-import io.warp10.script.WarpScriptStackFunction;
 import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptReturnException;
 import io.warp10.script.WarpScriptStack;
+import io.warp10.script.WarpScriptStackFunction;
 
 /**
  * Immediately exit the currently executing macro.
  */
 public class RETURN extends NamedWarpScriptFunction implements WarpScriptStackFunction {
-  
-  private final WarpScriptReturnException ex = new WarpScriptReturnException("RETURN");
-  
+
+  // The stack trace is not used so it can be instantiated once.
+  private final WarpScriptReturnException ex;
+  private final boolean multi;
+
   public RETURN(String name) {
-    super(name);
+    this(name, false);
   }
-  
+
+  public RETURN(String name, boolean multi) {
+    super(name);
+    this.multi = multi;
+    ex = new WarpScriptReturnException(name);
+  }
+
   @Override
   public Object apply(WarpScriptStack stack) throws WarpScriptException {
-    stack.getCounter(WarpScriptStack.COUNTER_RETURN_DEPTH).set(1L);
+    long levels = 1L;
+
+    if (multi) {
+      Object top = stack.pop();
+
+      if (!(top instanceof Long)) {
+        throw new WarpScriptException(getName() + " expects a number of levels on top of the stack.");
+      }
+
+      levels = ((Number) top).longValue();
+    }
+
+    stack.getCounter(WarpScriptStack.COUNTER_RETURN_DEPTH).set(levels);
     throw ex;
   }
 }

--- a/warp10/src/main/java/io/warp10/script/functions/TIMESPLIT.java
+++ b/warp10/src/main/java/io/warp10/script/functions/TIMESPLIT.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -19,14 +19,8 @@ package io.warp10.script.functions;
 import io.warp10.continuum.gts.GTSHelper;
 import io.warp10.continuum.gts.GeoTimeSerie;
 import io.warp10.script.ElementOrListStackFunction;
-import io.warp10.script.GTSStackFunction;
 import io.warp10.script.WarpScriptException;
-import io.warp10.script.WarpScriptLoopContinueException;
 import io.warp10.script.WarpScriptStack;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Apply timesplit on GTS instances


### PR DESCRIPTION
For a script containing only `CONTINUE` the error message is currently `CONTINUE`.
This PR changes it to `Exception at CONTINUE: must be used in a one of FOR, FOREACH, FORSTEP, WHILE, UNTIL loop.`

This is more informative than what we have currently but less than what we get for other WarpScriptException. Having the same level of information will probably have a negative impact on the performance on the use of WarpScriptATCException so this PR might be the right balance.

`CONTINUE` and `BREAK` now use a single Exception instance which is better in terms of performance but makes the display of the stack trace impossible. I'm not sure if it is problematic or not.

`RETURN` and `NRETURN` has also been merged and the `NRETURN` class is marked as deprecated, but not the function.

Some useless imports have been removed.