### PR TITLE
Make more types snapshotable

### DIFF
--- a/warp10/src/main/java/io/warp10/script/WarpScriptLib.java
+++ b/warp10/src/main/java/io/warp10/script/WarpScriptLib.java
@@ -346,15 +346,19 @@ public class WarpScriptLib {
   public static final String NOOP = "NOOP";
   public static final String JSONTO = "JSON->";
 
+  public static final String EMPTY_MAP = "{}";
   public static final String MAP_START = "{";
   public static final String MAP_END = "}";
 
+  public static final String EMPTY_LIST = "[]";
   public static final String LIST_START = "[";
   public static final String LIST_END = "]";
 
+  public static final String EMPTY_SET = "()";
   public static final String SET_START = "(";
   public static final String SET_END = ")";
 
+  public static final String EMPTY_VECTOR = "[[]]";
   public static final String VECTOR_START = "[[";
   public static final String VECTOR_END = "]]";
 
@@ -1313,17 +1317,17 @@ public class WarpScriptLib {
     addNamedWarpScriptFunction(new MMAP(MMAP));
     addNamedWarpScriptFunction(new NONNULL(NONNULL));
     addNamedWarpScriptFunction(new LMAP(LFLATMAP, true));
-    addNamedWarpScriptFunction(new EMPTYLIST("[]"));
+    addNamedWarpScriptFunction(new EMPTYLIST(EMPTY_LIST));
     addNamedWarpScriptFunction(new MARK(LIST_START));
     addNamedWarpScriptFunction(new ENDLIST(LIST_END));
     addNamedWarpScriptFunction(new STACKTOLIST(STACKTOLIST));
     addNamedWarpScriptFunction(new MARK(SET_START));
     addNamedWarpScriptFunction(new ENDSET(SET_END));
-    addNamedWarpScriptFunction(new EMPTYSET("()"));
+    addNamedWarpScriptFunction(new EMPTYSET(EMPTY_SET));
     addNamedWarpScriptFunction(new MARK(VECTOR_START));
     addNamedWarpScriptFunction(new ENDVECTOR(VECTOR_END));
-    addNamedWarpScriptFunction(new EMPTYVECTOR("[[]]"));
-    addNamedWarpScriptFunction(new EMPTYMAP("{}"));
+    addNamedWarpScriptFunction(new EMPTYVECTOR(EMPTY_VECTOR));
+    addNamedWarpScriptFunction(new EMPTYMAP(EMPTY_MAP));
     addNamedWarpScriptFunction(new IMMUTABLE(IMMUTABLE));
     addNamedWarpScriptFunction(new MARK(MAP_START));
     addNamedWarpScriptFunction(new ENDMAP(MAP_END));
@@ -1339,6 +1343,7 @@ public class WarpScriptLib {
     addNamedWarpScriptFunction(new SECTION(SECTION));
     addNamedWarpScriptFunction(new GETSECTION(GETSECTION));
     addNamedWarpScriptFunction(new SNAPSHOT(SNAPSHOT, false, false, true, false));
+    addNamedWarpScriptFunction(new SNAPSHOT("SNAPSHOTREADABLE", false, false, true, false, true, true));
     addNamedWarpScriptFunction(new SNAPSHOT(SNAPSHOTALL, true, false, true, false));
     addNamedWarpScriptFunction(new SNAPSHOT(SNAPSHOTTOMARK, false, true, true, false));
     addNamedWarpScriptFunction(new SNAPSHOT(SNAPSHOTALLTOMARK, true, true, true, false));

--- a/warp10/src/main/java/io/warp10/script/functions/SNAPSHOT.java
+++ b/warp10/src/main/java/io/warp10/script/functions/SNAPSHOT.java
@@ -416,39 +416,8 @@ public class SNAPSHOT extends NamedWarpScriptFunction implements WarpScriptStack
       } else if (o instanceof NamedWarpScriptFunction) {
         sb.append(o.toString());
         sb.append(" ");
-      } else if (o instanceof PGraphics) {
-        if(o instanceof PGraphicsJava2D || o instanceof PGraphics3D) {
-          PGraphics pg = (PGraphics) o;
-          sb.append("'");
-          sb.append(Pencode.PImageToString(pg, null));
-          sb.append("' ");
-          sb.append(WarpScriptLib.PDECODE);
-          sb.append(" ");
-          sb.append(WarpScriptLib.DUP);
-          sb.append(" ");
-          sb.append(WarpScriptLib.PSIZE);
-          sb.append(" '");
-          if (pg instanceof PGraphicsJava2D) {
-            sb.append("2D");
-          } else {
-            sb.append("3D");
-          }
-          sb.append(pg.smooth);
-          sb.append("' ");
-          sb.append(WarpScriptLib.PGRAPHICS);
-          sb.append(" ");
-          sb.append(WarpScriptLib.SWAP);
-          sb.append(" ");
-          sb.append(WarpScriptLib.PBACKGROUND);
-          sb.append(" ");
-        } else {
-          try {
-            sb.append("'UNSUPPORTED:" + WarpURLEncoder.encode(o.getClass().toString(), StandardCharsets.UTF_8) + "' ");
-          } catch (UnsupportedEncodingException uee) {
-            throw new WarpScriptException(uee);
-          }
-        }
-      } else if (o instanceof PImage) {
+      } else if (o instanceof PImage && !(o instanceof PGraphics)) {
+        // PGraphics cannot be snapshot properly because it would require PFont to be snapshotable, which is not.
         sb.append("'");
         sb.append(Pencode.PImageToString((PImage) o, null));
         sb.append("' ");
@@ -467,11 +436,7 @@ public class SNAPSHOT extends NamedWarpScriptFunction implements WarpScriptStack
           sb.append(WarpScriptLib.PLOADSHAPE);
           sb.append(" ");
         } catch (NoSuchFieldException | IllegalAccessException e) {
-          try {
-            sb.append("'UNSUPPORTED:" + WarpURLEncoder.encode(o.getClass().toString(), StandardCharsets.UTF_8) + "' ");
-          } catch (UnsupportedEncodingException uee) {
-            throw new WarpScriptException(uee);
-          }
+          sb.append("'UNSUPPORTED:" + WarpURLEncoder.encode(o.getClass().toString(), StandardCharsets.UTF_8) + "' ");
         }
       } else if (o instanceof RealVector) {
         RealVector vector = (RealVector) o;
@@ -496,8 +461,9 @@ public class SNAPSHOT extends NamedWarpScriptFunction implements WarpScriptStack
         sb.append(WarpScriptLib.TOMAT);
         sb.append(" ");
       } else if (o instanceof Matcher) {
+        sb.append("'");
         sb.append(((Matcher) o).pattern());
-        sb.append(" ");
+        sb.append("' ");
         sb.append(WarpScriptLib.MATCHER);
         sb.append(" ");
       } else {
@@ -517,13 +483,11 @@ public class SNAPSHOT extends NamedWarpScriptFunction implements WarpScriptStack
         // Nevertheless we need to have the correct levels of the stack preserved, so
         // we push an informative string onto the stack there
         if (!encoded) {
-          try {
-            sb.append("'UNSUPPORTED:" + WarpURLEncoder.encode(o.getClass().toString(), StandardCharsets.UTF_8) + "' ");
-          } catch (UnsupportedEncodingException uee) {
-            throw new WarpScriptException(uee);
-          }
+          sb.append("'UNSUPPORTED:" + WarpURLEncoder.encode(o.getClass().toString(), StandardCharsets.UTF_8) + "' ");
         }
       }
+    } catch (UnsupportedEncodingException uee) {
+      throw new WarpScriptException(uee);
     } finally {
       if (null != depth && 0 == depth.addAndGet(-1)) {
         recursionDepth.remove();

--- a/warp10/src/main/java/io/warp10/script/functions/SNAPSHOT.java
+++ b/warp10/src/main/java/io/warp10/script/functions/SNAPSHOT.java
@@ -30,6 +30,8 @@ import io.warp10.script.WarpScriptStack;
 import io.warp10.script.WarpScriptStack.Mark;
 import io.warp10.script.WarpScriptStackFunction;
 import io.warp10.script.processing.Pencode;
+import org.apache.commons.math3.linear.RealMatrix;
+import org.apache.commons.math3.linear.RealVector;
 import processing.awt.PGraphicsJava2D;
 import processing.core.PGraphics;
 import processing.core.PImage;
@@ -442,6 +444,28 @@ public class SNAPSHOT extends NamedWarpScriptFunction implements WarpScriptStack
         sb.append(Pencode.PImageToString((PImage) o, null));
         sb.append("' ");
         sb.append(WarpScriptLib.PDECODE);
+        sb.append(" ");
+      } else if (o instanceof RealVector) {
+        RealVector vector = (RealVector) o;
+        sb.append("[] ");
+        for (int i = 0; i < vector.getDimension(); i++) {
+          sb.append(vector.getEntry(i));
+          sb.append(" +! ");
+        }
+        sb.append(WarpScriptLib.TOVEC);
+        sb.append(" ");
+      } else if (o instanceof RealMatrix) {
+        RealMatrix matrix = (RealMatrix) o;
+        sb.append("[] ");
+        for (int i = 0; i < matrix.getColumnDimension(); i++) {
+          sb.append("[] ");
+          for (int j = 0; j < matrix.getRowDimension(); j++) {
+            sb.append(matrix.getEntry(i, j));
+            sb.append(" +! ");
+          }
+          sb.append(" +! ");
+        }
+        sb.append(WarpScriptLib.TOMAT);
         sb.append(" ");
       } else {
         // Check if any of the defined encoders can encode the current element

--- a/warp10/src/main/java/io/warp10/script/functions/SNAPSHOT.java
+++ b/warp10/src/main/java/io/warp10/script/functions/SNAPSHOT.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2020  SenX S.A.S.
+//   Copyright 2020-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -27,9 +27,13 @@ import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptLib;
 import io.warp10.script.WarpScriptStack;
-import io.warp10.script.WarpScriptStack.Macro;
 import io.warp10.script.WarpScriptStack.Mark;
 import io.warp10.script.WarpScriptStackFunction;
+import io.warp10.script.processing.Pencode;
+import processing.awt.PGraphicsJava2D;
+import processing.core.PGraphics;
+import processing.core.PImage;
+import processing.opengl.PGraphics3D;
 
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
@@ -406,6 +410,38 @@ public class SNAPSHOT extends NamedWarpScriptFunction implements WarpScriptStack
         sb.append(" ");
       } else if (o instanceof NamedWarpScriptFunction) {
         sb.append(o.toString());
+        sb.append(" ");
+      } else if (o instanceof PGraphics) {
+        PGraphics pg = (PGraphics) o;
+        sb.append("'");
+        sb.append(Pencode.PImageToString(pg, null));
+        sb.append("' ");
+        sb.append(WarpScriptLib.PDECODE);
+        sb.append(" ");
+        sb.append(WarpScriptLib.DUP);
+        sb.append(" ");
+        sb.append(WarpScriptLib.PSIZE);
+        sb.append(" '");
+        if (pg instanceof PGraphicsJava2D) {
+          sb.append("2D");
+        } else if (pg instanceof PGraphics3D) {
+          sb.append("3D");
+        } else {
+          throw new WarpScriptException("Neither 2D or 3D PGraphics encounter.");
+        }
+        sb.append(pg.smooth);
+        sb.append("' ");
+        sb.append(WarpScriptLib.PGRAPHICS);
+        sb.append(" ");
+        sb.append(WarpScriptLib.SWAP);
+        sb.append(" ");
+        sb.append(WarpScriptLib.PBACKGROUND);
+        sb.append(" ");
+      } else if (o instanceof PImage) {
+        sb.append("'");
+        sb.append(Pencode.PImageToString((PImage) o, null));
+        sb.append("' ");
+        sb.append(WarpScriptLib.PDECODE);
         sb.append(" ");
       } else {
         // Check if any of the defined encoders can encode the current element

--- a/warp10/src/main/java/io/warp10/script/functions/SNAPSHOT.java
+++ b/warp10/src/main/java/io/warp10/script/functions/SNAPSHOT.java
@@ -52,6 +52,7 @@ import java.util.UUID;
 import java.util.Vector;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.regex.Matcher;
 
 /**
  * Replaces the stack so far with a WarpScript snippet which will regenerate
@@ -467,6 +468,11 @@ public class SNAPSHOT extends NamedWarpScriptFunction implements WarpScriptStack
         }
         sb.append(WarpScriptLib.TOMAT);
         sb.append(" ");
+      } else if (o instanceof Matcher) {
+        sb.append(((Matcher) o).pattern());
+        sb.append(" ");
+        sb.append(WarpScriptLib.MATCHER);
+        sb.append(" ");
       } else {
         // Check if any of the defined encoders can encode the current element
         // loops will be caught by the recursion level check
@@ -481,7 +487,6 @@ public class SNAPSHOT extends NamedWarpScriptFunction implements WarpScriptStack
         }
 
         // Some types are not supported
-        // functions, PImage...
         // Nevertheless we need to have the correct levels of the stack preserved, so
         // we push an informative string onto the stack there
         if (!encoded) {

--- a/warp10/src/main/java/io/warp10/script/processing/Pencode.java
+++ b/warp10/src/main/java/io/warp10/script/processing/Pencode.java
@@ -30,7 +30,6 @@ import javax.imageio.ImageIO;
 import javax.imageio.ImageWriteParam;
 import javax.imageio.ImageWriter;
 
-import io.warp10.script.processing.image.Pimage;
 import org.apache.commons.codec.binary.Base64;
 
 import com.sun.imageio.plugins.png.PNGMetadata;
@@ -170,7 +169,7 @@ public class Pencode extends NamedWarpScriptFunction implements WarpScriptStackF
 
       writer.write(null, iioimage, param);
     } catch (IOException ioe) {
-      throw new WarpScriptException("Error while encoding PGraphics.", ioe);
+      throw new WarpScriptException("Error while encoding PGraphics or PImage.", ioe);
     }
 
     writer.dispose();


### PR DESCRIPTION
This PR adds:
- PGraphics
- PImage
- RealVector
- RealMatrix
- Matcher
- PShape (using reflection)

Types that can be created with core WarpScript that are still unhanded:
- PFont because it does not contain enough information to recreate the font with `PcreateFont` like the URI.
- StackContext because it could expose defined functions.