### PR TITLE
Add FUNCREF and improve snapshots of WarpScriptStackFunctions

### DIFF
--- a/warp10/src/main/java/io/warp10/script/MacroHelper.java
+++ b/warp10/src/main/java/io/warp10/script/MacroHelper.java
@@ -50,22 +50,26 @@ public class MacroHelper {
       if (null != getName()) {
         return super.toString();
       } else {
-        return this.macro.toString() + " " + WarpScriptLib.EVAL;
+        return this.macro.toString();
       }
     }
     
     @Override
     public String snapshot() {
-      if (null != macro) {
-        return macro.snapshot() + " " + WarpScriptLib.EVAL;
+      if (null != getName()) {
+        return super.toString();
       } else {
-        return this.toString();
+        return macro.snapshot() + " " + WarpScriptLib.EVAL;
       }
     }
   }
   
   public static WarpScriptStackFunction wrap(Macro m) {
-    return new MacroWrapper(null, m);
+    return wrap(null, m);
+  }
+
+  public static WarpScriptStackFunction wrap(String name, Macro m) {
+    return new MacroWrapper(name, m);
   }
   
   public static WarpScriptStackFunction wrap(String name, String mc2, boolean secure) {

--- a/warp10/src/main/java/io/warp10/script/MacroHelper.java
+++ b/warp10/src/main/java/io/warp10/script/MacroHelper.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -47,16 +47,16 @@ public class MacroHelper {
      
     @Override
     public String toString() {
-      if (null != getName()) {
+      if (null != getName() || null == macro) {
         return super.toString();
       } else {
-        return this.macro.toString();
+        return macro.toString();
       }
     }
     
     @Override
     public String snapshot() {
-      if (null != getName()) {
+      if (null != getName() || null == macro) {
         return super.toString();
       } else {
         return macro.snapshot() + " " + WarpScriptLib.EVAL;

--- a/warp10/src/main/java/io/warp10/script/MemoryWarpScriptStack.java
+++ b/warp10/src/main/java/io/warp10/script/MemoryWarpScriptStack.java
@@ -33,6 +33,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
+import io.warp10.script.functions.MSGFAIL;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.util.Progressable;
 
@@ -841,23 +842,11 @@ public class MemoryWarpScriptStack implements WarpScriptStack, Progressable {
             // This is a function call
             //
 
-            Object func = null;
+            Object func = findFunction(stmt);
 
             //
             // Check WarpScript functions
             //
-
-            func = defined.get(stmt);
-
-            if (null != func && Boolean.FALSE.equals(getAttribute(WarpScriptStack.ATTRIBUTE_ALLOW_REDEFINED))) {
-              throw new WarpScriptException("Disallowed redefined function '" + stmt + "'.");
-            }
-
-            func = null != func ? func : WarpScriptLib.getFunction(stmt);
-
-            if (null == func) {
-              throw new WarpScriptException("Unknown function '" + stmt + "'");
-            }
 
             Map<String,String> labels = new HashMap<String,String>();
             labels.put(SensisionConstants.SENSISION_LABEL_FUNCTION, stmt);
@@ -995,10 +984,20 @@ public class MemoryWarpScriptStack implements WarpScriptStack, Progressable {
       } else {
         String name = macro.getName();
         String section = (String) this.getAttribute(WarpScriptStack.ATTRIBUTE_SECTION_NAME);
+        Object statement = macro.get(i);
+        String statementString = statement.toString();
+        // For NamedWarpScriptFunction, toString is used for snapshotting. Getting the name is better to generate
+        // a clear error message.
+        if(statement instanceof NamedWarpScriptFunction) {
+          String funcName = ((NamedWarpScriptFunction) statement).getName();
+          if(null != funcName) {
+            statementString = funcName;
+          }
+        }
         if (null == name) {
-          throw new WarpScriptException("Exception" + (i < n ? (" at '" + macro.get(i).toString() + "'") : "") + " in section '" + section + "'", ee);
+          throw new WarpScriptException("Exception" + (i < n ? (" at '" + statementString + "'") : "") + " in section '" + section + "'", ee);
         } else {
-          throw new WarpScriptException("Exception" + (i < n ? (" at '" + macro.get(i).toString() + "'") : "") + " in section '" + section + "' called from macro '" + name + "'", ee);
+          throw new WarpScriptException("Exception" + (i < n ? (" at '" + statementString + "'") : "") + " in section '" + section + "' called from macro '" + name + "'", ee);
         }
       }
     } finally {
@@ -1065,6 +1064,22 @@ public class MemoryWarpScriptStack implements WarpScriptStack, Progressable {
     } catch (WarpScriptJavaFunctionException ejfe) {
       throw new WarpScriptException(ejfe);
     }
+  }
+
+  public Object findFunction(String stmt) throws WarpScriptException {
+    Object func = defined.get(stmt);
+
+    if (null != func && Boolean.FALSE.equals(getAttribute(WarpScriptStack.ATTRIBUTE_ALLOW_REDEFINED))) {
+      throw new WarpScriptException("Disallowed redefined function '" + stmt + "'.");
+    }
+
+    func = null != func ? func : WarpScriptLib.getFunction(stmt);
+
+    if (null == func) {
+      throw new WarpScriptException("Unknown function '" + stmt + "'");
+    }
+
+    return func;
   }
 
   @Override
@@ -1377,23 +1392,13 @@ public class MemoryWarpScriptStack implements WarpScriptStack, Progressable {
       if (this.unshadow) {
         this.defined.remove(stmt);
       } else {
-        this.defined.put(stmt, new WarpScriptStackFunction() {
-          @Override
-          public Object apply(WarpScriptStack stack) throws WarpScriptException {
-            throw new WarpScriptException("Function '" + stmt + "' is undefined.");
-          }
-        });
+        Macro undefMacro = new Macro();
+        undefMacro.add("is undefined.");
+        undefMacro.add(new MSGFAIL(stmt));
+        this.defined.put(stmt, MacroHelper.wrap(stmt, undefMacro));
       }
     } else {
-      // Wrap the macro into a function
-      WarpScriptStackFunction func = new WarpScriptStackFunction() {
-        @Override
-        public Object apply(WarpScriptStack stack) throws WarpScriptException {
-          stack.exec(macro);
-          return stack;
-        }
-      };
-      this.defined.put(stmt, func);
+      this.defined.put(stmt, MacroHelper.wrap(stmt, macro));
     }
   }
 

--- a/warp10/src/main/java/io/warp10/script/NamedWarpScriptFunction.java
+++ b/warp10/src/main/java/io/warp10/script/NamedWarpScriptFunction.java
@@ -16,6 +16,11 @@
 
 package io.warp10.script;
 
+import io.warp10.WarpURLEncoder;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+
 public class NamedWarpScriptFunction {
   private String name = "##UNDEF##";
   
@@ -35,7 +40,17 @@ public class NamedWarpScriptFunction {
     return this.name;
   }
 
+  /**
+   * Gives the snapshot to get the reference to this function.
+   */
   public final String refSnapshot() {
-    return "'" + this.name + "' " + WarpScriptLib.FUNCREF;
+    if (null == name) {
+      return null;
+    }
+    try {
+      return "'" + WarpURLEncoder.encode(name, StandardCharsets.UTF_8) + "' " + WarpScriptLib.FUNCREF;
+    } catch (UnsupportedEncodingException e) {
+      return null;
+    }
   }
 }

--- a/warp10/src/main/java/io/warp10/script/NamedWarpScriptFunction.java
+++ b/warp10/src/main/java/io/warp10/script/NamedWarpScriptFunction.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -22,9 +22,9 @@ public class NamedWarpScriptFunction {
   public NamedWarpScriptFunction(String name) {
     this.name = name;
   }
-  
+
   public String toString() {
-    return this.name;
+    return "'" + this.name + "' " + WarpScriptLib.FUNCREF;
   }
   
   public void setName(String name) {

--- a/warp10/src/main/java/io/warp10/script/NamedWarpScriptFunction.java
+++ b/warp10/src/main/java/io/warp10/script/NamedWarpScriptFunction.java
@@ -24,7 +24,7 @@ public class NamedWarpScriptFunction {
   }
 
   public String toString() {
-    return "'" + this.name + "' " + WarpScriptLib.FUNCREF;
+    return refSnapshot();
   }
   
   public void setName(String name) {
@@ -33,5 +33,9 @@ public class NamedWarpScriptFunction {
   
   public String getName() {
     return this.name;
+  }
+
+  public final String refSnapshot() {
+    return "'" + this.name + "' " + WarpScriptLib.FUNCREF;
   }
 }

--- a/warp10/src/main/java/io/warp10/script/WarpScriptLib.java
+++ b/warp10/src/main/java/io/warp10/script/WarpScriptLib.java
@@ -346,6 +346,7 @@ public class WarpScriptLib {
 
   public static final String EVAL = "EVAL";
   public static final String EVALSECURE = "EVALSECURE";
+  public static final String FUNCREF = "FUNCREF";
   public static final String SNAPSHOT = "SNAPSHOT";
   public static final String SNAPSHOTALL = "SNAPSHOTALL";
   public static final String DEREF = "DEREF";
@@ -1320,6 +1321,7 @@ public class WarpScriptLib {
     addNamedWarpScriptFunction(new SYMBOLS(SYMBOLS));
     addNamedWarpScriptFunction(new MAXJSON(MAXJSON));
     addNamedWarpScriptFunction(new EVAL(EVAL));
+    addNamedWarpScriptFunction(new FUNCREF(FUNCREF));
     addNamedWarpScriptFunction(new NOW(NOW));
     addNamedWarpScriptFunction(new AGO(AGO));
     addNamedWarpScriptFunction(new MSTU(MSTU));

--- a/warp10/src/main/java/io/warp10/script/WarpScriptStack.java
+++ b/warp10/src/main/java/io/warp10/script/WarpScriptStack.java
@@ -433,8 +433,7 @@ public interface WarpScriptStack {
               // In the case the snapshot of the function is 'MYFUNC' FUNCREF, instead of adding
               // 'MYFUNC' FUNCREF EVAL to the snapshot, MYFUNC can simply be added.
               if (o instanceof NamedWarpScriptFunction
-                  && null != funcSnapshot
-                  && funcSnapshot.equals("'" + ((NamedWarpScriptFunction) o).getName() + "' " + WarpScriptLib.FUNCREF)) {
+                  && ((NamedWarpScriptFunction) o).refSnapshot().equals(funcSnapshot)) {
                 sb.append(((NamedWarpScriptFunction) o).getName());
               } else {
                 sb.append(funcSnapshot);
@@ -704,6 +703,14 @@ public interface WarpScriptStack {
    * Execute a WarpScriptJavaFunction against the stack
    */
   public void exec(WarpScriptJavaFunction function) throws WarpScriptException;
+
+  /**
+   * Find a function by name
+   *
+   * @param macroName Name of function to find
+   * @throws WarpScriptException if macro is not found
+   */
+  public Object findFunction(String macroName) throws WarpScriptException;
 
   /**
    * Find a macro by name

--- a/warp10/src/main/java/io/warp10/script/WarpScriptStack.java
+++ b/warp10/src/main/java/io/warp10/script/WarpScriptStack.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2020  SenX S.A.S.
+//   Copyright 2018-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -427,6 +427,20 @@ public interface WarpScriptStack {
           try {
             if (o instanceof Macro) {
               sb.append(((Macro) o).snapshot(hideSecure));
+              sb.append(" ");
+            } else if (o instanceof WarpScriptStackFunction) {
+              String funcSnapshot = o.toString();
+              // In the case the snapshot of the function is 'MYFUNC' FUNCREF, instead of adding
+              // 'MYFUNC' FUNCREF EVAL to the snapshot, MYFUNC can simply be added.
+              if (o instanceof NamedWarpScriptFunction
+                  && null != funcSnapshot
+                  && funcSnapshot.equals("'" + ((NamedWarpScriptFunction) o).getName() + "' " + WarpScriptLib.FUNCREF)) {
+                sb.append(((NamedWarpScriptFunction) o).getName());
+              } else {
+                sb.append(funcSnapshot);
+                sb.append(" ");
+                sb.append(WarpScriptLib.EVAL);
+              }
               sb.append(" ");
             } else {
               SNAPSHOT.addElement(sb, o);

--- a/warp10/src/main/java/io/warp10/script/functions/FUNCREF.java
+++ b/warp10/src/main/java/io/warp10/script/functions/FUNCREF.java
@@ -1,0 +1,47 @@
+//
+//   Copyright 2021  SenX S.A.S.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+package io.warp10.script.functions;
+
+import io.warp10.script.NamedWarpScriptFunction;
+import io.warp10.script.WarpScriptException;
+import io.warp10.script.WarpScriptLib;
+import io.warp10.script.WarpScriptStack;
+import io.warp10.script.WarpScriptStackFunction;
+
+/**
+ * Push the reference of the giving function named based on functions known to WarpScriptLib.
+ */
+public class FUNCREF extends NamedWarpScriptFunction implements WarpScriptStackFunction {
+
+  public FUNCREF(String name) {
+    super(name);
+  }
+
+  @Override
+  public Object apply(WarpScriptStack stack) throws WarpScriptException {
+    Object top = stack.pop();
+
+    if (!(top instanceof String)) {
+      throw new WarpScriptException(getName() + " expects the function name as a STRING.");
+    }
+
+    stack.push(WarpScriptLib.getFunction((String) top));
+
+    return stack;
+  }
+
+}

--- a/warp10/src/main/java/io/warp10/script/functions/FUNCREF.java
+++ b/warp10/src/main/java/io/warp10/script/functions/FUNCREF.java
@@ -18,12 +18,11 @@ package io.warp10.script.functions;
 
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptException;
-import io.warp10.script.WarpScriptLib;
 import io.warp10.script.WarpScriptStack;
 import io.warp10.script.WarpScriptStackFunction;
 
 /**
- * Push the reference of the giving function named based on functions known to WarpScriptLib.
+ * Push the reference of the given function named based on functions known to WarpScriptLib.
  */
 public class FUNCREF extends NamedWarpScriptFunction implements WarpScriptStackFunction {
 
@@ -39,7 +38,7 @@ public class FUNCREF extends NamedWarpScriptFunction implements WarpScriptStackF
       throw new WarpScriptException(getName() + " expects the function name as a STRING.");
     }
 
-    stack.push(WarpScriptLib.getFunction((String) top));
+    stack.push(stack.findFunction((String) top));
 
     return stack;
   }

--- a/warp10/src/main/java/io/warp10/script/functions/SNAPSHOT.java
+++ b/warp10/src/main/java/io/warp10/script/functions/SNAPSHOT.java
@@ -531,11 +531,14 @@ public class SNAPSHOT extends NamedWarpScriptFunction implements WarpScriptStack
     }
   }
 
-  //
-  // Process a string to make it readable and compatible in WarpScript code
-  //
-
-  private static void appendProcessedString(StringBuilder sb, String s) {
+  /**
+   * Process a string to make it readable and compatible in WarpScript code.
+   * @param sb A StringBuilder whose given String will appended to.
+   * @param s A String which may contain invalid WarpScript characters. It will not be encapsulated with quote
+   *          characters so it should be appended to the StringBuilder before and after. Double quotes will not
+   *          be escaped, so only single quotes are acceptable.
+   */
+  public static void appendProcessedString(StringBuilder sb, String s) {
 
     char[] chars = UnsafeString.getChars(s);
 


### PR DESCRIPTION
This is an attempt to improve the snapshot of `WarpScriptStackFunctions` and `NamedWarpScriptFunctions` for https://github.com/senx/warp10-platform/pull/945.

This also solve a bug with the snapshots of `WarpScriptStackFunctions` whose reference is on the stack, using `NPDF` for instance. `42 mapper.gt` does not trigger the bug because it is only a `NamedWarpScriptFunction`.

Tested using:
```
42 mapper.gt 'M' STORE
0 1 NPDF 'N' STORE
<%
  'Hello' 42 
  53 SQRT
  42 mapper.gt
  !$M
  0 0 1 NPDF EVAL
  0 !$N
%>
'macro' STORE

// Macro snapshot and EVAL
$macro
SNAPSHOT
EVAL
EVAL

// Snapshot of MACRO-> and EVAL
$macro
MACRO->
SNAPSHOT
EVAL
->MACRO
EVAL

// EVAL of the macro to check the results
@macro
```