### PR TITLE
Better integrate thrift generation in gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -134,16 +134,19 @@ subprojects {
     // Generate thrift classes, used by token and warp10.
     //
     task generateThrift {
-        doLast {
-            def thriftOutputDir = new File(project.projectDir, 'src/generated/thrift')
+        def thriftOutputDir = new File(project.projectDir, 'src/generated/thrift')
+        def thriftFiles = fileTree(dir: 'src/main/thrift').matching { include '**/*.thrift' }
 
+        outputs.dir(thriftOutputDir)
+        inputs.files(thriftFiles)
+
+        doLast {
             // Delete the thrift dir if exists
             if (thriftOutputDir.exists()) {
                 thriftOutputDir.deleteDir()
             }
             thriftOutputDir.mkdirs()
 
-            def thriftFiles = fileTree(dir: 'src/main/thrift').matching { include '**/*.thrift' }
             thriftFiles.collect {
                 def file = relativePath(it)
                 exec {
@@ -152,6 +155,10 @@ subprojects {
                 }
             }
         }
+    }
+
+    clean {
+        delete generateThrift
     }
 
     //

--- a/warp10/build.gradle
+++ b/warp10/build.gradle
@@ -165,9 +165,6 @@ task pack(type: Jar) {
     manifest {
         attributes(
             "Main-Class": "io.warp10.standalone.Warp",
-            "Implementation-Title": "Warp 10",
-            "Implementation-Vendor": "Warp 10",
-            "Implementation-Version": project.version
         )
     }
 


### PR DESCRIPTION
This PR make sure Gradle tracks Thrift files and files generated by Thrift. Thus, they are not re-generated if either the thrift files or the generated files are left untouched.

The `clean` task now properly deletes classes generated by Thrift.


Also removed duplicate manifest configuration. Those keys were already set by `tasks.withType(Jar)` blocks.