### PR TITLE
Fix import of Bytes in ->RLP

### DIFF
--- a/warp10/src/main/java/io/warp10/script/functions/TORLP.java
+++ b/warp10/src/main/java/io/warp10/script/functions/TORLP.java
@@ -21,8 +21,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 
-import org.iq80.leveldb.shaded.guava.primitives.Bytes;
-
+import com.google.common.primitives.Bytes;
 import com.google.common.primitives.Longs;
 
 import io.warp10.script.NamedWarpScriptFunction;


### PR DESCRIPTION
Previous import made the function fail when using pure WarpScript lib.