### PR TITLE
Fix required lib for WarpScript

### DIFF
--- a/warpscript/build.gradle
+++ b/warpscript/build.gradle
@@ -27,7 +27,7 @@ ext {
     // List of dependencies required by Warpscript
     requiredLibsMc2 = [ 'libthrift', 'bcprov-jdk15on', 'commons-io', 'commons-codec', 'commons-lang3', 'commons-math3',\
                         'compiler', 'core', 'curator-x-discovery', 'geoxplib', 'guava', 'hadoop-common', 'hadoop-mapreduce-client-core',\
-                        'java-merge-sort','joda-time', 'jtransforms', 'jts', 'oss-client', 'sensision', 'slf4j-api', 'pyrolite',\
+                        'java-merge-sort','joda-time', 'jtransforms', 'jts-core', 'oss-client', 'sensision', 'slf4j-api', 'pyrolite',\
                         'jts2geojson', 'jackson-core', 'jackson-databind', 'jackson-annotations' ]
 }
 


### PR DESCRIPTION
Following https://github.com/senx/warp10-platform/commit/82a19b8a8c733703b1dbf870c43313c9c34434ed the JTS lib which Warp 10 depends on is `jts-core` and not `jts` anymore.

As `com.geoxp:geoxplib` pulls jts and `com.geoxp:geoxplib` pull jts-core, the WarpScript lib is already working properly.