### PR TITLE
Add .noauth, .nometa and .nofetch attributes for read tokens

### DIFF
--- a/warp10/src/main/java/io/warp10/continuum/egress/EgressFetchHandler.java
+++ b/warp10/src/main/java/io/warp10/continuum/egress/EgressFetchHandler.java
@@ -467,7 +467,7 @@ public class EgressFetchHandler extends AbstractHandler {
           }
 
           Map<String, String> rtokenAttributes = rtoken.getAttributes();
-          if (null != rtokenAttributes && (rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOFETCH) || rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOMETA))) {
+          if (null != rtokenAttributes && (rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOFETCH) || rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOFIND))) {
             httpStatusCode = HttpServletResponse.SC_FORBIDDEN;
             throw new IOException("Token cannot be used for fetching data.");
           }

--- a/warp10/src/main/java/io/warp10/continuum/egress/EgressFetchHandler.java
+++ b/warp10/src/main/java/io/warp10/continuum/egress/EgressFetchHandler.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2020  SenX S.A.S.
+//   Copyright 2018-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -464,6 +464,12 @@ public class EgressFetchHandler extends AbstractHandler {
           if (rtoken.getHooksSize() > 0) {
             httpStatusCode = HttpServletResponse.SC_BAD_REQUEST;
             throw new IOException("Tokens with hooks cannot be used for fetching data.");
+          }
+
+          Map<String, String> rtokenAttributes = rtoken.getAttributes();
+          if (null != rtokenAttributes && (rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOFETCH) || rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOMETA))) {
+            httpStatusCode = HttpServletResponse.SC_FORBIDDEN;
+            throw new IOException("Token cannot be used for fetching data.");
           }
         } catch (WarpScriptException wse) {
           httpStatusCode = HttpServletResponse.SC_FORBIDDEN;

--- a/warp10/src/main/java/io/warp10/continuum/egress/EgressFindHandler.java
+++ b/warp10/src/main/java/io/warp10/continuum/egress/EgressFindHandler.java
@@ -124,7 +124,7 @@ public class EgressFindHandler extends AbstractHandler {
 
         Map<String, String> rtokenAttributes = rtoken.getAttributes();
         if (null != rtokenAttributes && rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOFIND)) {
-          resp.sendError(HttpServletResponse.SC_FORBIDDEN, "Invalid token.");
+          resp.sendError(HttpServletResponse.SC_FORBIDDEN, "Token cannot be used for finding metadata.");
           return;
         }
 

--- a/warp10/src/main/java/io/warp10/continuum/egress/EgressFindHandler.java
+++ b/warp10/src/main/java/io/warp10/continuum/egress/EgressFindHandler.java
@@ -123,7 +123,7 @@ public class EgressFindHandler extends AbstractHandler {
         rtoken = Tokens.extractReadToken(token);
 
         Map<String, String> rtokenAttributes = rtoken.getAttributes();
-        if (null != rtokenAttributes && rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOMETA)) {
+        if (null != rtokenAttributes && rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOFIND)) {
           resp.sendError(HttpServletResponse.SC_FORBIDDEN, "Invalid token.");
           return;
         }

--- a/warp10/src/main/java/io/warp10/continuum/egress/EgressFindHandler.java
+++ b/warp10/src/main/java/io/warp10/continuum/egress/EgressFindHandler.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2020  SenX S.A.S.
+//   Copyright 2018-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -121,12 +121,15 @@ public class EgressFindHandler extends AbstractHandler {
       
       try {
         rtoken = Tokens.extractReadToken(token);
-      } catch (WarpScriptException ee) {
-        throw new IOException(ee);
-      }
 
-      if (null == rtoken) {
-        resp.sendError(HttpServletResponse.SC_FORBIDDEN, "Missing token.");
+        Map<String, String> rtokenAttributes = rtoken.getAttributes();
+        if (null != rtokenAttributes && rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOMETA)) {
+          resp.sendError(HttpServletResponse.SC_FORBIDDEN, "Invalid token.");
+          return;
+        }
+
+      } catch (WarpScriptException wse) {
+        resp.sendError(HttpServletResponse.SC_FORBIDDEN, "Missing or invalid token.");
         return;
       }
 

