### PR TITLE
Avoid overflow of the encoder estimated size

### DIFF
--- a/warp10/src/main/java/io/warp10/standalone/InMemoryChunkSet.java
+++ b/warp10/src/main/java/io/warp10/standalone/InMemoryChunkSet.java
@@ -471,7 +471,14 @@ public class InMemoryChunkSet {
     long oursize = this.getSize();
     long ourcount = this.getCount();
     int avgsize = (int) Math.ceil((double) oursize / (double) ourcount);
-    int hint = (int) Math.min((int) (count * avgsize), this.getSize());
+    int estimatedEncoderSize;
+    try {
+      // estimatedEncoderSize = (count + postBoundary) * avgsize
+      estimatedEncoderSize = Math.toIntExact(Math.multiplyExact(Math.addExact(count, postBoundary), avgsize));
+    } catch (ArithmeticException ae) {
+      estimatedEncoderSize = Integer.MAX_VALUE;
+    }
+    int hint = (int) Math.min(estimatedEncoderSize, this.getSize());
     GTSEncoder encoder = new GTSEncoder(0L, null, hint);
 
     //


### PR DESCRIPTION
`hint` could be negative when count is large because of an overflow. This PR handles the overflow.

Also added the postBoundary to the count to have a more precise estimation of the encoder size.