### PR TITLE
Support for inline macro as value in configurations

### DIFF
--- a/warp10/src/main/java/io/warp10/WarpConfig.java
+++ b/warp10/src/main/java/io/warp10/WarpConfig.java
@@ -317,7 +317,7 @@ public class WarpConfig {
         String key = tokens[0];
         String macro = line.substring(key.length() + 1);
         macro = macro.trim();
-        if (macro.length() < 5 || !WarpScriptStack.MACRO_START.equals(macro.substring(0, 2)) || !WarpScriptStack.MACRO_END.equals(macro.substring(macro.length() - 2))) {
+        if (macro.length() < 5 || !WarpScriptStack.MACRO_END.equals(macro.substring(macro.length() - 2))) {
           linesInError.add(lineno);
           continue;
         }

--- a/warp10/src/main/java/io/warp10/WarpConfig.java
+++ b/warp10/src/main/java/io/warp10/WarpConfig.java
@@ -311,7 +311,7 @@ public class WarpConfig {
 
       String[] tokens = line.split("=");
 
-      if (tokens[1].contains(WarpScriptStack.MACRO_START)) {
+      if (tokens[1].contains(WarpScriptStack.MACRO_START) && WarpScriptStack.MACRO_START.equals(tokens[1].trim().substring(0, 2))) {
 
         // Expect value to be a macro
         String key = tokens[0];

--- a/warp10/src/main/java/io/warp10/WarpConfig.java
+++ b/warp10/src/main/java/io/warp10/WarpConfig.java
@@ -326,10 +326,8 @@ public class WarpConfig {
       }
 
       if (tokens.length > 2) {
-        if (!line.contains(WarpScriptStack.MACRO_START) || !line.contains(WarpScriptStack.MACRO_END)) {
-          linesInError.add(lineno);
-          continue;
-        }
+        linesInError.add(lineno);
+        continue;
       }
 
       if (tokens.length < 2) {

--- a/warp10/src/main/java/io/warp10/script/ext/shadow/ShadowWarpScriptExtension.java
+++ b/warp10/src/main/java/io/warp10/script/ext/shadow/ShadowWarpScriptExtension.java
@@ -209,8 +209,10 @@ public class ShadowWarpScriptExtension extends WarpScriptExtension {
 
           @Override
           public Object apply(WarpScriptStack stack) throws WarpScriptException {
+            Object stackContext = null;
             if (!finalUnsafe) {
               stack.save();
+              stackContext = stack.pop();
             }
             try {
               if (!finalUnsafe) {
@@ -225,6 +227,7 @@ public class ShadowWarpScriptExtension extends WarpScriptExtension {
               }
             } finally {
               if (!finalUnsafe) {
+                stack.push(stackContext);
                 stack.restore();
               }
             }

--- a/warp10/src/main/java/io/warp10/script/ext/shadow/ShadowWarpScriptExtension.java
+++ b/warp10/src/main/java/io/warp10/script/ext/shadow/ShadowWarpScriptExtension.java
@@ -148,7 +148,6 @@ public class ShadowWarpScriptExtension extends WarpScriptExtension {
     for (String key: properties.stringPropertyNames()) {
       if (key.startsWith(SHADOW_MACRO + ".")) {
         final String f = key.substring(SHADOW_MACRO.length() + 1);
-        System.out.println(f);
         boolean globalUnsafe = "true".equals(WarpConfig.getProperty(SHADOW_UNSAFEMACRO));
                 
         boolean unsafe = globalUnsafe;

--- a/warp10/src/main/java/io/warp10/script/ext/shadow/ShadowWarpScriptExtension.java
+++ b/warp10/src/main/java/io/warp10/script/ext/shadow/ShadowWarpScriptExtension.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
+import io.warp10.ThrowableUtils;
 import io.warp10.WarpConfig;
 import io.warp10.script.MemoryWarpScriptStack;
 import io.warp10.script.NamedWarpScriptFunction;
@@ -195,7 +196,7 @@ public class ShadowWarpScriptExtension extends WarpScriptExtension {
             //
 
             inlineMacro = new Macro();
-            inlineMacro.add("Error while parsing inline macro for shadowing function " + f);
+            inlineMacro.add("Error while parsing inline macro for shadowing function " + f + ": " + ThrowableUtils.getErrorMessage(wse, 1024));
             inlineMacro.add(WarpScriptLib.getFunction(WarpScriptLib.MSGFAIL));
 
           } finally {


### PR DESCRIPTION
- Configuration value can be a macro using syntax
`warp.configuration = <% 'this is a macro' %>`

- configuration shadow.macro.FUNC can parse an inline macro

- fix a bug related to configuration shadow.macro.FUNC