--- a/warp10/src/main/java/io/warp10/continuum/egress/EgressSplitsHandler.java
+++ b/warp10/src/main/java/io/warp10/continuum/egress/EgressSplitsHandler.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -100,6 +100,11 @@ public class EgressSplitsHandler extends AbstractHandler {
       
       if (rtoken.getHooksSize() > 0) {
         throw new IOException("Tokens with hooks cannot be used for generating splits.");        
+      }
+
+      Map<String, String> rtokenAttributes = rtoken.getAttributes();
+      if (null != rtokenAttributes && (rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOFETCH) || rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOMETA))) {
+        throw new IOException("Token cannot be used for fetching data.");
       }
     } catch (WarpScriptException ee) {
       throw new IOException(ee);

--- a/warp10/src/main/java/io/warp10/continuum/egress/EgressSplitsHandler.java
+++ b/warp10/src/main/java/io/warp10/continuum/egress/EgressSplitsHandler.java
@@ -103,7 +103,7 @@ public class EgressSplitsHandler extends AbstractHandler {
       }
 
       Map<String, String> rtokenAttributes = rtoken.getAttributes();
-      if (null != rtokenAttributes && (rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOFETCH) || rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOMETA))) {
+      if (null != rtokenAttributes && (rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOFETCH) || rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOFIND))) {
         throw new IOException("Token cannot be used for fetching data.");
       }
     } catch (WarpScriptException ee) {

--- a/warp10/src/main/java/io/warp10/continuum/store/Constants.java
+++ b/warp10/src/main/java/io/warp10/continuum/store/Constants.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2020  SenX S.A.S.
+//   Copyright 2018-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -384,11 +384,31 @@ public class Constants {
   //
   
   /**
-   * Attribute used to specify a WRITE token cannot be used for delete
+   * Attribute used to specify that a WRITE token cannot be used for delete.
    */
   public static final String TOKEN_ATTR_NODELETE = ".nodelete";
+
+  /**
+   * Attribute used to specify that a WRITE token cannot be used for updating.
+   */
   public static final String TOKEN_ATTR_NOUPDATE = ".noupdate";
+
+  /**
+   * Attribute used to specify that a WRITE token cannot be used for updating metadata.
+   * Attribute used to specify that a READ token cannot be used for metadata queries.
+   * A READ token that cannot be used for metadata queries cannot be use either to query for data.
+   */
   public static final String TOKEN_ATTR_NOMETA = ".nometa";
+
+  /**
+   * Attribute used to specify that a READ token cannot be used to query for data.
+   */
+  public static final String TOKEN_ATTR_NOFETCH = ".nofetch";
+
+  /**
+   * Attribute used to specify that a READ token cannot be used to AUTHENTICATE.
+   */
+  public static final String TOKEN_ATTR_NOAUTH = ".noauth";
   
   /**
    * Attribute to specify the maximum value size

--- a/warp10/src/main/java/io/warp10/continuum/store/Constants.java
+++ b/warp10/src/main/java/io/warp10/continuum/store/Constants.java
@@ -395,10 +395,14 @@ public class Constants {
 
   /**
    * Attribute used to specify that a WRITE token cannot be used for updating metadata.
+   */
+  public static final String TOKEN_ATTR_NOMETA = ".nometa";
+
+  /**
    * Attribute used to specify that a READ token cannot be used for metadata queries.
    * A READ token that cannot be used for metadata queries cannot be use either to query for data.
    */
-  public static final String TOKEN_ATTR_NOMETA = ".nometa";
+  public static final String TOKEN_ATTR_NOFIND = ".nofind";
 
   /**
    * Attribute used to specify that a READ token cannot be used to query for data.

--- a/warp10/src/main/java/io/warp10/script/functions/FETCH.java
+++ b/warp10/src/main/java/io/warp10/script/functions/FETCH.java
@@ -227,7 +227,17 @@ public class FETCH extends NamedWarpScriptFunction implements WarpScriptStackFun
       bases = new GeoTimeSerie[5];
     }
 
-    ReadToken rtoken = Tokens.extractReadToken(params.get(PARAM_TOKEN).toString());
+    ReadToken rtoken;
+    try {
+      rtoken = Tokens.extractReadToken(params.get(PARAM_TOKEN).toString());
+
+      Map<String, String> rtokenAttributes = rtoken.getAttributes();
+      if (null != rtokenAttributes && (rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOFETCH) || rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOMETA))) {
+        throw new WarpScriptException("Token cannot be used for fetching data.");
+      }
+    } catch (WarpScriptException wse) {
+      throw new WarpScriptException(getName() + " given an invalid read token.", wse);
+    }
 
     boolean expose = rtoken.getAttributesSize() > 0 && rtoken.getAttributes().containsKey(Constants.TOKEN_ATTR_EXPOSE);
 
@@ -954,7 +964,16 @@ public class FETCH extends NamedWarpScriptFunction implements WarpScriptStackFun
       }
 
       // Attempt to extract token, this will raise an exception if token has expired or was revoked
-      ReadToken rtoken = Tokens.extractReadToken(metaset.getToken());
+      try {
+        ReadToken rtoken = Tokens.extractReadToken(metaset.getToken());
+
+        Map<String, String> rtokenAttributes = rtoken.getAttributes();
+        if (null != rtokenAttributes && (rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOFETCH) || rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOMETA))) {
+          throw new WarpScriptException("Token cannot be used for fetching data.");
+        }
+      } catch (WarpScriptException wse) {
+        throw new WarpScriptException(getName() + " MetaSet token is not valid.", wse);
+      }
 
       params.put(PARAM_METASET, metaset);
       params.put(PARAM_TOKEN, metaset.getToken());

--- a/warp10/src/main/java/io/warp10/script/functions/FETCH.java
+++ b/warp10/src/main/java/io/warp10/script/functions/FETCH.java
@@ -232,7 +232,7 @@ public class FETCH extends NamedWarpScriptFunction implements WarpScriptStackFun
       rtoken = Tokens.extractReadToken(params.get(PARAM_TOKEN).toString());
 
       Map<String, String> rtokenAttributes = rtoken.getAttributes();
-      if (null != rtokenAttributes && (rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOFETCH) || rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOMETA))) {
+      if (null != rtokenAttributes && (rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOFETCH) || rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOFIND))) {
         throw new WarpScriptException("Token cannot be used for fetching data.");
       }
     } catch (WarpScriptException wse) {
@@ -968,7 +968,7 @@ public class FETCH extends NamedWarpScriptFunction implements WarpScriptStackFun
         ReadToken rtoken = Tokens.extractReadToken(metaset.getToken());
 
         Map<String, String> rtokenAttributes = rtoken.getAttributes();
-        if (null != rtokenAttributes && (rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOFETCH) || rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOMETA))) {
+        if (null != rtokenAttributes && (rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOFETCH) || rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOFIND))) {
           throw new WarpScriptException("Token cannot be used for fetching data.");
         }
       } catch (WarpScriptException wse) {

--- a/warp10/src/main/java/io/warp10/script/functions/FIND.java
+++ b/warp10/src/main/java/io/warp10/script/functions/FIND.java
@@ -327,7 +327,7 @@ public class FIND extends NamedWarpScriptFunction implements WarpScriptStackFunc
 
       Map<String, String> rtokenAttributes = rtoken.getAttributes();
       if (null != rtokenAttributes) {
-        if (rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOMETA)) {
+        if (rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOFIND)) {
           throw new WarpScriptException("Token cannot be used for finding metadata.");
         }
         if (metaset && rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOFETCH)) {

--- a/warp10/src/main/java/io/warp10/script/functions/FIND.java
+++ b/warp10/src/main/java/io/warp10/script/functions/FIND.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2020  SenX S.A.S.
+//   Copyright 2018-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -321,7 +321,17 @@ public class FIND extends NamedWarpScriptFunction implements WarpScriptStackFunc
     
     DirectoryClient directoryClient = stack.getDirectoryClient();
     
-    ReadToken rtoken = Tokens.extractReadToken(token);
+    ReadToken rtoken;
+    try {
+      rtoken = Tokens.extractReadToken(token);
+
+      Map<String, String> rtokenAttributes = rtoken.getAttributes();
+      if (null != rtokenAttributes && rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOMETA)) {
+        throw new WarpScriptException("Token cannot be used for finding metadata.");
+      }
+    } catch (WarpScriptException wse) {
+      throw new WarpScriptException(getName() + " given an invalid token.", wse);
+    }
 
     boolean expose = rtoken.getAttributesSize() > 0 && rtoken.getAttributes().containsKey(Constants.TOKEN_ATTR_EXPOSE);
     

--- a/warp10/src/main/java/io/warp10/script/functions/FIND.java
+++ b/warp10/src/main/java/io/warp10/script/functions/FIND.java
@@ -326,8 +326,13 @@ public class FIND extends NamedWarpScriptFunction implements WarpScriptStackFunc
       rtoken = Tokens.extractReadToken(token);
 
       Map<String, String> rtokenAttributes = rtoken.getAttributes();
-      if (null != rtokenAttributes && rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOMETA)) {
-        throw new WarpScriptException("Token cannot be used for finding metadata.");
+      if (null != rtokenAttributes) {
+        if (rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOMETA)) {
+          throw new WarpScriptException("Token cannot be used for finding metadata.");
+        }
+        if (metaset && rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOFETCH)) {
+          throw new WarpScriptException("Token cannot be used for fetching data.");
+        }
       }
     } catch (WarpScriptException wse) {
       throw new WarpScriptException(getName() + " given an invalid token.", wse);

--- a/warp10/src/main/java/io/warp10/script/functions/FINDSTATS.java
+++ b/warp10/src/main/java/io/warp10/script/functions/FINDSTATS.java
@@ -121,7 +121,7 @@ public class FINDSTATS extends NamedWarpScriptFunction implements WarpScriptStac
       rtoken = Tokens.extractReadToken(token);
 
       Map<String, String> rtokenAttributes = rtoken.getAttributes();
-      if (null != rtokenAttributes && rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOMETA)) {
+      if (null != rtokenAttributes && rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOFIND)) {
         throw new WarpScriptException("Token cannot be used for finding metadata.");
       }
     } catch (WarpScriptException wse) {

--- a/warp10/src/main/java/io/warp10/script/functions/FINDSTATS.java
+++ b/warp10/src/main/java/io/warp10/script/functions/FINDSTATS.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -115,8 +115,18 @@ public class FINDSTATS extends NamedWarpScriptFunction implements WarpScriptStac
 
     
     DirectoryClient directoryClient = stack.getDirectoryClient();
-    
-    ReadToken rtoken = Tokens.extractReadToken(token);
+
+    ReadToken rtoken;
+    try {
+      rtoken = Tokens.extractReadToken(token);
+
+      Map<String, String> rtokenAttributes = rtoken.getAttributes();
+      if (null != rtokenAttributes && rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOMETA)) {
+        throw new WarpScriptException("Token cannot be used for finding metadata.");
+      }
+    } catch (WarpScriptException wse) {
+      throw new WarpScriptException(getName() + " given an invalid token.", wse);
+    }
 
     labelSelectors.remove(Constants.PRODUCER_LABEL);
     labelSelectors.remove(Constants.OWNER_LABEL);

--- a/warp10/src/main/java/io/warp10/standalone/StandalonePlasmaHandler.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandalonePlasmaHandler.java
@@ -198,7 +198,7 @@ public class StandalonePlasmaHandler extends WebSocketHandler.Simple implements 
           }
 
           Map<String, String> rtokenAttributes = rtoken.getAttributes();
-          if (null != rtokenAttributes && (rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOFETCH) || rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOMETA))) {
+          if (null != rtokenAttributes && (rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOFETCH) || rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOFIND))) {
             throw new IOException("Token cannot be used for fetching data.");
           }
         } catch (Exception e) {

--- a/warp10/src/main/java/io/warp10/standalone/StandalonePlasmaHandler.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandalonePlasmaHandler.java
@@ -196,6 +196,11 @@ public class StandalonePlasmaHandler extends WebSocketHandler.Simple implements 
           if (rtoken.getHooksSize() > 0) {
             throw new IOException("Tokens with hooks cannot be used with Plasma.");        
           }
+
+          Map<String, String> rtokenAttributes = rtoken.getAttributes();
+          if (null != rtokenAttributes && (rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOFETCH) || rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOMETA))) {
+            throw new IOException("Token cannot be used for fetching data.");
+          }
         } catch (Exception e) {
           rtoken = null;
         }

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneSplitsHandler.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneSplitsHandler.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -96,6 +96,11 @@ public class StandaloneSplitsHandler extends AbstractHandler {
       
       if (rtoken.getHooksSize() > 0) {
         throw new IOException("Tokens with hooks cannot be used for generating splits.");        
+      }
+
+      Map<String, String> rtokenAttributes = rtoken.getAttributes();
+      if (null != rtokenAttributes && (rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOFETCH) || rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOMETA))) {
+        throw new IOException("Token cannot be used for fetching data.");
       }
     } catch (WarpScriptException ee) {
       throw new IOException(ee);

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneSplitsHandler.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneSplitsHandler.java
@@ -99,7 +99,7 @@ public class StandaloneSplitsHandler extends AbstractHandler {
       }
 
       Map<String, String> rtokenAttributes = rtoken.getAttributes();
-      if (null != rtokenAttributes && (rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOFETCH) || rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOMETA))) {
+      if (null != rtokenAttributes && (rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOFETCH) || rtokenAttributes.containsKey(Constants.TOKEN_ATTR_NOFIND))) {
         throw new IOException("Token cannot be used for fetching data.");
       }
     } catch (WarpScriptException ee) {


### PR DESCRIPTION
This will allow read tokens that, among other things:
- can fetch data but cannot be used for authentication
- can be used for authentication but not to fetch data
- can used to find metadata but not actual data

This also offers an alternative solution for pure capabilities tokens as you can either:
- use a write token with .noauth, .nometa, .noupdate and .nodelete
- use a read token with .noauth, .nometa and .nofetch (instead of using a dummy app/owner/producer)