### PR TITLE
PcreateFont: Fix parameter handling to allow for default 12 size

### DIFF
--- a/warp10/src/main/java/io/warp10/script/processing/typography/PcreateFont.java
+++ b/warp10/src/main/java/io/warp10/script/processing/typography/PcreateFont.java
@@ -43,6 +43,8 @@ import processing.core.PGraphics;
  * Call createFont
  */
 public class PcreateFont extends NamedWarpScriptFunction implements WarpScriptStackFunction {
+
+  public static float DEFAULT_FONT_SIZE = 12.0F;
     
   private final FontResolver resolver;
   
@@ -109,7 +111,7 @@ public class PcreateFont extends NamedWarpScriptFunction implements WarpScriptSt
         
         Font f = Font.createFont(Font.TRUETYPE_FONT, in);
         
-        float size = 12.0F;
+        float size = DEFAULT_FONT_SIZE;
         boolean smooth = true;
         char[] charset = null;
         
@@ -135,7 +137,7 @@ public class PcreateFont extends NamedWarpScriptFunction implements WarpScriptSt
       }      
     } else {
       if (2 == params.size()) {
-        font = pg.parent.createFont(params.get(1).toString(), 12.0F);
+        font = pg.parent.createFont(params.get(1).toString(), DEFAULT_FONT_SIZE);
       } else if (3 == params.size()) {
         font = pg.parent.createFont(params.get(1).toString(), ((Number) params.get(2)).floatValue());
       } else if (4 == params.size()) {

--- a/warp10/src/main/java/io/warp10/script/processing/typography/PcreateFont.java
+++ b/warp10/src/main/java/io/warp10/script/processing/typography/PcreateFont.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -78,7 +78,7 @@ public class PcreateFont extends NamedWarpScriptFunction implements WarpScriptSt
   @Override
   public Object apply(WarpScriptStack stack) throws WarpScriptException {
     
-    List<Object> params = ProcessingUtil.parseParams(stack, 2, 3, 4);
+    List<Object> params = ProcessingUtil.parseParams(stack, 1, 2, 3, 4);
         
     PGraphics pg = (PGraphics) params.get(0);
 
@@ -134,7 +134,9 @@ public class PcreateFont extends NamedWarpScriptFunction implements WarpScriptSt
         if (null != in) { try { in.close(); } catch (Exception e) {} }
       }      
     } else {
-      if (3 == params.size()) {      
+      if (2 == params.size()) {
+        font = pg.parent.createFont(params.get(1).toString(), 12.0F);
+      } else if (3 == params.size()) {
         font = pg.parent.createFont(params.get(1).toString(), ((Number) params.get(2)).floatValue());
       } else if (4 == params.size()) {
         font = pg.parent.createFont(


### PR DESCRIPTION
The documentation specifies that the size is optional and the online font case (line 92) does handle that case with a default of 12 size font.