### PR TITLE
Better handling of errors in websockets

### DIFF
--- a/warp10/src/main/java/io/warp10/continuum/egress/EgressMobiusHandler.java
+++ b/warp10/src/main/java/io/warp10/continuum/egress/EgressMobiusHandler.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -161,8 +161,6 @@ public class EgressMobiusHandler extends WebSocketHandler.Simple implements Runn
       
       WarpScriptStack stack = new MemoryWarpScriptStack(null, null);           
 
-      boolean error = false;
-      
       try {
         //
         // Replace the context with the bootstrap one

--- a/warp10/src/main/java/io/warp10/continuum/ingress/IngressStreamUpdateHandler.java
+++ b/warp10/src/main/java/io/warp10/continuum/ingress/IngressStreamUpdateHandler.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2020  SenX S.A.S.
+//   Copyright 2018-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -429,7 +429,7 @@ public class IngressStreamUpdateHandler extends WebSocketHandler.Simple {
           String msg = "ERROR " + ThrowableUtils.getErrorMessage(t);
           session.getRemote().sendString(msg);
         } else {
-          throw t;
+          session.close(HttpServletResponse.SC_BAD_REQUEST, ThrowableUtils.getErrorMessage(t));
         }
       }      
     }

--- a/warp10/src/main/java/io/warp10/standalone/StandalonePlasmaHandler.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandalonePlasmaHandler.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2020  SenX S.A.S.
+//   Copyright 2018-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.warp10.standalone;
 
+import io.warp10.ThrowableUtils;
 import io.warp10.json.JsonUtils;
 import io.warp10.continuum.Configuration;
 import io.warp10.continuum.Tokens;
@@ -321,7 +322,7 @@ public class StandalonePlasmaHandler extends WebSocketHandler.Simple implements 
           this.handler.sampleRate.remove(session);
         }
       } else {
-        throw new IOException("Invalid verb.");
+        session.close(HttpServletResponse.SC_BAD_REQUEST, "Invalid verb.");
       }
     }
     

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneStreamUpdateHandler.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneStreamUpdateHandler.java
@@ -614,7 +614,7 @@ public class StandaloneStreamUpdateHandler extends WebSocketHandler.Simple {
           String msg = "ERROR " + ThrowableUtils.getErrorMessage(t);
           session.getRemote().sendString(msg);
         } else {
-          throw t;
+          session.close(HttpServletResponse.SC_BAD_REQUEST, ThrowableUtils.getErrorMessage(t));
         }
       }
     }


### PR DESCRIPTION
Throwing an exception in a `@OnWebSocketMessage` method result in a Jetty error:
```
Cannot call method public void io.warp10.standalone.StandaloneStreamUpdateHandler$StandaloneStreamUpdateWebSocket#onWebSocketMessage(org.eclipse.jetty.websocket.api.Session, java.lang.String) with args: [org.eclipse.jetty.websocket.common.WebSocketSession, java.lang.String]
```

It seems the correct way is to close the session with a status code and an error message, which is what this PR does.