### PR TITLE
Change REVISION generation task dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -246,7 +246,7 @@ subprojects {
         }
     }
 
-    classes.dependsOn updateRevision
+    processResources.dependsOn updateRevision
 }
 
 if (project.hasProperty("ossrhUsername")) {


### PR DESCRIPTION
The REVISION file was generated too late for it to be included in the jar. This may generate WarpScript and Warp 10 jars without the REVISION file.