### PR TITLE
fix bugs that raised cryptic error messages in STL

### DIFF
--- a/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
+++ b/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
@@ -10288,16 +10288,18 @@ public class GTSHelper {
           // extracting subRho
           if (s > 0) {
             double[] tmp = seasonal.doubleValues;
+            int tmp_size = seasonal.values;
             seasonal.doubleValues = rho;
+            seasonal.values = rho.length;
             subRho = subCycleSerie(seasonal, seasonal.lastbucket - c * seasonal.bucketspan, buckets_per_period, true, subRho);
             seasonal.doubleValues = tmp;
+            seasonal.values = tmp_size;
           }
 
           // applying lowess
           if (subCycle.values > 0) {
             lowess_stl(subCycle, seasonal, neighbour_s, degree_s, jump_s, weights, s > 0 ? subRho.doubleValues : rho);
           }
-
         }
 
         /*
@@ -10462,12 +10464,17 @@ public class GTSHelper {
         // compute residual
         int idx_s = 0;
         int idx_t = 0;
+        int id = 0;
         for (int idx = 0 ; idx < nonnull; idx++){
-          idx_s = Arrays.binarySearch(seasonal.ticks, idx_s, nonnull, gts.ticks[idx]);
+          idx_s = Arrays.binarySearch(seasonal.ticks, idx_s, seasonal.size(), gts.ticks[idx]);
+
+          // we assume idx_t == idx_s so we comment the following line
           //idx_t = Arrays.binarySearch(trend.ticks, idx_t, nonnull, gts.ticks[idx]);
-          // we assume idx_t == idx_s
-          idx_t = idx_s;
-          residual[idx] = Math.abs(((Number) valueAtIndex(gts,idx)).doubleValue() - seasonal.doubleValues[idx_s] - trend.doubleValues[idx_t]);
+
+          if (idx_s >= 0) {
+            idx_t = idx_s;
+            residual[id++] = Math.abs(((Number) valueAtIndex(gts, idx)).doubleValue() - seasonal.doubleValues[idx_s] - trend.doubleValues[idx_t]);
+          }
         }
 
         //

--- a/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
+++ b/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
@@ -10332,7 +10332,7 @@ public class GTSHelper {
         }
         if (0 == count) {
           // this should not happen
-          throw new WarpScriptException("STL found no value in its step 3.0, is GTS empty ?");
+          throw new WarpScriptException("STL found no value in its step 3.0, is GTS empty?");
 
         } else {
           lowpassed.doubleValues[0] = sum / count;
@@ -10359,7 +10359,7 @@ public class GTSHelper {
               count--;
               if (0 == count) {
                 // this should not happen
-                throw new WarpScriptException("STL found no value in its step 3.1, is GTS empty ?");
+                throw new WarpScriptException("STL found no value in its step 3.1, is GTS empty?");
               }
               sum -= (Double) firstVal;
 

--- a/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
+++ b/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
@@ -1961,10 +1961,11 @@ public class GTSHelper {
     while (iter.hasNext()) {
 
       tick = iter.next();
-      i = Arrays.binarySearch(gts.ticks, 0, i, tick);
+      int j = Arrays.binarySearch(gts.ticks, 0, i, tick);
 
-      if (i >= 0) {
-        setValue(subgts, gts.ticks[i], null != gts.locations ? gts.locations[i] : GeoTimeSerie.NO_LOCATION, null != gts.elevations ? gts.elevations[i] : GeoTimeSerie.NO_ELEVATION, valueAtIndex(gts, i), overwrite);
+      if (j >= 0) {
+        setValue(subgts, tick, null != gts.locations ? gts.locations[j] : GeoTimeSerie.NO_LOCATION, null != gts.elevations ? gts.elevations[j] : GeoTimeSerie.NO_ELEVATION, valueAtIndex(gts, j), overwrite);
+        i = j;
       }
     }
 


### PR DESCRIPTION
First bug fixed: when a subcycle series was empty, NaN values were pushed into the transient seasonal GTS, and then were propagated with the subsequent aggregations.

Second bug fixed: the aggregation did not take into account correctly missing values if input GTS was not filled.