### PR TITLE
Clean binary search implementation in SlicedRowFilter

### DIFF
--- a/warp10/src/main/java/io/warp10/continuum/store/SlicedRowFilterGTSDecoderIterator.java
+++ b/warp10/src/main/java/io/warp10/continuum/store/SlicedRowFilterGTSDecoderIterator.java
@@ -151,7 +151,7 @@ public class SlicedRowFilterGTSDecoderIterator extends GTSDecoderIterator implem
     
     // 128BITS
     
-    int[] bounds = { 0, 24 };
+    int[] bounds = { 0, prefix.length + 23 };
     
     //
     // Create singleton for each classId/labelsId combo

--- a/warp10/src/main/java/org/apache/hadoop/hbase/filter/SlicedRowFilter.java
+++ b/warp10/src/main/java/org/apache/hadoop/hbase/filter/SlicedRowFilter.java
@@ -61,22 +61,6 @@ public class SlicedRowFilter extends FilterBase {
   private int slicesLength;
   
   /**
-   * Ranges in which the concatenation of slices must fall
-   * NOTE: the end keys are included in their respective ranges.
-   */
-  private List<Pair<byte[],byte[]>> ranges;
-
-  /**
-   * Comparator to find insertion point of slice in a list of ranges
-   */
-  private Comparator<Pair<byte[], byte[]>> SLICE_RANGE_COMPARATOR = new Comparator<Pair<byte[],byte[]>>() {
-    @Override
-    public int compare(Pair<byte[], byte[]> o1, Pair<byte[], byte[]> o2) {
-      return Bytes.compareTo(o1.getFirst(), o2.getFirst());
-    }
-  };
-  
-  /**
    * Flag indicating we're done filtering rows since we've encountered a slice starting at offset 0
    * and which was past the end of the last range
    */
@@ -707,53 +691,31 @@ public class SlicedRowFilter extends FilterBase {
     
     return slice;
   }
-  
-  private int findInsertionPoint(byte[] subrow) {    
-    //
-    // Attempt to find the insertion point
-    //
-    
-    int nranges = this.rangekeys.length / this.slicesLength;
-    int insertionPoint = nranges;
-    
-    int left = 0;
-    int right = insertionPoint - 1;
-    
-    while(true) {
-      
-      if (left > right) {
-        left = right;
-      } else if (right < left) {
-        right = left;
-      }
-      
-      int mid = (left + right) / 2;
-            
-      int res = Bytes.compareTo(subrow, 0, subrow.length, this.rangekeys, mid * this.slicesLength, this.slicesLength);
 
-      if (0 == res) {
-        insertionPoint = mid;
-        break;
-      } else if (res < 0) {
-        // If left==right this means the insertion point is before 'right'
-        if (right == left) {
-          insertionPoint = -(right) - 1;
-          break;
-        }
-        right = mid - 1;
-        // TODO(hbs): should we use right = mid;
-      } else if (res > 0) {
-        // If left==right this means the insertion point is after left
-        if (right == left) {
-          insertionPoint = -(right + 1) - 1;
-          break;
-        }
-        left = mid + 1;
-        // TODO(hbs): should we use left = mid;
+  private int findInsertionPoint(byte[] subrow) {
+    int low = 0;
+    int high = (this.rangekeys.length / this.slicesLength) - 1;
+
+    // Look for subrow with binary search.
+    while (low <= high) {
+      int mid = (low + high) >>> 1;
+
+      int cmp = Bytes.compareTo(subrow, 0, subrow.length, this.rangekeys, mid * this.slicesLength, this.slicesLength);
+
+      if (cmp > 0) {
+        // subrow if after midpoint
+        low = mid + 1;
+      } else if (cmp < 0) {
+        // subrow is before midpoint
+        high = mid - 1;
+      } else {
+        // Key is found.
+        return mid;
       }
     }
-    
-    return insertionPoint;
+
+    // Key was not found.
+    return -(low + 1);
   }
   
   @Override
@@ -819,12 +781,8 @@ public class SlicedRowFilter extends FilterBase {
     //
     // If the first slice starts at offset 0 then we will be able to provide a key hint
     //
-    
-    if (0 == filter.bounds[0]) {
-      filter.hasHinting = true;
-    } else {
-      filter.hasHinting = false;
-    }
+
+    filter.hasHinting = (0 == filter.bounds[0]);
 
     filter.rangekeys = new byte[bb.getInt()];
     bb.get(filter.rangekeys);


### PR DESCRIPTION
Rewrote SlicedRowFilter#findInsertionPoint for a cleaner version. Previous version had strange conditionals (same for if and else):
```
      if (left > right) {
        left = right;
      } else if (right < left) {
        right = left;
      }
```
and FIXME comments cast some doubts on the correctness of the code. In the end, the code was correct but not very readable.


Tested both previous and current implementation with
```
  public static void main(String[] args) {
    List<Pair<byte[], byte[]>> ranges = new ArrayList<>();
    ranges.add(new Pair<>(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24}, new byte[] {0, 2, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24}));
    ranges.add(new Pair<>(new byte[] {0, 3, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24}, new byte[] {0, 4, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24}));
    SlicedRowFilter srf = new SlicedRowFilter(new int[] {0, 24}, ranges, Long.MAX_VALUE);

    // -1
    System.out.println(srf.findInsertionPoint(new byte[] {0, 0, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24}));
    // 0
    System.out.println(srf.findInsertionPoint(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24}));
    // -2
    System.out.println(srf.findInsertionPoint(new byte[] {0, 1, 3, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24}));
    // 1
    System.out.println(srf.findInsertionPoint(new byte[] {0, 2, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24}));
    // -3
    System.out.println(srf.findInsertionPoint(new byte[] {0, 2, 3, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24}));
    // 2
    System.out.println(srf.findInsertionPoint(new byte[] {0, 3, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24}));
    // -4
    System.out.println(srf.findInsertionPoint(new byte[] {0, 3, 3, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24}));
    // 3
    System.out.println(srf.findInsertionPoint(new byte[] {0, 4, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24}));
    // -5
    System.out.println(srf.findInsertionPoint(new byte[] {0, 4, 3, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24}));
  }
```
and it gives the same result.


Also some minor changes.