### PR TITLE
Make MVEXTRACT push ArrayList of lat/lon on the stack

### DIFF
--- a/warp10/src/main/java/io/warp10/script/functions/MVEXTRACT.java
+++ b/warp10/src/main/java/io/warp10/script/functions/MVEXTRACT.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.apache.thrift.TDeserializer;
@@ -169,16 +168,17 @@ public class MVEXTRACT extends ElementOrListStackFunction implements ElementStac
         return null != decoder ? decoder.getTimestamp() : GTSHelper.tickAtIndex(gts, idx);
       case LATLON:
         long location = null != decoder ? decoder.getLocation() : GTSHelper.locationAtIndex(gts, idx);
-        double[] latlon;
-        
+        List<Double> latlon = new ArrayList<Double>(2);
+
         if (GeoTimeSerie.NO_LOCATION == location) {
-          latlon = new double[2];
-          latlon[0] = Double.NaN;
-          latlon[1] = Double.NaN;
+          latlon.add(Double.NaN);
+          latlon.add(Double.NaN);
         } else {
-          latlon = GeoXPLib.fromGeoXPPoint(location);
-        }        
-        return Arrays.asList(latlon[0], latlon[1]);
+          double[] latlonArray = GeoXPLib.fromGeoXPPoint(location);
+          latlon.add(latlonArray[0]);
+          latlon.add(latlonArray[1]);
+        }
+        return latlon;
       case ELEVATION:
         return null != decoder ? decoder.getElevation() : GTSHelper.elevationAtIndex(gts, idx);
       case LOCATION:


### PR DESCRIPTION
Currently an `Arrays.ArrayList` is pushed on the stack which is not consistent with all other functions.