### PR TITLE
Update changelog generation to display PRs if possible

### DIFF
--- a/warp10/build.gradle
+++ b/warp10/build.gradle
@@ -14,11 +14,6 @@
 //   limitations under the License.
 //
 
-// Only the warp10 subproject uses changelog, so apply the plugin here.
-plugins {
-    id "com.selesse.git.changelog" version "0.3.0"
-}
-
 sourceSets {
     main {
         java {
@@ -195,8 +190,8 @@ task pack(type: Jar) {
 // Exec task to create the Warp 10 tar.gz file
 //
 task createTarArchive(type: Exec, dependsOn: pack) {
-    workingDir = '.'
-    commandLine = ["${workingDir}/src/main/sh/package.sh", version, projectDir]
+    workingDir '.'
+    commandLine "${projectDir}/src/main/sh/package.sh", version, projectDir
     outputs.file "${buildDir}/libs/warp10-${version}.tar.gz"
 }
 
@@ -221,56 +216,74 @@ publishing {
     }
 }
 
-changelog {
-    // The title appears at the top of the changelog.
-    // Default value: the name of the project.
-    title = "${project.name} - Changelog"
+task generateChangelog(type: Exec) {
+    workingDir '.'
 
-    // The output directory where the report is generated.
-    // Default value: main resource directory, or the "build" directory
-    outputDirectory = file("${project.buildDir}")
+    String separator = "§ÉÖÁËÁÞÓË"
 
-    // The name of the report to generate.
-    // Default value: CHANGELOG.md
-    fileName = "changelog.txt"
+    commandLine 'git', 'log', '--first-parent', 'master', '--decorate=short', '--decorate-refs=refs/tags/', '--format=%cs' + separator + '%D' + separator + '%s' + separator + '%b'
 
-    // The range of commits the changelog should be composed of.
-    // Default value: 'beginning' (i.e. full changelog)
-    // Possible values: 'beginning', 'last_tag', 'xxx'
-    //
-    // 'last_tag' will use all the commits since the last tag,
-    // 'beginning' will use all commits since the initial commit (default)
-    // 'xxx' will use all the tags since the 'xxx' Git reference (i.e. `since = 1.2.0` will display the changelog
-    //       since the 1.2.0 tag, excluding 1.2.0)
-    since = 'beginning'
+    standardOutput = new ByteArrayOutputStream()
 
-    // The output formats that should be generated.
-    // Default value: ['markdown']
-    // Possible values: 'html', 'markdown'.
-    formats = ['html', 'markdown']
+    File changelogFile = new File('.', "CHANGELOG.md")
+    outputs.file changelogFile
 
-    // The Git "pretty" changelog commit format.
-    // Default value: %ad%x09%s (%an), which produces:
-    // Thu May 7 20:10:33 2015 -0400    Initial commit (Alex Selesse)
-    commitFormat = '%ad%x09%s'
+    doLast {
+        changelogFile.write("# Warp 10 Changelog\n")
 
-    // Specifies a commit format for Markdown.
-    // Default value: '* %s (%an)', which produces:
-    // * Initial commit (Alex Selesse)
-    markdown {
-        commitFormat = '* %s'
-    }
+        boolean firstLine = true
+        BufferedReader br = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(standardOutput.toByteArray())));
 
-    // Specifies a commit format for the HTML template.
-    // Default value: see commitFormat
-    html {
-        commitFormat = '%s'
-    }
+        for (String line; (line = br.readLine()) != null;) {
+            String[] splittedLine = line.trim().split(separator)
 
-    // A closure that returns 'true' if the line should be included in the changelog.
-    // Default value: accept everything, { true }
-    includeLines = {
-        !it.contains("Merge")
+            if (splittedLine.length < 3) {
+                // Skip invalid lines, usually the last empty line.
+                continue
+            }
+
+            // Release
+            if (!"".equals(splittedLine[1])) {
+                // There can be several tags for the same commit (rc for instance).
+                String[] tags = splittedLine[1].split(",")
+                changelogFile.append("##")
+                // Last tag is last created, so scan from the end.
+                for (int i = tags.length - 1; i >= 0; i--) {
+                    if (i < tags.length - 1) {
+                        changelogFile.append(",")
+                    }
+                    changelogFile.append(tags[i].trim().substring(4))
+                }
+                // Add date of tagged commit.
+                changelogFile.append(" (" + splittedLine[0] + ")\n")
+            } else if (firstLine) {
+                // First line but no tag, add "Unreleased" section.
+                changelogFile.append("## Unreleased\n")
+            }
+
+            // Commit
+            String commitMessage
+            if (splittedLine.length < 4) {
+                // Not a PR
+                commitMessage = splittedLine[2]
+            } else {
+                // Most probably a PR
+                commitMessage = splittedLine[3]
+                if (splittedLine[2].startsWith("Merge pull request")) {
+                    // Definitively a PR, add link
+                    int prNumberStartIndex = splittedLine[2].indexOf("#") + 1
+                    int prNumberEndIndex = splittedLine[2].indexOf(" ", prNumberStartIndex)
+                    String prNumber = splittedLine[2].substring(prNumberStartIndex, prNumberEndIndex)
+                    commitMessage += " [#" + prNumber + "](https://github.com/senx/warp10-platform/pull/" + prNumber + ")"
+                }
+            }
+            if (commitMessage.startsWith("#")) {
+                commitMessage = "\\" + commitMessage
+            }
+            changelogFile.append("* " + commitMessage + "\n")
+
+            firstLine = false
+        }
     }
 }
 

--- a/warp10/build.gradle
+++ b/warp10/build.gradle
@@ -1,3 +1,5 @@
+import java.nio.charset.StandardCharsets
+
 //
 //   Copyright 2018-2021  SenX S.A.S.
 //
@@ -219,7 +221,7 @@ publishing {
 task generateChangelog(type: Exec) {
     workingDir '.'
 
-    String separator = "§ÉÖÁËÁÞÓË"
+    String separator = "\uBEEF\uC0DE";
 
     commandLine 'git', 'log', '--first-parent', 'master', '--decorate=short', '--decorate-refs=refs/tags/', '--format=%cs' + separator + '%D' + separator + '%s' + separator + '%b'
 


### PR DESCRIPTION
This PR removes `com.selesse.git.changelog` which is not maintained anymore and will not be compatible with Gradle 7.

Instead of listing all commits in the changelog, this new way of generating the changelog tries to list PRs:
- Commits applied directly to master are listed
- Only the merge of a PR is listed, all commits in the PR are not listed.

This method generates much more readable changelogs at the cost of:
- Being dependent to the way GitHub merges PRs (ie a commit message starting with "Merge pull request")
- Hiding merges of branches containing themselves merges of PRs. See for instance the merge of the 2.x branch.

Here is the changelog generated at this time. Links to issues and commits are added by GitHub, links to PRs are really in the changelog:

# Warp 10 Changelog
## Unreleased
* Remove unused variables and fields [#993](https://github.com/senx/warp10-platform/pull/993)
* Fix shardmodulus assignment [#992](https://github.com/senx/warp10-platform/pull/992)
* Fixed batch closing and write method called. [#988](https://github.com/senx/warp10-platform/pull/988)
* Added support for setting capabilities via HTTP header [#986](https://github.com/senx/warp10-platform/pull/986)
* Timebox [#976](https://github.com/senx/warp10-platform/pull/976)
* METASORT Extends behavior to attributes [#973](https://github.com/senx/warp10-platform/pull/973)
* Added missing call to close for iterators used in accelerator initial… [#987](https://github.com/senx/warp10-platform/pull/987)
* Make MVEXTRACT push ArrayList of lat/lon on the stack [#983](https://github.com/senx/warp10-platform/pull/983)
* fix a npe in WarpScript exception message [#982](https://github.com/senx/warp10-platform/pull/982)
* Modified scheduling so it uses System.nanoTime [#980](https://github.com/senx/warp10-platform/pull/980)
* Added stack attribute to indicate current execution is timeboxed [#978](https://github.com/senx/warp10-platform/pull/978)
* warpscript context bugfix in shadow extension [#979](https://github.com/senx/warp10-platform/pull/979)
* Initial commit of POLYFIT / POLYFUNC [#974](https://github.com/senx/warp10-platform/pull/974)
* Fixes macro TTL extraction [#975](https://github.com/senx/warp10-platform/pull/975)
* Replace printStackTrace with LOG.error when relevant [#969](https://github.com/senx/warp10-platform/pull/969)
* Added missing timestamp extraction [#971](https://github.com/senx/warp10-platform/pull/971)
* fix bugs that raised cryptic error messages in STL [#968](https://github.com/senx/warp10-platform/pull/968)
* Update the README header [#967](https://github.com/senx/warp10-platform/pull/967)
* Update building procedure [#970](https://github.com/senx/warp10-platform/pull/970)
## 2.8.1, 2.8.1-rc0 (2021-05-05)
* Fix dependencies definition for correct .module generation in WarpScript lib [#966](https://github.com/senx/warp10-platform/pull/966)
## 2.8.0, 2.8.0-rc1 (2021-05-04)
* STRICTMAPPER on macros [#962](https://github.com/senx/warp10-platform/pull/962)
* Change REVISION generation task dependency [#965](https://github.com/senx/warp10-platform/pull/965)
## 2.8.0-rc0 (2021-05-03)
* Change publishing pipeline so that it does not rely on Bintray anymore [#925](https://github.com/senx/warp10-platform/pull/925)
* Fix import of Bytes in ->RLP [#964](https://github.com/senx/warp10-platform/pull/964)
* Add .noauth, .nometa and .nofetch attributes for read tokens [#955](https://github.com/senx/warp10-platform/pull/955)
* Add names to threads or thread factories [#960](https://github.com/senx/warp10-platform/pull/960)
* Http extension [#891](https://github.com/senx/warp10-platform/pull/891)
* Fix required lib for WarpScript [#963](https://github.com/senx/warp10-platform/pull/963)
* add FUNCTION as output of TYPEOF since WarpscriptStackFunction object… [#961](https://github.com/senx/warp10-platform/pull/961)
* Add JSONPRETTY/JSONCOMPACT to prettify or not JSON output [#959](https://github.com/senx/warp10-platform/pull/959)
* Added parameters i and even to limit the number of candidate keys of ECRECOVER [#958](https://github.com/senx/warp10-platform/pull/958)
* Initial commit of MACRO-> and ->MACRO [#945](https://github.com/senx/warp10-platform/pull/945)
* Add function name and cause to WarpScriptExceptions [#957](https://github.com/senx/warp10-platform/pull/957)
* URLFETCH: Fix NPE when response have no body [#954](https://github.com/senx/warp10-platform/pull/954)
* Add FUNCREF and improve snapshots of WarpScriptStackFunctions [#951](https://github.com/senx/warp10-platform/pull/951)
* Merge TOBIN and ->BIN as well as TOHEX and ->HEX. [#952](https://github.com/senx/warp10-platform/pull/952)
* ECRECOVER - Recovering ECC public key from curve, hash and signature [#946](https://github.com/senx/warp10-platform/pull/946)
* Support for encoding/decoding using rlp (Recursive Length Prefix) [#948](https://github.com/senx/warp10-platform/pull/948)
* Fix IMMUTABLE to handle Map and return correct type [#949](https://github.com/senx/warp10-platform/pull/949)
* Fix error message with comparator aggregators. [#950](https://github.com/senx/warp10-platform/pull/950)
* Fix NPDF snapshot [#947](https://github.com/senx/warp10-platform/pull/947)
* Initial commit of Base58/Base58Check support [#943](https://github.com/senx/warp10-platform/pull/943)
* Added support for hex encoding ECC private key [#944](https://github.com/senx/warp10-platform/pull/944)
* Added Keccak/SHA-3 digest functions [#942](https://github.com/senx/warp10-platform/pull/942)
* Small optimization avoiding asList [#941](https://github.com/senx/warp10-platform/pull/941)
* Added white space checks in snapshot to avoid missing/repeated spaces [#940](https://github.com/senx/warp10-platform/pull/940)
* Fix current tick for mappers when GTS has duplicate ticks [#889](https://github.com/senx/warp10-platform/pull/889)
* Added support for getting size of Macro [#939](https://github.com/senx/warp10-platform/pull/939)
* Removed extraneous white space in macro snapshot
* Add support for signing macros [#938](https://github.com/senx/warp10-platform/pull/938)
* PcreateFont: Fix parameter handling to allow for default 12 size [#935](https://github.com/senx/warp10-platform/pull/935)
* Make more types snapshotable [#937](https://github.com/senx/warp10-platform/pull/937)
* Deprecate formatted [#934](https://github.com/senx/warp10-platform/pull/934)
* Crypto.updates [#936](https://github.com/senx/warp10-platform/pull/936)
* Avoid overflow of the encoder estimated size [#933](https://github.com/senx/warp10-platform/pull/933)
* Fix Shadow context save and restore [#932](https://github.com/senx/warp10-platform/pull/932)
* Fix DEDUP signature so that it reduces list nesting [#893](https://github.com/senx/warp10-platform/pull/893)
* Make ADD handle secure macros [#914](https://github.com/senx/warp10-platform/pull/914)
* Better handling of errors in websockets [#930](https://github.com/senx/warp10-platform/pull/930)
* Fix fields reinitialization when handling a new GTS [#931](https://github.com/senx/warp10-platform/pull/931)
* Fix wrongly caught ATC exception [#929](https://github.com/senx/warp10-platform/pull/929)
* Fix broken link for Warp 10 logo [#928](https://github.com/senx/warp10-platform/pull/928)
## 2.7.5 (2021-03-03)
* Uniformize and improve error messages for ATC Exceptions [#921](https://github.com/senx/warp10-platform/pull/921)
* Shamir Secret Sharing Scheme functions [#927](https://github.com/senx/warp10-platform/pull/927)
* Move revision task to subproject and fix task dependency [#926](https://github.com/senx/warp10-platform/pull/926)
## 2.7.4 (2021-02-23)
* Fix javadoc warnings [#924](https://github.com/senx/warp10-platform/pull/924)
* Refactored to expose compact method [#923](https://github.com/senx/warp10-platform/pull/923)
* Added sequence number to datalog file names to ensure unicity [#922](https://github.com/senx/warp10-platform/pull/922)
* Added configuration keys for various LevelDB low level parameters [#916](https://github.com/senx/warp10-platform/pull/916)
* Added config to load plugins using the default class loader [#920](https://github.com/senx/warp10-platform/pull/920)
* Removed SenX bintray maven repo following migration to Maven Central
* Bumped Sensision to 1.0.24 following migration to Maven Central
* Bumped Sensision to 1.0.24 following migration to Maven Central
* Modified GeoXP Lib dep to reflect switch to Maven Central
* Bumped OSS Client to 1.0.1 following its migration to Maven Central
* Fix race condition where a GTSDecoderIteratorRunnable could be interr… [#919](https://github.com/senx/warp10-platform/pull/919)
* Revamp gradle files and build script for cleaner build and publish [#774](https://github.com/senx/warp10-platform/pull/774)
* Proper type checks, better error messages and fix typo [#913](https://github.com/senx/warp10-platform/pull/913)
* Fix token expiry test [#915](https://github.com/senx/warp10-platform/pull/915)
* Add LevelDB createIfMissing Warp 10 configuration [#904](https://github.com/senx/warp10-platform/pull/904)
* Added support for FETCH to return GTSEncoders [#917](https://github.com/senx/warp10-platform/pull/917)
* Created a singleton RejectedExecutionException to reduce CPU consumption [#918](https://github.com/senx/warp10-platform/pull/918)
## 2.7.3 (2021-02-01)
* Add default value to $1 to avoid unbound variable error if no parameter [#905](https://github.com/senx/warp10-platform/pull/905)
* Allow GET on String and make path-like parameter work on all accepted types [#854](https://github.com/senx/warp10-platform/pull/854)
* Remove stacktrace and add clearer error message [#912](https://github.com/senx/warp10-platform/pull/912)
* Remove deprecated configuration keys from templates [#911](https://github.com/senx/warp10-platform/pull/911)
* Fixed NPE when deleting with start == 0 in the presence of uninitialized chunks [#909](https://github.com/senx/warp10-platform/pull/909)
* Uniformize the way macro TTL is handled, fix WarpScriptMacroLibrary TTL [#910](https://github.com/senx/warp10-platform/pull/910)
* Moved the hard value check in WarpScriptMacroRepository [#908](https://github.com/senx/warp10-platform/pull/908)
* Fixes #906 - Corrected bitset length retrieval. [#907](https://github.com/senx/warp10-platform/pull/907)
* Processing.pencode [#901](https://github.com/senx/warp10-platform/pull/901)
* Add tests for GTSHelper#subserie and clean/comment code [#899](https://github.com/senx/warp10-platform/pull/899)
* Fix retrieval of post boundary when at the end of LevelDB key space. [#902](https://github.com/senx/warp10-platform/pull/902)
* Remove python dependency by generating crypto keys using java [#863](https://github.com/senx/warp10-platform/pull/863)
* Add nullity checks for filenames in WarpConfig#setProperties [#898](https://github.com/senx/warp10-platform/pull/898)
* Add DELETE dryrun option returning a list of would-be deleted GTSs [#900](https://github.com/senx/warp10-platform/pull/900)
* Add Presize for bilinear resizing and small fixes [#896](https://github.com/senx/warp10-platform/pull/896)
* Initial commit of MacroResolver [#894](https://github.com/senx/warp10-platform/pull/894)
* Make memory store chunked by default in the conf file [#895](https://github.com/senx/warp10-platform/pull/895)
* Check the type of 'ticks' before casting [#897](https://github.com/senx/warp10-platform/pull/897)
## 2.7.2 (2021-01-06)
* Made locks fair
* Disable WarpInit with in memory mode to avoid IO error with LevelDB. [#892](https://github.com/senx/warp10-platform/pull/892)
* Added method init to extract suffix from config
* Merge branch 'master' of github.com:senx/warp10-platform into master
* Fixed resolving so NULL default value is not considered as no value found
* More precise offset for ParseException thrown by GTSHelper.parseValue [#886](https://github.com/senx/warp10-platform/pull/886)
* Add streamDelimiter parameter to HTTP definitions to stream the POST payload to the macro [#855](https://github.com/senx/warp10-platform/pull/855)
* Allow TOKENGEN and TOKENDUMP to be used always on custom keys without secret [#882](https://github.com/senx/warp10-platform/pull/882)
* Readme [#885](https://github.com/senx/warp10-platform/pull/885)
* Fix SORTWITH to throw ATC exceptions instead of catching them. [#884](https://github.com/senx/warp10-platform/pull/884)
* Refactored capabilities integrating functions in core WarpScript [#883](https://github.com/senx/warp10-platform/pull/883)
* Review README page [#881](https://github.com/senx/warp10-platform/pull/881)
* ALMOSTEQ (~=): Make conditions on parameters less strict [#876](https://github.com/senx/warp10-platform/pull/876)
* Add capabilities to tokens [#878](https://github.com/senx/warp10-platform/pull/878)
* Support dumping file based tokens when custom keys are not in use [#879](https://github.com/senx/warp10-platform/pull/879)
* Fix concurrency in StandaloneDirectoryClient [#866](https://github.com/senx/warp10-platform/pull/866)
* Modified safe delta mode to allow for fast merges in more cases [#867](https://github.com/senx/warp10-platform/pull/867)
* Fix bootstrap issue when running warp10-standalone.sh [#873](https://github.com/senx/warp10-platform/pull/873)
* More detailed error messages for /update [#871](https://github.com/senx/warp10-platform/pull/871)
* Add missing configuration keys to configuration templates [#864](https://github.com/senx/warp10-platform/pull/864)
* Add SHMDEFINED which tells if a symbol is defined in SHM [#865](https://github.com/senx/warp10-platform/pull/865)
* 400 error codes and clearer status messages for bad parameters [#870](https://github.com/senx/warp10-platform/pull/870)
* Add missing GeoShape case [#869](https://github.com/senx/warp10-platform/pull/869)
* Added support for BYTES in == [#868](https://github.com/senx/warp10-platform/pull/868)
* Merge branch 'master' into metadataiterator-export
* Added MetadataIterator in WarpScript library.
* Added support for fetching HBase cell TTLs. [#857](https://github.com/senx/warp10-platform/pull/857)
* Make DTW work on locations and elevations and add window parameter [#858](https://github.com/senx/warp10-platform/pull/858)
* Implement Hyndman's 9 types of percentile computation [#849](https://github.com/senx/warp10-platform/pull/849)
* Ecdh [#856](https://github.com/senx/warp10-platform/pull/856)
* Add a limit parameter to SPLIT [#853](https://github.com/senx/warp10-platform/pull/853)
## 2.7.1, 2.7.1-rc1 (2020-09-25)
* Rolling back signature change. [#852](https://github.com/senx/warp10-platform/pull/852)
* Set UTF-8 as default encoding and check it is at the start of Warp 10 [#846](https://github.com/senx/warp10-platform/pull/846)
* Add support for checking intersection of two GEOSHAPE instances [#850](https://github.com/senx/warp10-platform/pull/850)
* Added conditionals so an NPE is not raised when name or labels is null [#839](https://github.com/senx/warp10-platform/pull/839)
* Fix integer divisions [#848](https://github.com/senx/warp10-platform/pull/848)
* Refactored HIDE/SHOW so 0 is interpreted as no levels instead of all levels [#842](https://github.com/senx/warp10-platform/pull/842)
* Fix cast in OpAdd and OpMul and cleaning [#836](https://github.com/senx/warp10-platform/pull/836)
* Simplify, factorize and uniformize the code of arithmetic operations [#834](https://github.com/senx/warp10-platform/pull/834)
* Make POW work on GTSs and Lists the same way numerical functions do [#833](https://github.com/senx/warp10-platform/pull/833)
* Make numerical functions work on GTSs [#832](https://github.com/senx/warp10-platform/pull/832)
* Initial commit of mapper.geo.fence, added constants for geo mappers [#835](https://github.com/senx/warp10-platform/pull/835)
* Fix comparator to behave correctly with NaN and -0.0 [#847](https://github.com/senx/warp10-platform/pull/847)
* Switch from a HashMap using URLS to URIs [#843](https://github.com/senx/warp10-platform/pull/843)
* Do not instantiate a new Random each time a onetimepad is created [#838](https://github.com/senx/warp10-platform/pull/838)
* Remove the dbdump function because it is unused and always throws a NPE [#844](https://github.com/senx/warp10-platform/pull/844)
* Remove unnecessary call to ceil on Long [#837](https://github.com/senx/warp10-platform/pull/837)
* Remove unneeded check because metadata is always non-null [#841](https://github.com/senx/warp10-platform/pull/841)
* Remove unused and non-functioning KeySlicesFilter [#840](https://github.com/senx/warp10-platform/pull/840)
* Update DocumentationGenerator.java [#826](https://github.com/senx/warp10-platform/pull/826)
* Remove unused keys in keystore [#827](https://github.com/senx/warp10-platform/pull/827)
* Fix possible NPE in NE.java [#831](https://github.com/senx/warp10-platform/pull/831)
* Set default split length to 1 instead of 0
* Fixed error message and handled NoClassDefFound
* Modified changelog method used by Jenkins
* Speed up restore with System.arraycopy on registers [#829](https://github.com/senx/warp10-platform/pull/829)
* Remove unused changelog.js [#828](https://github.com/senx/warp10-platform/pull/828)
## 2.7.0, 2.7.0-rc2 (2020-09-08)
* Added configuration for Jetty thread pool and queue size [#825](https://github.com/senx/warp10-platform/pull/825)
* Fix typo in ->WKT and ->WKB error messages [#824](https://github.com/senx/warp10-platform/pull/824)
## 2.7.0-rc1 (2020-09-07)
* Bumped Sensision to 1.0.22
* Make sure all created GeoXPShapes contain sorted and deduped arrays [#823](https://github.com/senx/warp10-platform/pull/823)
* Removed log message as we throw an exception
* Optimized metadata handling [#816](https://github.com/senx/warp10-platform/pull/816)
* Merge branch 'master' of github.com:senx/warp10-platform into master
* Bumped Sensision dependency to 1.0.22
* Fix and simplify condition for shrink in GTSHelper#chunk [#820](https://github.com/senx/warp10-platform/pull/820)
* Add MMAP, transposition of LMAP to Maps [#821](https://github.com/senx/warp10-platform/pull/821)
* Add utility functions to check and set keys in keystore… [#814](https://github.com/senx/warp10-platform/pull/814)
* Add Pmask for masking a PImage with another [#817](https://github.com/senx/warp10-platform/pull/817)
* Factorize stat in Directories and fix stat on sharding [#815](https://github.com/senx/warp10-platform/pull/815)
* Modify custom JSON serialization [#802](https://github.com/senx/warp10-platform/pull/802)
* Modified code so list of Metadatas is not deep copied when cloning Fe… [#803](https://github.com/senx/warp10-platform/pull/803)
* Add optimization to ASREGS [#810](https://github.com/senx/warp10-platform/pull/810)
* Add conversion between GeoJSON, WKT and WKB formats [#808](https://github.com/senx/warp10-platform/pull/808)
* Fixes #812 - Changed fairness of lock [#813](https://github.com/senx/warp10-platform/pull/813)
* Make REMOVE work on GTS using point index [#811](https://github.com/senx/warp10-platform/pull/811)
* Fix VARS so that it detects variables that are only used for storing [#809](https://github.com/senx/warp10-platform/pull/809)
* Replaced uses of ImmutableMap.copyof by Collections.unmodifiableMap [#804](https://github.com/senx/warp10-platform/pull/804)
* Fixes #805 [#806](https://github.com/senx/warp10-platform/pull/806)
* Initial commit of labels priority support [#777](https://github.com/senx/warp10-platform/pull/777)
* Neg hide [#800](https://github.com/senx/warp10-platform/pull/800)
* Geo Buffer fix [#801](https://github.com/senx/warp10-platform/pull/801)
* Merge branch 'master' of github.com:senx/warp10-platform
* Enhanced error message
* Modified the way PImage/PGraphics are handled since PGraphics extends PImage
* Added support for encoding iTXt PNG chunks [#796](https://github.com/senx/warp10-platform/pull/796)
* Added pixel extraction from PImage instances [#797](https://github.com/senx/warp10-platform/pull/797)
* Add optional macro or mapper parameter for DEDUP to merge duplicate ticks [#789](https://github.com/senx/warp10-platform/pull/789)
* Try type resolver if typeofable fails [#794](https://github.com/senx/warp10-platform/pull/794)
* Uniformize the configuration templates [#782](https://github.com/senx/warp10-platform/pull/782)
* fix UNBUCKETIZE.CALENDAR for empty series [#793](https://github.com/senx/warp10-platform/pull/793)
* fix bucketcount in BUCKETIZE.CALENDAR [#792](https://github.com/senx/warp10-platform/pull/792)
* Added fix for split fetching in which case rtoken is null
* Merge branch 'master' of github.com:senx/warp10-platform
* Added fix for == when the first operand is null
* Moved input format class name extraction after configuration update
* Initial commit of step and timestep support for data retrieval [#772](https://github.com/senx/warp10-platform/pull/772)
* Return clearer error message when /delete fails on token [#784](https://github.com/senx/warp10-platform/pull/784)
* Fixes #779 - Added checks for null tokens [#783](https://github.com/senx/warp10-platform/pull/783)
* Make sure a FETCH with MINLONG timespan does not overflow count [#781](https://github.com/senx/warp10-platform/pull/781)
* Fixes #778 - Corrected sign in fetchCountEncoder [#780](https://github.com/senx/warp10-platform/pull/780)
* Allow headers setting in URLFETCH [#776](https://github.com/senx/warp10-platform/pull/776)
* Initial commit of HIDE/SHOW [#775](https://github.com/senx/warp10-platform/pull/775)
* Initial commit of GEO.BUFFER [#773](https://github.com/senx/warp10-platform/pull/773)
* Update gradle to 6.4.1 [#771](https://github.com/senx/warp10-platform/pull/771)
* Exec: allow trailing slash and improve error messages for symbols in URL [#770](https://github.com/senx/warp10-platform/pull/770)
## 2.6.0 (2020-05-27)
* Fixed config extraction for bootstrap
* Refactored Accelerator Config for WarpScript lib compatibility [#769](https://github.com/senx/warp10-platform/pull/769)
* Change 2.5.1 to 2.6.0 [#768](https://github.com/senx/warp10-platform/pull/768)
* Corrected execution of macros, was missing call to EVAL [#767](https://github.com/senx/warp10-platform/pull/767)
* Cleaned imports
* Macro value encoder [#766](https://github.com/senx/warp10-platform/pull/766)
* Initial commit of upgrade doc [#764](https://github.com/senx/warp10-platform/pull/764)
* Initial commit of ThreadProperties support [#765](https://github.com/senx/warp10-platform/pull/765)
* Fixed comment
* Merge most Math functions and make them applicable on lists [#761](https://github.com/senx/warp10-platform/pull/761)
* Jenkins: disable BigBang publish [#763](https://github.com/senx/warp10-platform/pull/763)
* Added logging [#759](https://github.com/senx/warp10-platform/pull/759)
* Removed calls to toCharArray [#760](https://github.com/senx/warp10-platform/pull/760)
* Fixed edge cases when count is 0 [#758](https://github.com/senx/warp10-platform/pull/758)
* Make metaset easier to use and avoid NPE when fetching without timespan [#757](https://github.com/senx/warp10-platform/pull/757)
* Added retrieval of store/directory clients [#756](https://github.com/senx/warp10-platform/pull/756)
* Added log message indicating a property was removed
* Add configuration to disable env/system properties and expansion failures [#755](https://github.com/senx/warp10-platform/pull/755)
* Make MIN and MAX return LONG for Counters [#753](https://github.com/senx/warp10-platform/pull/753)
* Added support for configuring default accelerator strategies [#751](https://github.com/senx/warp10-platform/pull/751)
* Remove archiving [#754](https://github.com/senx/warp10-platform/pull/754)
* Make list of symbol names optional for ASREGS [#752](https://github.com/senx/warp10-platform/pull/752)
* Initial commit of ->VARINT and VARINT-> [#749](https://github.com/senx/warp10-platform/pull/749)
* Add more conversions from/to HHCodes [#736](https://github.com/senx/warp10-platform/pull/736)
* Simplify constant conditions and constant variables [#746](https://github.com/senx/warp10-platform/pull/746)
* Initial commit of Elliptic-Curve Cryptography support [#747](https://github.com/senx/warp10-platform/pull/747)
* Added identification of python interpreter [#750](https://github.com/senx/warp10-platform/pull/750)
* Fix typo in WarpScript jar inclusion list [#748](https://github.com/senx/warp10-platform/pull/748)
* Change checks order to really make name optional [#744](https://github.com/senx/warp10-platform/pull/744)
* Merge OpAND and OpOR [#741](https://github.com/senx/warp10-platform/pull/741)
* Remove old WIP methods [#745](https://github.com/senx/warp10-platform/pull/745)
* Make code clearer and cleaner for the range case of SUBLIST [#743](https://github.com/senx/warp10-platform/pull/743)
* Fix loop to find most common baseNanos [#742](https://github.com/senx/warp10-platform/pull/742)
* Fix get/remove on Maps with wrong keys or replace with simplier parameter [#740](https://github.com/senx/warp10-platform/pull/740)
* Changed non-short-circuit operator for short-circuit one. [#739](https://github.com/senx/warp10-platform/pull/739)
* Mapper, Bucketizer and Reducer Interfaces extends Aggregator for simplicity [#738](https://github.com/senx/warp10-platform/pull/738)
* Replace diamond operator with explicit declaration [#737](https://github.com/senx/warp10-platform/pull/737)
* Merge branch 'master' of github.com:senx/warp10-platform
* Added repo for oss-client
* Modified GeoXPLib dep and NOTICE
* \#Fixes 716 - Fixes edge cases of boundary fetch [#731](https://github.com/senx/warp10-platform/pull/731)
* Initial commit of Psize [#734](https://github.com/senx/warp10-platform/pull/734)
* Fix mapper.second [#732](https://github.com/senx/warp10-platform/pull/732)
* Config fetch [#717](https://github.com/senx/warp10-platform/pull/717)
* Check that the expected parameter is a String instead of using .toString() [#725](https://github.com/senx/warp10-platform/pull/725)
* Make NPEEK always consume the number of levels and PEEKN check parameter type, … [#726](https://github.com/senx/warp10-platform/pull/726)
* Fix type check in MOD: now returns long value for AtomicLong [#728](https://github.com/senx/warp10-platform/pull/728)
* Stricter type check for ADD when used with operand+GTS [#729](https://github.com/senx/warp10-platform/pull/729)
* Fix parameter conversion in NPDF [#727](https://github.com/senx/warp10-platform/pull/727)
* Use more precise type check for NE and EQ [#730](https://github.com/senx/warp10-platform/pull/730)
* Wrapmv nocomp [#719](https://github.com/senx/warp10-platform/pull/719)
* UNLIST to throw when not given a List/Array. … [#721](https://github.com/senx/warp10-platform/pull/721)
* Avoid a copy when building List from stack [#720](https://github.com/senx/warp10-platform/pull/720)
* Add Context in TYPEOF [#724](https://github.com/senx/warp10-platform/pull/724)
* Geounpack loose [#718](https://github.com/senx/warp10-platform/pull/718)
* Added flag to potentially disable shutdown hook [#722](https://github.com/senx/warp10-platform/pull/722)
* Factorize mappers using DateTime and fail for invalid TimeZone or offset. [#723](https://github.com/senx/warp10-platform/pull/723)
* Bumped Sensision to 1.0.21
* Fixed comment
## 2.5.0 (2020-04-02)
* Added synchronized
* Removed sizing as size may get negative
* Fixed jackson libs
* Fixed keystore initalization
* Typo [#715](https://github.com/senx/warp10-platform/pull/715)
* Extract JAVA_OPTS before switching to strict mode
* Merge branch 'master' of github.com:senx/warp10-platform
* Update
* Added support for listing and aborting WarpScript executions [#686](https://github.com/senx/warp10-platform/pull/686)
* Merge branch 'master' of github.com:senx/warp10-platform
* Fixed value extraction from getValue to getBinaryValue
* Added early exit
* Added output of HHCode as STRING or LONG
* Fixed instanceof test
* Fixed parameters order
* Fixes #708 - Corrected pre/post window handling. [#709](https://github.com/senx/warp10-platform/pull/709)
* Added TypeResolver support to TYPEOF [#707](https://github.com/senx/warp10-platform/pull/707)
* Initial commit of Java version of leveldb repair [#700](https://github.com/senx/warp10-platform/pull/700)
* Added missing classes to warpscript library
* Fixed default value of skipCheckAttributes
* Set the source and target to Java 8, making this project only support Java 8+. [#703](https://github.com/senx/warp10-platform/pull/703)
* Fix missing properties in GTSEncoderTest [#706](https://github.com/senx/warp10-platform/pull/706)
* TOKENGEN and TOKENDUM initialization fix: keystore is null [#704](https://github.com/senx/warp10-platform/pull/704)
* Add missing return statement in handling of /delete. [#702](https://github.com/senx/warp10-platform/pull/702)
* Replaces printStackTrace by LOG.warn
* Warp 10 Accelerator [#666](https://github.com/senx/warp10-platform/pull/666)
* Added configuration of macro cache size [#691](https://github.com/senx/warp10-platform/pull/691)
* Attribute check for tokens [#699](https://github.com/senx/warp10-platform/pull/699)
* Added missing AuthenticationPlugin
* Adds activeafter/quietafter params to /delete requests and a metaonly option [#690](https://github.com/senx/warp10-platform/pull/690)
* Modified validation of GTS list. [#692](https://github.com/senx/warp10-platform/pull/692)
* Fixes #682 - Added support for GTS Encoders in PIVOT [#683](https://github.com/senx/warp10-platform/pull/683)
* fix #635 [#676](https://github.com/senx/warp10-platform/pull/676)
* added WarpScriptAggregatorFunction to remaining mappers [#678](https://github.com/senx/warp10-platform/pull/678)
* Initial commit of ValueEncoder support [#671](https://github.com/senx/warp10-platform/pull/671)
* Enable OSS support in TOKENGEN and TOKENDUMP for the secret management [#696](https://github.com/senx/warp10-platform/pull/696)
* Initial commit of GEOSPLIT [#673](https://github.com/senx/warp10-platform/pull/673)
* Added support for GTSEncoder instances in META [#675](https://github.com/senx/warp10-platform/pull/675)
* Added early exit when extracting only specific indices [#685](https://github.com/senx/warp10-platform/pull/685)
* Fixes #664 - Enhanced error message when a macro cannot be loaded [#677](https://github.com/senx/warp10-platform/pull/677)
* Fixes #688 - Corrects the boundary fetches [#689](https://github.com/senx/warp10-platform/pull/689)
* Fixes #680 - Only check if count is specified when timespan is negative. [#681](https://github.com/senx/warp10-platform/pull/681)
* Added FOREACH iteration on STRINGs [#693](https://github.com/senx/warp10-platform/pull/693)
* set log4j properties to fix #694 [#695](https://github.com/senx/warp10-platform/pull/695)
* fix #679 shell script for opensuse env [#684](https://github.com/senx/warp10-platform/pull/684)
* Added specific buffer sizes to speed up decoding
* Added hinting in ->GTS when forcing type.
* Initial commit of GEOSHIFT [#672](https://github.com/senx/warp10-platform/pull/672)
* Fixes #667 - Add support for missing labels in Directory searches [#669](https://github.com/senx/warp10-platform/pull/669)
* Duration.bucketize [#665](https://github.com/senx/warp10-platform/pull/665)
* STORE bug fix for singleton list [#670](https://github.com/senx/warp10-platform/pull/670)
* Merge branch 'master' of github.com:senx/warp10-platform
* Optimized array copy between partitioner and processing macro
* Fixed typo in log message
* Initial commit of GEO.GEOHASHES [#658](https://github.com/senx/warp10-platform/pull/658)
* Bumped GeoXPLib to 1.0.0-rc23
* Bumped GeoXPLib to 1.0.0-rc21
* GEO.UNION and GEO.INTESERCTION to take a list of shapes. [#663](https://github.com/senx/warp10-platform/pull/663)
* Merge branch 'master' of github.com:senx/warp10-platform
* Bumped GeoXPLib to 1.0.0-rc20
* Added support for fetching TrueType fonts via http/https [#648](https://github.com/senx/warp10-platform/pull/648)
* Initial commit of ->GEOJSON [#656](https://github.com/senx/warp10-platform/pull/656)
* Initial commit of GEO.NORMALIZE [#657](https://github.com/senx/warp10-platform/pull/657)
* Expose producer owner [#649](https://github.com/senx/warp10-platform/pull/649)
* MAP to accept abs(occurrences)>Integer.MAX_VALUE and code simplification. [#654](https://github.com/senx/warp10-platform/pull/654)
* Make median aggregator always return a double. [#653](https://github.com/senx/warp10-platform/pull/653)
* Fix counter type [#655](https://github.com/senx/warp10-platform/pull/655)
* fix: divide TTL by MSTU [#652](https://github.com/senx/warp10-platform/pull/652)
* Merge branch 'master' of github.com:senx/warp10-platform
* Fixed error message
* Bumped GeoXPLib to 1.0.0-rc16
* Clone the INFO map so it is not exposed outside the macro
## 2.4.0 (2020-01-24)
* Addduration [#647](https://github.com/senx/warp10-platform/pull/647)
* Added indirection via parent PApplet instance so we can use recorders [#645](https://github.com/senx/warp10-platform/pull/645)
* Fix format test [#646](https://github.com/senx/warp10-platform/pull/646)
* Addduration [#639](https://github.com/senx/warp10-platform/pull/639)
* Filter any all [#644](https://github.com/senx/warp10-platform/pull/644)
* Add functions from HHCodeHelper [#642](https://github.com/senx/warp10-platform/pull/642)
* fix median and percentile aggregators bugs when used as reducer [#631](https://github.com/senx/warp10-platform/pull/631)
* changed comment for number of http thread [#643](https://github.com/senx/warp10-platform/pull/643)
* Fixes #640 - Converted negative cell timestamps to 0 [#641](https://github.com/senx/warp10-platform/pull/641)
* filter by size [#637](https://github.com/senx/warp10-platform/pull/637)
* duplicate stderr to logs and stderr for process journal [#638](https://github.com/senx/warp10-platform/pull/638)
* Bumped GeoXPLib to 1.0.0-rc15
* Merge branch 'master' of github.com:senx/warp10-platform
* Fixed TOKENGEN for secret use
* Typed ->GTS function and filter.byselector [#617](https://github.com/senx/warp10-platform/pull/617)
* Added support for additional SNAPSHOT encoders [#625](https://github.com/senx/warp10-platform/pull/625)
* HYBRIDTEST2 bugfix [#626](https://github.com/senx/warp10-platform/pull/626)
* Issue 627 [#628](https://github.com/senx/warp10-platform/pull/628)
* Merge branch 'master' of github.com:senx/warp10-platform
* Removed cause because it has a gigantic message
* Fixes 621 - Added missing metadata when wrapping a GTS. Added sorting… [#622](https://github.com/senx/warp10-platform/pull/622)
* Merge branch 'master' of github.com:senx/warp10-platform
* Removed warp.tokens which whould not have been committed
* Fixed key extraction
* Fixed timespan computation
## 2.3.0 (2019-12-13)
* Fixed off by one error which could lead to too many datapoints being returned when willing to fetch 1
* Fix translation from list to map in FETCH. [#614](https://github.com/senx/warp10-platform/pull/614)
* Rewrite FETCH and fetch endpoint parameters handling [#613](https://github.com/senx/warp10-platform/pull/613)
* Added supplemental check to ignore the token secret if keys were specified
* Moved numregs positioning
* Merge branch 'master' of github.com:senx/warp10-platform
* Added SO links
* Fixed typo
* Fixed off by one error in number of used registers
* Added null check of owner
* Merge branch 'master' of github.com:senx/warp10-platform
* Added compression
* Merge branch 'master' of github.com:senx/warp10-platform
* Added missing doc for ingress.parse.attributes
* Fixes #604 - Fixed token attribute constants. [#605](https://github.com/senx/warp10-platform/pull/605)
* Merge branch 'master' of github.com:senx/warp10-platform
* Added size hint when allocating context HashMaps
* Merge branch 'master' of github.com:senx/warp10-platform
* Set thread as daemon
* Merge branch 'master' of github.com:senx/warp10-platform
* Modified location of call to telinit
* Modified waiting period from 10us to 50us
* Fixes #595 - Handled extreme case of end timestamp being MIN_LONG [#596](https://github.com/senx/warp10-platform/pull/596)
* Initial commit of ephemeral support [#593](https://github.com/senx/warp10-platform/pull/593)
* Initial implementation of DEREF [#594](https://github.com/senx/warp10-platform/pull/594)
* Initial commit of boundary support [#592](https://github.com/senx/warp10-platform/pull/592)
* Attributes update [#587](https://github.com/senx/warp10-platform/pull/587)
* Merge branch 'master' of github.com:senx/warp10-platform
* Added remote reporting
* Motionsplit [#571](https://github.com/senx/warp10-platform/pull/571)
* typo in 20-warpscript.conf.template [#591](https://github.com/senx/warp10-platform/pull/591)
* Merge branch 'master' of github.com:senx/warp10-platform
* Fixes #589 - Moved standaloneMode setting earlier
* Directory unregister [#579](https://github.com/senx/warp10-platform/pull/579)
* feat(warpscript): add SYMBOLS function [#585](https://github.com/senx/warp10-platform/pull/585)
* Formatted [#584](https://github.com/senx/warp10-platform/pull/584)
* Fixed tm [#583](https://github.com/senx/warp10-platform/pull/583)
* Documented trademarks
* Add logo and badges [#582](https://github.com/senx/warp10-platform/pull/582)
* Install Thrift and use urandom [#581](https://github.com/senx/warp10-platform/pull/581)
* Merge branch 'master' of github.com:senx/warp10-platform
* Added support for string keys in the renaming map
* Clearer, standardized and more secure error messages. [#577](https://github.com/senx/warp10-platform/pull/577)
* Fix syntax: Add parameters about Listen Queue/Backlog in TCP [#576](https://github.com/senx/warp10-platform/pull/576)
* Add parameters about Listen Queue/Backlog in TCP [#569](https://github.com/senx/warp10-platform/pull/569)
* feat(directory): add a gts per app metrics [#572](https://github.com/senx/warp10-platform/pull/572)
* TOKENGEN throws when missing a mandatory field [#575](https://github.com/senx/warp10-platform/pull/575)
* Added support for WKB [#570](https://github.com/senx/warp10-platform/pull/570)
* Merge branch 'master' of github.com:senx/warp10-platform
* Added safety net around cache dump
* Added missing recomputation of class/labels ID
* Added removal of producer/owner/app labels and forcing of token labels [#562](https://github.com/senx/warp10-platform/pull/562)
* Fixes #563 - Added update of sensision metrics upon broadcast/fusion of estimators [#566](https://github.com/senx/warp10-platform/pull/566)
* Add EmptyWarpScriptStackException to void overriding every EmptyStackException [#567](https://github.com/senx/warp10-platform/pull/567)
* Fix some stack size checks [#565](https://github.com/senx/warp10-platform/pull/565)
* Moved fullsort of GTSEncoder into GTSHelper. Added support or GTSEnco… [#558](https://github.com/senx/warp10-platform/pull/558)
* Added bucketizer.sd.forbid-nulls
* feat add bucketizer.sd as WarpScript BUCKETIZE [#561](https://github.com/senx/warp10-platform/pull/561)
* seeded version of RANDPDF [#559](https://github.com/senx/warp10-platform/pull/559)
* Use configured header for error messages [#560](https://github.com/senx/warp10-platform/pull/560)
* Merge branch 'master' of github.com:senx/warp10-platform
* Fixed typo in exception message for values too large
* Added support for comparison of byte arrays
* Merge branch 'master' of github.com:senx/warp10-platform
* Fixes #556 - corrected serialized Metadata instance
* bugfix [#554](https://github.com/senx/warp10-platform/pull/554)
* Remove unnecessary steps [#553](https://github.com/senx/warp10-platform/pull/553)
## 2.2.0 (2019-09-13)
* Optimize fullsort when GTS is already sorted. [#552](https://github.com/senx/warp10-platform/pull/552)
* Throw exception when maximum number of cells is exceeded [#551](https://github.com/senx/warp10-platform/pull/551)
* Hbase cell ttl
* Added support for per token maxsize [#531](https://github.com/senx/warp10-platform/pull/531)
* Doc gen [#548](https://github.com/senx/warp10-platform/pull/548)
* Add SORTWITH to sort a list using a comparator macro. [#549](https://github.com/senx/warp10-platform/pull/549)
* REXEC: More detailed error messages [#546](https://github.com/senx/warp10-platform/pull/546)
* GOLDWRAP [#544](https://github.com/senx/warp10-platform/pull/544)
* Cleaner and more understandable error messages from Throwables [#543](https://github.com/senx/warp10-platform/pull/543)
* Merge branch 'master' of github.com:senx/warp10-platform
* Merge branch 'master' of github.com:senx/warp10-platform
* Cleaned required libs for WarpScript
* Merge branch 'master' of github.com:senx/warp10-platform
* Added configuration for strict writables conversion
* added razorvine pyrolite module to warpscript build [#541](https://github.com/senx/warp10-platform/pull/541)
* Add an aggregator and mapper to extend comparison mappers to tick, lat, lon, etc. [#535](https://github.com/senx/warp10-platform/pull/535)
* Add equality for List, Map and Set and minor fixes for EQ [#540](https://github.com/senx/warp10-platform/pull/540)
* GTS to Encoder conversions [#523](https://github.com/senx/warp10-platform/pull/523)
* Static names [#538](https://github.com/senx/warp10-platform/pull/538)
* Formatted [#539](https://github.com/senx/warp10-platform/pull/539)
* Systemd unit fix [#533](https://github.com/senx/warp10-platform/pull/533)
* add error location tip into error message [#537](https://github.com/senx/warp10-platform/pull/537)
* Add GTSEncoder cloning. [#536](https://github.com/senx/warp10-platform/pull/536)
* Set lastbucket, bucketcount and bucketspan [#534](https://github.com/senx/warp10-platform/pull/534)
* Modified behavior to only call HTable#batch if we have mutations to apply
* Modified exception message to indicate the name of the current macro if available
* Readable doc gen [#507](https://github.com/senx/warp10-platform/pull/507)
* Merge branch 'master' of github.com:senx/warp10-platform
* Fixes #528 - Added Authorization header with basic auth when user/password are present in the URL
* Merge branch 'master' of github.com:senx/warp10-platform
* Fixes #527 - Modified check so null values are correctly handled
* Added support for GeoXPShape in SIZE
* Merge branch 'master' of github.com:senx/warp10-platform
* Added support for byte arrays
* Added support for GTS Encoders in VALUEHISTOGRAM
* Modified macro loading so the macro name is inherited by all child macros so MACROCONFIG works.
* Merge branch 'master' of github.com:senx/warp10-platform
* Added missing LF after macro expansion
* Check for GTS type in lists given to frameworks for more explicit error messages. [#512](https://github.com/senx/warp10-platform/pull/512)
* Add more sleep [#517](https://github.com/senx/warp10-platform/pull/517)
* Fix testTokenExpired [#516](https://github.com/senx/warp10-platform/pull/516)
* Sensision version bump [#515](https://github.com/senx/warp10-platform/pull/515)
* Convert some GTSStackFunctions to ElementOrListStackFunction [#514](https://github.com/senx/warp10-platform/pull/514)
* Add STRINGFORMAT function to format strings using String.format [#513](https://github.com/senx/warp10-platform/pull/513)
* Do not check nullity when instanceof already does [#510](https://github.com/senx/warp10-platform/pull/510)
* Convert last groovy code to java [#509](https://github.com/senx/warp10-platform/pull/509)
* Merge branch 'master' of github.com:senx/warp10-platform
* Added readable option to SNAPSHOT#addElement for map/list/set/vector elements.
* No need to install crypto and token modules [#505](https://github.com/senx/warp10-platform/pull/505)
* Fix IFTE type check, IFT/IFTE explicit variable names and less type check [#504](https://github.com/senx/warp10-platform/pull/504)
*  Use entrySet instead of keySet when get(key) is used in the loop. [#503](https://github.com/senx/warp10-platform/pull/503)
* Use the Properties methods instead of the Hashtable one on Properties instances. [#502](https://github.com/senx/warp10-platform/pull/502)
* Added support for variable expansion in runners [#499](https://github.com/senx/warp10-platform/pull/499)
* Stop the server when address is already in use. [#501](https://github.com/senx/warp10-platform/pull/501)
* Add missing spaces in error messages [#500](https://github.com/senx/warp10-platform/pull/500)
* Fixed possible macro cache abuse by disallowinf leading / in macro names fetched from WarpFleet/MacroRepository/MacroLibrary
* Modified fix of MVEXTRACT/MVSPLIT by calling GTSWrapper#clear instead of creating a new instsance
* Fixed incorrect decoding of GTSWrapper due to missing instanciation
## 2.1.0 (2019-07-12)
* Fix sed compatibility between Linux and MacOS [#498](https://github.com/senx/warp10-platform/pull/498)
## 2.1.0-rc2 (2019-07-12)
* Bumped com.jfrog.bintray to 1.8.4 to fix a bug with Gradle wrapper 4.10
* Merge branch 'master' of github.com:senx/warp10-platform
* Bumped Sensision to 1.0.19
* Bumped WarpStudio Plugin to 0.0.80
* Bumped WarpStudio Plugin to v0.0.80
* Datalog sharding [#416](https://github.com/senx/warp10-platform/pull/416)
* Dispatched configuration in multiple files
* Moved confs in subdirs of conf.templates
* Merge branch 'master' of github.com:senx/warp10-platform
* Moved configuration templates in conf.templates
* Changed in-memory config
* Made IN_MEMORY_CHUNKED mandatory config when using an in-memory store
* Refactored WRAP to remove WRAPRAW [#488](https://github.com/senx/warp10-platform/pull/488)
* Merge branch 'master' of github.com:senx/warp10-platform
* Cleaned up imports
* Convert BigDecimal to double
* Fixed indices
* Fixed output when not requesting VALUE, we need to emit a pair for every MV value encountered
* Initial commit of MVLOCATIONS, MVELEVATIONS, MVTICKS, MVHHCODES
* Intial commit of MVVALUES
* Added support for lists of GTS/Encoders as input
* Removed dead code
* Initial commit of ->ENCODERS, MVTICKSPLIT and MVINDEXSPLIT
* Added support for iterating over Geo Time Series™ and GTS Encoders
* Added removal of comments and trimming of input lines
* Modified comment
* Merge branch 'master' of github.com:senx/warp10-platform
* Refactored TICKINDEX to operate on GTSEncoder instances too
* Merge branch 'master' of github.com:senx/warp10-platform
* Added support for adding GTS and Encoders via ADDVALUE. Added support for GTS/GTSEncoder input for ->MVSTRING
* Initial commit of PARSEVALUE
* Initial commit of ->MVSTRING
* Pdecode from bytes [#483](https://github.com/senx/warp10-platform/pull/483)
* Fixed handling of type attribute
* Added native SSL support [#457](https://github.com/senx/warp10-platform/pull/457)
* Bumped Java LevelDB to 0.12 following merge of PR110
* Multi value update [#478](https://github.com/senx/warp10-platform/pull/478)
* preallocate result size list in LMAP [#481](https://github.com/senx/warp10-platform/pull/481)
* Fixed UNWRAPENCODER to correctly extract empty encoders from a wrapper
* Bumped Sensision dep to 1.0.18
* Merge branch 'master' of github.com:senx/warp10-platform
* Default warpfleet.macros.repos value
* Make Metadata optional in GTSWrapper [#448](https://github.com/senx/warp10-platform/pull/448)
* Resolved conflict
* Removed reference to index keys
* Added support for multiple configuration files [#414](https://github.com/senx/warp10-platform/pull/414)
* QUANTIZE now only accepts sorted and finite bounds [#475](https://github.com/senx/warp10-platform/pull/475)
* OPTIMIZE to accept Numbers and work on lists, minor fix on GTSEncoder.resize [#474](https://github.com/senx/warp10-platform/pull/474)
* Support for Lists and Maps in formatted functions [#470](https://github.com/senx/warp10-platform/pull/470)
* Add a method to fully sort a GTS using tick, value, location, elevation. [#465](https://github.com/senx/warp10-platform/pull/465)
* Fix pack parsing for booleans, factorize parsing, allow U for PACK. [#472](https://github.com/senx/warp10-platform/pull/472)
* Fix BitSet usages. [#473](https://github.com/senx/warp10-platform/pull/473)
* Binary support [#449](https://github.com/senx/warp10-platform/pull/449)
* Factoring, fixing and optimizing BIN-> and BINTOHEX [#460](https://github.com/senx/warp10-platform/pull/460)
* Allow RUN to use registers [#466](https://github.com/senx/warp10-platform/pull/466)
* Fixes to chunks methods and cleaning of WS functions. [#464](https://github.com/senx/warp10-platform/pull/464)
* Remove producer and owner labels when FETCHing with typeattr [#469](https://github.com/senx/warp10-platform/pull/469)
* Merge branch 'master' of github.com:senx/warp10-platform
* Added configuration to convert header names to lower case in the request map
* Fixes #458. Modified lastbucket computation in reduce
* Merge branch 'master' of github.com:senx/warp10-platform
* Bumped gradle wrapper version to 4.10
## 2.1.0-rc1 (2019-06-05)
* Initial commit
* Added configuration to send metadata in the Data messages pushed to Kafka
* Added output of list of plugins which failed to load.
* Wait for stop, allow clean restart with long plugin timeout + JMX [#435](https://github.com/senx/warp10-platform/pull/435)
* added timeouts to REXEC [#446](https://github.com/senx/warp10-platform/pull/446)
## 2.1.0-rc0 (2019-05-27)
* Merge branch 'master' of github.com:senx/warp10-platform
* Added thread name change to reflect the path of the currently executed script
* Fixed indices checks for subserie()
* Initial commit of SHUFFLE
* Fix JSON formatting issue in EgressFetchHandler [#443](https://github.com/senx/warp10-platform/pull/443)
* Merge branch 'master' of github.com:senx/warp10-platform
* Initial commit of SHAPE and RESHAPE
* Fixes #442 - Added missing closing quote
* Added forcing of sync write when flushing metadata or data writes
* Added support for setting hash keys
* Added message attributes
* Changed version of classId/labelsId used
* Added support for gzip output
* Modified bubble sort indices handling in labelsid. Changed quicksort swap cases to exclude i == j
* Added copy of environment variables to the config
* Initial commit of WRAPFAST and CHECKMACRO
* Worf - Use current directory when the file has no parent [#437](https://github.com/senx/warp10-platform/pull/437)
* Minor optimisations following 9240b90fd91dcc8a47727d879863182524924f3e [#439](https://github.com/senx/warp10-platform/pull/439)
* Fixes #438 Added check for pre/post windows extending beyong Integer.MAX_VALUE ticks
* Optimized timeclip for the case when the GTS is sorted
* Added initial capacity
* Improved sorting performance when reversing GTS
* Fixed incorrect retrieval when fetching by count with GTS spanning regions
* Fixed handling of showuuid
* hotfix [#436](https://github.com/senx/warp10-platform/pull/436)
* Fix new SUBLIST signature and align start using step [#434](https://github.com/senx/warp10-platform/pull/434)
* Added datalog.sync [#431](https://github.com/senx/warp10-platform/pull/431)
* Fix MINLONG usage with STRICTMAPPER [#433](https://github.com/senx/warp10-platform/pull/433)
* Fix key check for value check [#432](https://github.com/senx/warp10-platform/pull/432)
* Make STRICTMAPPER work with timespans. [#423](https://github.com/senx/warp10-platform/pull/423)
* Range signature with step for SUBLIST [#430](https://github.com/senx/warp10-platform/pull/430)
* Negative indexing for lists, byte arrays and GTSs [#429](https://github.com/senx/warp10-platform/pull/429)
* Removed unused tick ordering [#426](https://github.com/senx/warp10-platform/pull/426)
* Formatted patch [#428](https://github.com/senx/warp10-platform/pull/428)
* Anomaly patch [#427](https://github.com/senx/warp10-platform/pull/427)
* Add overrideTick option to REDUCE [#424](https://github.com/senx/warp10-platform/pull/424)
* Merge Argmin and Argmax reducers [#425](https://github.com/senx/warp10-platform/pull/425)
* Fixed properties setting
* Formatted [#419](https://github.com/senx/warp10-platform/pull/419)
* Write token attributes [#422](https://github.com/senx/warp10-platform/pull/422)
* Shadow Extension [#413](https://github.com/senx/warp10-platform/pull/413)
* FILLNEXT, FILLPREVIOUS, FILLVALUE can take a single GTS [#420](https://github.com/senx/warp10-platform/pull/420)
* Fixed disabling of UPDATE/META/DELETE
* Initial commit of WFON/WFOFF
* Added check for exact matches when determining prefix
* Fixed issue with '/' prefix
* Added support for gzipped content
* Fixed handling of spaces
* Removed unused constant
* Modified configuration fetch so we get the latest version at the time REPORT is called
* Merge branch 'master' of github.com:senx/warp10-platform
* Fixed use of maxMessages
* Added support for removing configuration by setting a NULL value
* Added support for removing configuration by setting a NULL value
* Added configuration for macroconfig secret
* Initial commit of MACROCONFIGSECRET/SETMACROCONFIG
* Byte array concatenation [#417](https://github.com/senx/warp10-platform/pull/417)
* Fixed imports
* Add PtoImage [#415](https://github.com/senx/warp10-platform/pull/415)
* Added support for byte arrays
* Clarified error messages
* Added support for byte arrays
* Added support for byte arrays
* Added sorting of plugin classes prior to loading
* Added support for STRING parameters
* Initial commit of SENSISION.DUMP[EVENTS]
* Added timeout configuration for WarpFleet™ repositories
* Merge branch 'master' of github.com:senx/warp10-platform
* Replaced hostname by IP
* Initial commit of DEFLATE/INFLATE
* Fixed datalogPSK initialization
* Use WarpConfig.getProperty where relevant [#408](https://github.com/senx/warp10-platform/pull/408)
* Simpler and clearer version of DEFINEDMACRO [#407](https://github.com/senx/warp10-platform/pull/407)
* Add more checks for SUB MUL DIV for error messages [#406](https://github.com/senx/warp10-platform/pull/406)
* Remove useless code [#405](https://github.com/senx/warp10-platform/pull/405)
* Fix Argmin and Argmax aggregators. [#404](https://github.com/senx/warp10-platform/pull/404)
* Add type check to */- operations involving a GTS and a value. [#402](https://github.com/senx/warp10-platform/pull/402)
* Remove unnecessary check. [#403](https://github.com/senx/warp10-platform/pull/403)
* Allow double and long for percentile aggregator. [#401](https://github.com/senx/warp10-platform/pull/401)
* Use the uber jar of leveldb java implementation
* Merge branch 'master' of github.com:senx/warp10-platform
* Added support for finding first/last tick of a list of GTS
* Added remaining cache time in failed macros
* Removed debugging output
## 2.0.3 (2019-02-25)
* Warp DB [#398](https://github.com/senx/warp10-platform/pull/398)
* Warp fleet repository [#397](https://github.com/senx/warp10-platform/pull/397)
* Initial commit of TOKENSECRET. Added support for token.secret
* Added token.secret
* Added WarpManager and UPDATE/META/DELETE{ON,OFF}
* Fixed implementation name. Removed duplicate jar entries
* Merge branch 'master' of github.com:senx/warp10-platform
* Added check for nullity of properties in constructor
* Fixes #394 - Changed synchronization around DDP check
* Fixes #393 - Fixed incorrect null compensation when null at end of value array
* Merge branch 'master' of github.com:senx/warp10-platform
* Added waiting until Warp 10 is initialized before starting scheduling. Fixed issue which could cause scripts to stop being scheduled.
* Cleaned up obsolete code
* Initial commit of GTSOpsHelper
* Changed HashMap into ConcurrentHashMap for tracking the next runs
* Initial commit of TIMEBOX
* Removed file committed by mistake
* Added TTL for script metrics
* Initial commit of REPORT
* Added method to retrieve list of loaded plugins
* Fixed TTL handling
* Added tracking of number of calibrations and wait until at least one calibration occurred
## 2.0.2 (2018-12-17)
* Cleaner test [#388](https://github.com/senx/warp10-platform/pull/388)
* Fixed ts comparison when operating on GTS
* Fix array init [#387](https://github.com/senx/warp10-platform/pull/387)
* Merge branch 'master' of github.com:senx/warp10-platform
* Added support for REXEC endpoint patterns
* URLFETCH as integrated extension (deactivated by default) [#384](https://github.com/senx/warp10-platform/pull/384)
* Fixed time unit for issuance/expiry/ttl
* Merge branch 'master' of github.com:senx/warp10-platform
* Added -1 as an option for the bucketspan parameter of bucketize to determine the longest matching bucketspan instead of the smallest
* Only execute the finally macro if it is not empty
* Fixed casting
* GEO.WKT and GEO.JSON: Make sure the resolution is even and in 2..30 [#380](https://github.com/senx/warp10-platform/pull/380)
* Issue 381 [#383](https://github.com/senx/warp10-platform/pull/383)
* Merge branch 'master' of github.com:senx/warp10-platform
* Removed WarpReport
* Moved HBase prefix in Constants instead of Store and Directory
## 2.0.1 (2018-11-28)
* Fixed quantum loading
* Add integrated plugins, extension and their conf to conf templates [#377](https://github.com/senx/warp10-platform/pull/377)
* Consistency with HTTP plugin [#376](https://github.com/senx/warp10-platform/pull/376)
* Explicit int overflow [#375](https://github.com/senx/warp10-platform/pull/375)
* Removed call to printStackTrace committed by error
* Removed unused repos
* Merge branch 'master' of github.com:senx/warp10-platform
* Modified TOKENINFO so tokens from plugins which are both READ and WRITE are correctly displayed
* Bumped GeoXPLib dep to 1.0.0-rc14
* Merge branch '2.x'
* Fix bug and typos in copy [#366](https://github.com/senx/warp10-platform/pull/366)
* Merge branch '2.x'
## 2.0.0 (2018-11-19)
* Merge branch '2.x'
* Cleaned config
* Merge branch '2.x'
* Merge branch '2.x'
* Merge branch '2.x'
* Merge branch '2.x'
* Merge branch '2.x'
* Resolved merge conflicts 2.x -> master
## 1.2.28 (2018-11-13)
* Added support for NULLs in the symbol list
* Added missing import
* Merge branch 'master' of github.com:senx/warp10-platform
* Added support for storing multiple elements
* Fixed copyright
* Fixed possible NPE
## 1.2.26, 1.2.27 (2018-11-06)
* Fixed repo
* Bumped sensision to 1.0.17
* Bumped quantum version to 3.0.6 and modified repo
* Added userOrg
* Added organization
* Fixed copyright
* Fixed copyright notice
* Reverted incorrect commit
* Modified STORE so it accepts a list of symbols as parameter
* Fixed active loop in TimeSource
## 1.2.25 (2018-10-23)
* Added Py4JEntryPoint
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Initial commit of Py4JEntryPoint
* Fixed Runners
* Modified TimeSource to start a calibration immediately
## 1.2.24 (2018-10-16)
* Fixed incorrect macro size
* Added support for GTSEncoders
* Added conditional around call to Tokens#init
* Fixed problem when encountering an exception in an empty macro
## 1.2.23 (2018-10-10)
* Added missing call to PrintWriter.close in close
* Fixed incorrect imports
* Added forcing of token labels in /meta call
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Added setting of .path in config when input split is from a file, this way we can know from within the script what the current path is
* Added write token attribute to forbid deletions
* Fixed suffix use for input format class and added conf suffix removal
* Added forcing of token labels in delete selector
* Initial commit
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Added fill
* Added labels from token when they exist
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Fixes #350 - Added metric to track waiting time and rejections for parallel scanners. Changed pool size to a fixed one.
* Fixes #345 - Corrected handling of empty lists
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Modified conditions
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Changed the way revision is set
## 1.2.22 (2018-08-19)
* Updated commons-math3 to 3.6. Removed commons-math4
* Modified Macro's toString to use snapshot
* Added parameterized message to FAIL
* Added setSize
* Fixed Revision
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Corrected snapshot of counters
* Added TOKENDUMP/TokenDump
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Added support for FINDSTATS in Standalone
* Added REF and other reservation functions.
* Initial commit of REF
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Added constants SAVE and RESTORE
* Added method getMacro
* Fixed snapshots
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Fixed autoboxing problem in ternary constructs
* Added FILTERBY and GROUPBY
* Initial commit of FILTERBY
* Added support for any list
* Fixed error message
* Added support for STRING or BOOLEAN GTS in lttb, now simply return the original GTS
* Corrected error message
* Added waiting for Warp to be initialized before we use WarpScriptLib
* Allow for empty lists of producers/owners/applications
* Allow blank lines in trl
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Added out
* Added properties to disable checksums and paranoidchecks
* Modified report building
* Added safety check when the jar directory does not exist.
## 1.2.21 (2018-07-23)
* Fixed visibility of methods so they can be overriden
## 1.2.20 (2018-07-23)
* Added detailed reporting of extensions which failed being loaded
* Added support for exposing configuration in the script
* Added support for token specs in token file
* Optimized comparisons for numbers
* Removed unit tests moved to warpdoc
* Initial commit of WarpRun
* Added leveldb.block.size for WarpCompact
* Initial commit of WarpCompact
* Initial commit of WarpReport
* Initial commit of WritableUtils
* Initial commit of TokenGen
* Initial commit of TokenWarpScriptExtension
* Initial commit of WarpScriptInputFormat
* Added possibility to modify suffix via configuration
* Added option to launch only the Warp 10™ Analytics Engine.
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Fixed store client exposition.
## 1.2.19 (2018-07-16)
* Modified ondemand example and comment
* Changed ondemand to true by default.
* Added support for generic keys. Changed visibility of extractKeys
* Added support for generic keys
* Added batching of deletes and parameterization of sync writes rate
* Added sorting of metadata prior to their deletion
* Added WARP_KEY_PREFIX
* Added comments
* Changed visibility and added encryptToken
* Added standalone.max.delete.batchsize, syncrates
* Added standalone.max.delete.batchsize
* Moved deletion of the metadata for a GTS after the deletion of its datapoints
* Removed recursion in quicksortBy{Value,Location,}
* Added support for STRING GTS
* Optimized parsing of values
* Added support for durations in timespan parameter
* Added support for setting the config file in environment variable WARP10_CONFIG
* Added runner.runatstartup config
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Fixes #328 - Added final flush after metadata updates.
* Removed unused field during serialization
* Added support for config file defined in environment or JVM property
* Added WARP10_CONFIG_ENV
* Fixed imports
* Modified getProperty to use a Configuration
* Initial commit of Warp10OutputFormat
* Added runner.runatstartup
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Fixed map() so it correctly handles duplicate ticks
* Switched to TreeMap
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Initial commit of REMOVETICK
* Fixed concurrency support when loading classes
* Added IOException cause to WarpScriptException
* Fixed typo in error message
## 1.2.18 (2018-06-07)
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Added comment with source of the banner
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Added support for byte[]
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Fixes #305. Added a sanity chek to avoid an NPE when the directory does not know any GTS for an owner
* Added comments for compensateResets
* Fixed handling of overflow indices in SUBLIST
* Fixed Psmooth import
* Initial commit of Pshape / PloadShape. Enabled PshapeMode
* Fixed exception message in getn
* Initial commit of NOLOG
* Added support for smoothing
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Forced type of GTS decoding when decoding GTSDecoders 2..
* Added throwing of RuntimeException when attempting to merge GTS with incompatible types
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Added support for LONG GTS
* Corrected handling of null label
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Fixed name of PAPPLY
* Fixed error message
* Removed LORA related imports
* Modified code so loading of failed macros is retried earlier when ondemand is true
* Removed LORA{ENC,MIC} as they were not complete and belong more in a dedicated extension.
* Added methods to retrieve the exposed Store and Directory Clients
## 1.2.17 (2018-04-23)
* Fixed comment
* Fixed parsing of 'start'
* Fixed cast
* Fixes #290 - Added support for namespaces when loading extensions
* Fixed typo
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Corrected level numbering
* Added support for operating on a single GTS not in a list
## 1.2.16 (2018-04-11)
* Added support for base snapshot to limit the time during which compactions are disabled
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Added messages to EmptyStack and IndexOutOfBounds exceptions
* Added clearing of executor
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Added shutdown of executor
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Fixes #275 - Corrected order of parameters
* Added new types for TYPEOF [#271](https://github.com/senx/warp10-platform/pull/271)
* Initial commit of REOPTALT. Removed dead code
* Fixed token extraction
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Fixed shrinkTo so it accepts to shrink a GTS to 0
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Fixed comparator when both GTS have no labels
* Added info output
* Added possibility to set Jetty's attributes
* Changed HashMap to LinkedHashMap so MSORT can be used on a submap
* Added cast to long so RESET behaves correctly
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Fixed incorrect inclusion of the MARK in the resulting WarpScript code when using *TOMARK*
* Added method charAt
* Added support for list,map,set and vector cloning
* Corrected level #
* Fixed comment
* Reversed normalization.
* Bumped GeoXPLib to 1.0.0-rc13
* ISO8601 and HUMANDURATION: Fix for large and negative values for the timestamp or duration. [#265](https://github.com/senx/warp10-platform/pull/265)
* Fixed dequeue size
* Minor comment fix
* Replaced call to contains with a binary search on a sorted GTS list in partitionAndApplyUnflattened
* Exposed META_COMPARATOR
* Modified max value of maxgeocells
* Added option to expose the egress exec handler store/directory clients.
## 1.2.15 (2018-03-14)
* Initial commit of LINEON/LINEOFF
* Fix for sep
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Fixed windows separator handling
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Added attribute lineno
* Fixes #262 - Added replacement of / with platform file separator
* Added support for quaternion values when ingesting data
* Added metric for tracking shutdowns.
## 1.2.14 (2018-02-21)
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Added support for plugin prefix config
* Added plugin prefix
* Modified to support collections instead of only lists
* Added support for joining a list of strings
* Added INFO/INFOMODE
* Removed warp.script.lastexec.timestamp as it does not really provide value and leads to a high cardinality due to the thread id being a label value
* Added support for encoding lat/lon to HHCode in GTS values.
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Resolves #255 - Added limit parameter for /find. Note that order of results is not guaranteed to be deterministic.
* Fixes #225 - Added configuration to disable delete endpoint in standalone
* Replaced call to push/peekn when converting stack to JSON
* Publish artefacts on local repo [#253](https://github.com/senx/warp10-platform/pull/253)
*  bintray fix [#252](https://github.com/senx/warp10-platform/pull/252)
## 1.2.13 (2018-02-02)
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Added info message prior to dumping
* Corrected bigint initialization
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Rebumped GeoXPLib to 1.0.0-rc11
* Added try/catch in the synchronizer to correctly abort the Directory when a synchronizer dies. Added systematic commit of counter offsets.
* Jenkins integration [#245](https://github.com/senx/warp10-platform/pull/245)
* Added reuse of Json serializer
* Initial commit of GEOOPTIMIZE
* Bumped GeoXPLib to 1.0.0-rc12
* Added GEO.OPTIMIZE, GEO.JSON.UNIFORM. Corrected name of GEO.INTERSECTS
* Added support for uniform coverage in GeoJSON. Added support for resolution spec
* Added trimming of string prior to decoding
## 1.2.13-rc1 (2018-01-26)
* Renamed splits config
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Initial commit of splits handler for standalone instances
* Added checks for token nullity
* Fixed the way fallbacksonly is interpreted
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Fixed incorrect bit alignment
* Added support for custom CORS headers.
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Fixed propagation of secure macro flag when creating macros in a secure script
* Corrected the way URL decoding is performed as we only support % encoding and need to deal with plus signs in a specific manner.
* Added support for parsing hhcode
* Modified template
* Changed regexp for group names
* Added quoting
* Added support for multiple elevation units. Fixed ts unit parsing.
* Added different output format
* Added comments
* Removed extraneous space
* Added SMARTPARSE, vector and set short notations
* Initial commit of SMARTPARSE
* Initial commit of EXTLOADED
* ASSERTMSG
* Initial commit of ENDVECTOR/ENDSET/EMPTYVECTOR/EMPTYSET
* Initial commit of SIG/SIGMODE
* Add new metric when an estimator is reset [#237](https://github.com/senx/warp10-platform/pull/237)
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Removed updating of GTS count when using a Directory plugin
* fixed
* Fixed rev
* Modified classloader so it does not filter out io.warp10 anymore. Added comments.
* Added id field to GTS, deprecated uuid
* Clarified comment
* Added missing copyright header
* Added comment
* Added getRawMetadata
* Added missing copyright header
* Fixed ttl test
* Refactored timestamp parsing to support time precision down to ns when using JDK 8+
* Initial commit of SUBTRACTION which fixes DIFFERENCE
* Fixed casts for Vector and Set
* Modified snapshotting of lists and maps to avoir exceeding stack depth limits
* Modified constructor to allow for optional compression
* Added constants for PUT and INPLACEADD
* Initial commit of MACROTTL
* Added ATAN2
* add example for Mobius [#232](https://github.com/senx/warp10-platform/pull/232)
* Change default python string name str to mystr as str is a reserved name [#231](https://github.com/senx/warp10-platform/pull/231)
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Fixes #229 - Added sanity check prior to converting ticks
* Initial commit of KURTOSIS and SKEWNESS
* Fixed dumping
* Fixed comments
* Modified the way value size is checked, we now do it post parsing.
* Added computation of standardized moments
* Fixed edge cases
* Fixed loop scan
* Initial commit of HBaseWarpScriptExtension [#228](https://github.com/senx/warp10-platform/pull/228)
* Initial commit of FFTWINDOW
## 1.2.12-rc2 (2017-11-13)
* Added limit of logged GTS when deleting
* Fixed elapsed nanos
* Added logging events in Directory
* Added failsafe loading of dumped state for ChunkedMemStore
* Fixed incorrect loop bounds when iterating over chunks in dump
## 1.2.12-rc1 (2017-11-03)
* Changed SNAPSHOT constructor
* Initial commit of MAXRECURSION. Added SNAPSHOTN and SNAPSHOTCOPYN
* Added synchronization around the updates of serializedMetsadataCache
* Corrected import
* Removed useless import
## 1.2.11 (2017-10-25)
* warp10 init script: restore the definition of WARP10_HOME [#224](https://github.com/senx/warp10-platform/pull/224)
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Added comments
## 1.2.11-rc6 (2017-10-19)
* fix issue: test of WARP10_HOME failed in warp10 init script [#222](https://github.com/senx/warp10-platform/pull/222)
* Modified the way files currently being processed are checked to avoid errors when large number of files is present
## 1.2.11-rc5 (2017-10-18)
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Bumped GeoXPLib to 1.0.0-rc9
## 1.2.11-rc4 (2017-10-09)
* Fixes #216 - modified to call sendError if we have not yet written any output when an error occurs.
* Added mapper.sqrt
## 1.2.11-rc3 (2017-09-29)
* Quantum 2.6.6 [#214](https://github.com/senx/warp10-platform/pull/214)
* Fix puid option broken [#212](https://github.com/senx/warp10-platform/pull/212)
* Use the pid file to test another Warp 10 instance is running [#211](https://github.com/senx/warp10-platform/pull/211)
## 1.2.11-rc2 (2017-09-27)
* Added functions to generate token identifier from libtoken [#196](https://github.com/senx/warp10-platform/pull/196)
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Added support for storing null values in symbols
## 1.2.11-rc1 (2017-09-25)
* Modified leveldb cache size
* Fixes #206 - Added sortmeta to /find and /fetch [#207](https://github.com/senx/warp10-platform/pull/207)
* Fixed snapshotting of inner macros
## 1.2.10, 1.2.10-rc3 (2017-09-17)
* Exposed SECURE
* Updated to use Macro's snapshot method
* Added support for encoders in CLONEEMPTY and TOSELECTOR
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Updated README
* Added copying of label selectors so we do not expose app/owner/producer
* Made Macro snapshotable thus correcting incorrect macro snapshot so far.
* Add the original parse exception as the cause of the WarpScriptException we throw.
* Initial commit of ISAUTHENTICATED
## 1.2.10-rc2 (2017-09-05)
* Added TRY/ERROR/RETHROW
## 1.2.10-rc1 (2017-08-21)
* Added GEO.WKT.UNIFORM
* Add support for consumerid in Kafka ConsumerConnector [#201](https://github.com/senx/warp10-platform/pull/201)
* Fixes #198 - Corrected bucketsize computation and bucket used for computing avg.
* Added commons-lang3, commons-math4
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Added RAWDTW, ZDTW. Added Z-Normalization to OPTDTW.
* Added support for forcing mu/sigma in standardize
* Added support for MAXCELLS
* Added config parameters for max geocells
* Decode: display Metadata [#193](https://github.com/senx/warp10-platform/pull/193)
## 1.2.9 (2017-07-10)
* Initial commit of Decode
* Added PRNG and SRAND
* Added sorting of extensions prior to loading them.
* Initial commit of PRNG and SRAND
## 1.2.9-rc4 (2017-06-29)
* Added check for unsupported types in validate
## 1.2.9-rc3 (2017-06-26)
* move CapacityExtractorOutputStream to io.warp10 [#192](https://github.com/senx/warp10-platform/pull/192)
* Added check for empty files
## 1.2.9-rc2 (2017-06-21)
* Removed TF extension which is moved to its own repo
## 1.2.9-rc1 (2017-06-21)
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Initial commit of TF extension
* Initial commit
* Fixed comparison so VALUESPLIT works correctly for string values.
* Added constant for MSGFAIL. Modified extension properties.
## 1.2.8-rc3 (2017-06-06)
* Fixed to account for Bessel's correction
* Fixed issue with last value in RANGECOMPACT when it is identical to the previous one
* Corrected handling of NULL name in relabel.
* Fixes #180 - Keep common class name when performing REDUCE.
## 1.2.8-rc2 (2017-05-25)
* standalone: do not use sudo for worfcli [#190](https://github.com/senx/warp10-platform/pull/190)
## 1.2.8-rc1 (2017-05-24)
* Standalone init + snapshot revamped to be run as warp10 user [#189](https://github.com/senx/warp10-platform/pull/189)
* Adds Worf in interactive mode from standanlone.init [#188](https://github.com/senx/warp10-platform/pull/188)
* snapshot: update default leveldb directory [#187](https://github.com/senx/warp10-platform/pull/187)
* Add function to parse GEO JSON strings into WarpScript [#186](https://github.com/senx/warp10-platform/pull/186)
* Added fs implementations
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Added explicit definition of FS handlers.
## 1.2.7 (2017-05-15)
* Renamed to correct typo
* Added missing UUID pushed onto the stack
* Added missing copy of attributes in timeclip
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Forces attribute key/value to be strings.
* Fixed style
* Initial commit of NONNULL
* Fixes #176 - Corrected handling of -1 producer limits
## 1.2.7-rc2 (2017-04-25)
* Added flushing of Directory
* Switched streaming request to POST to support large selectors.
* Fixed SHOWATTR parameter.
* Added support for SHOWATTR parameter.
* Added config options to disable plasma/mobius/streamupdate
* Added section in error messages
## 1.2.7-rc1 (2017-04-03)
* Added cause to the thrown exception.
* Dispatched logging events in different log levels depending if there was an error or not.
* Modified the way stack trace is stored in the logging event. We now store the cause correctly
* Moved exposition of headers after bootstrap context restore so they are available to BOOTSTRAP
* Added support for timestamp in event creation
## 1.2.6, 1.2.6-rc9 (2017-03-22)
* Corrected string repr of JSON CharSequenceValue
## 1.2.6-rc8 (2017-03-22)
* Initial commit of Logging extension
* Initial support of on demand macro loading [#171](https://github.com/senx/warp10-platform/pull/171)
* Initial commit of GETSECTION
* Removed debug output
* Modified so we generate modifiable maps and lists and String when parsing JSON content
* Modified to log http headers and other infos as JSON
## 1.2.6-rc7 (2017-03-20)
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Added tolerance for null messages
* Initial commit of SECTION
* Fixed so queue is >= 0
## 1.2.6-rc6 (2017-03-18)
* Added early return in safeSetProperties(String) so we don't risk a FNFE in FileReader
## 1.2.6-rc5 (2017-03-18)
* Removed debug output
## 1.2.6-rc4 (2017-03-17)
* Added support for iterator/iterable
* Fixed storing of stack trace in logging event
* Fixed incorrect class for synchronized block
* Added inclusion of method POST in GzipHandler instances
## 1.2.6-rc3 (2017-03-13)
* Standalone init: rename attribute and add comments [#168](https://github.com/senx/warp10-platform/pull/168)
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Refactored error handling for Jetty 9.4
* Added runner nonce support
## 1.2.6-rc2 (2017-03-10)
* Fixed error output
## 1.2.6-rc1 (2017-03-10)
* Refactored for Jetty 9.4 [#166](https://github.com/senx/warp10-platform/pull/166)
* Corrected case when the intermediary decoder contains less than the n… [#160](https://github.com/senx/warp10-platform/pull/160)
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Fixed periodic execution by removing current scheduled exec when updating macro
* Added synchronization to avoid not find macros when the reload occurs
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Added synchronization to avoid not find macros when the reload occurs
## 1.2.5 (2017-03-02)
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Added missing update of GTS count when Directory is not backed by levelDB
* Modified the controls done on structure prior to their serialization. We avoid multiple references to a given list/map
## 1.2.5-rc10 (2017-02-24)
* Find handler: add CORS header [#161](https://github.com/senx/warp10-platform/pull/161)
* Added support for reversing strings
* Corrected skipping of values after 'now' when encoder is NOT in chron… [#159](https://github.com/senx/warp10-platform/pull/159)
## 1.2.5-rc9 (2017-02-20)
* Quantum 2.2.4 [#158](https://github.com/senx/warp10-platform/pull/158)
## 1.2.5-rc8 (2017-02-17)
* Added removal of empty chunksets [#156](https://github.com/senx/warp10-platform/pull/156)
* Initial commit of gzip support for REXEC [#153](https://github.com/senx/warp10-platform/pull/153)
* Added deletion of temp files once the splits are extracted
* Added '=' prefix in application selector
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Fixed typo
* Bumped GeoXPLib to 1.0.0-rc8
* Fixed java-merge-sort bug by providing CustomReader [#154](https://github.com/senx/warp10-platform/pull/154)
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Initial commit of UNWRAPSIZE/UNWRAPEMPTY
* Added possibilty to not wrap WarpScript code in a macro construct
* Moved metaset key initialization in 'apply' so FIND can be instantiated in WarpScript lib which does not include WarpDist
* Added configuration parameters for various HBase client parameters. Corrected controller/callback initialization for BulkDeleteEndPoint invocation.
* Added clean closing of shuffler and deletion of cache files.
## 1.2.5-rc7 (2017-01-27)
* Macro map bucketize [#150](https://github.com/senx/warp10-platform/pull/150)
* Modified metrics for chunked memstore [#149](https://github.com/senx/warp10-platform/pull/149)
* Initial commit of MetaSet support [#140](https://github.com/senx/warp10-platform/pull/140)
* Redefined protection [#142](https://github.com/senx/warp10-platform/pull/142)
* Refactored find to use SmartPattern instances [#141](https://github.com/senx/warp10-platform/pull/141)
* Initial commit of sharded in memory datastore. Added synchronization … [#143](https://github.com/senx/warp10-platform/pull/143)
* Optimized buffer allocation [#147](https://github.com/senx/warp10-platform/pull/147)
* Add metrics to monitor time spent by Ingress sending data/metadata to Kafka [#148](https://github.com/senx/warp10-platform/pull/148)
* Warpscript: add trove4j (transitive) dependency [#146](https://github.com/senx/warp10-platform/pull/146)
* Initial commit of EMPTY
* Cleaned imports
* Added check for existence of the selector parameter
* Fixed leaked code from external branch
* Fixes #144 - Added missing continue clause.
* Add parsedouble mapper function [#138](https://github.com/senx/warp10-platform/pull/138)
* Fix in.memory.depth template unit [#139](https://github.com/senx/warp10-platform/pull/139)
* Added possibility for MAP/BUCKETIZE to use macros which handle Geo Ti… [#137](https://github.com/senx/warp10-platform/pull/137)
* Bumped GeoXPLib to 1.0.0-rc7
* Added global count of streamed datapoints
## 1.2.5-rc6 (2016-12-22)
* Added COPY versions of SNAPSHOT* which leave the snapshot on the stack without altering the stack.
* Added error reporting in thrown exception
* Added HTTP error message in thrown exception
* Fixes #135 - renamed LOG into LOGMSG
* Added exception when the object on top of the stack is not a list
## 1.2.5-rc5 (2016-12-20)
* Added throttling for store to be able to limit the number of deletes/puts we push to HBase
* Updated GeoXPLib to 1.0.0-rc6
* Added support for short string HHCodes
* Initial commit of debug WarpScript extension
* Added nullifying of thread after we're done processing a parallel scan. Otherwise the call to close might interrupt a thread from the executor which is currently executing another parallel scan
* This reverts commit 5bf47581a48c82d89951dc3adc1ff766d226557a.
* Modified catch clauses to catch Throwable instead of Exception
* Added ->HHCODELONG to emit a LONG HHCode
* Initial commit of PIGSCHEMA
* Added showErrors parameter for /find and /delete endpoints
* Changed catch clause to Throwable
* Refactored so we don't hold the lock while waiting
* Modified condition tested when commitPeriod is overdue, we want to ge… [#134](https://github.com/senx/warp10-platform/pull/134)
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Swapped List and Vector handling
* Added setting of labels in write tokens
* Bugfix in REPLACE and REPLACEALL [#129](https://github.com/senx/warp10-platform/pull/129)
* Added conversion to long for the tick. Modified parameter passing.
* Modified the way we track the number of classes. The call to ConcurrentSkipListMap.size is too expensive.
* Added check of directory.delete when batching to HBase
* Modified waiting times. Added deletes metrics
* Added metric for Directory deletes
## 1.2.5-rc4 (2016-12-08)
* Corrected bogus cast
## 1.2.5-rc3 (2016-12-08)
* Adds quiet option to Worf [#128](https://github.com/senx/warp10-platform/pull/128)
* Replaced unsafe casts
* Fixed standalone config template [#127](https://github.com/senx/warp10-platform/pull/127)
* Replaced invalid casts by use of Number#{long,double}Value
## 1.2.5-rc2 (2016-12-06)
* Modified growth parameters
* Modified cloneEmpty so it does not reuse the size hint of the cloned GTS. This could lead to serious memory consumption in chunk/map/...
## 1.2.5-rc1 (2016-12-02)
* Optimized chunk so we don't do re-allocation too often
* Added GET
* Added throwing of WarpScriptException when encountering an exception in an underlying scanner
* Added propagation of root cause.
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Added exception throwing when an underlying scanner encounters an error.
## 1.2.4 (2016-11-29)
* Added safety net around system properties URL decoding
* Added suffix for properties
* Corrected registration of op.add.ignore-nulls
* Initial commit of macro-template.mc2
* Corrected registration of op.mul.ignore-nulls
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Added support for converting GTS values using ->{FLOAT,DOUBLE}BITS->
## 1.2.3 (2016-11-25)
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Added setting of symbols runner.{path,periodicity,scheduledat} for scripts launched by 'runner'
* Added WRAPOPT/WRAPRAWOPT
* Added option to use encodeOptimized
* Removed try/catch from lttb
* Modified encodeOptimized so it uses a stable char array
* Fixes #121 - Copy attributes in various GTS ops.
* Initial commit of mapper.mod
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Added method encodeOptimized which converts Double to BigDecimal for more efficient encoding
* Added dynamic URL constructor
* Added constructor which allows the setting of URL
* Added limiting of plasma subscriptions.
* Added missing increment of idx
* Corrected encoder pushed on the stack.
* Removed AFETCH
* Added support for converting a double to/from float bits. Added ->FLOATBITS,->DOUBLEBITS,DOUBLEBITS->,FLOATBITS->
* Initial commit of Warp 10 plugin support and InfluxDB example plugin
* Added trimming of extension names
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Refactored additional language support via extensions
* Corrected imports
## 1.2.2 (2016-11-18)
* add README to explain how to configure macros [#117](https://github.com/senx/warp10-platform/pull/117)
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Corrected parameter conversions
* Corrected exit condition in timeclip when GTS is sorted in reverse chronological order
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Removed dead code
* Fixes #114 - Changed MARK pushed on the stack.
## 1.2.1 (2016-11-16)
* Refactored
* Corrected padding
* Added setting of warp.revision Sensision metric
* Corrected exception message
* Changed Einstein into WarpScript
* Corrected incorrect labels decoding
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Moved CEVAL and SYNC to the extension package
* Removed obsolete functions
* Refactored so function map is static
* Modified clearing of redefined functions so we respect the unshadow parameter
## 1.2.0 (2016-11-15)
* Initial commit of callable.sh
* WarpConfig: lazy loading when we use only the property value extraction [#112](https://github.com/senx/warp10-platform/pull/112)
* Cleaning
* Reverted Sensision init
* Added display of Sensision.getStartTime so Sensision gets initialized
* Added call to Sensision.getStartTime so Sensision gets initialized
* Initial commit of MAD, Median Absolute Deviation
* Modified where SensisionConstants is initialized. Added init of ShutdownHookManager
* Modified where SensisionConstants is initialized
* Standalone: add worf command - add LOG and *.log files in leveldb snapshots [#111](https://github.com/senx/warp10-platform/pull/111)
* Add functions MD5 SHA1 SHA1HMAC SHA256 SHA256HMAC [#109](https://github.com/senx/warp10-platform/pull/109)
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Removed 'einstein' references
* Removed TZ param when working on a ts elements list
* Added copying of the tselements list prior to its modification
* Updates token encoders [#107](https://github.com/senx/warp10-platform/pull/107)
* Exposed CLIP, ADDDAYS, TSELEMENTS->, ->TSELEMENTS
* Initial commit of FROMTSELEMENTS
* Initial commit of CLIP
* Initial commit of ADDDAYS
* Added support for tselements.
* Added fast exit in timeclip when GTS is sorted.
* Added missing carrying on of chunk
* Removed ADDDAYS/ADDWEEKS
* Corrected chunk computation for negative timestamps
* Added ADDDAYS/ADDWEEKS
* Initial commit of ADDDAYS/ADDWEEKS
* Added timezone support
* Initial commit of ADDMONTHS and ADDYEARS
* Modified to use DEFAULT_PACKED_MAXSIZE
* Added chunksize parameter to unpack
* Added commons-cli for Pack
* Changed default suffix
* Initial commit of Pack
* Added value max size config
* Added WARP10_QUIET
* Changed split threshold
* Added warpscript.def.unshadow
* Added stream test
* Modified the way functions are 'undef'ed, so you can't expose the original function after it has been redefined.
* Limit parallelism to number of macros to eval
* Checked for nullity of lock prior to using it
* Added revision
* Added Warp 10 banner
* Refactored so condition can be a boolean instead of a macro
* Initial commit of ConcurrentWarpScriptExtension
* Added '+\!'
* Refactored so we can create sub tasks.
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Added LF
* Added SIGMODE
* Modified format of toString when a macro is secure
* Removed empty properties from stack init
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Initial commit of MacroHelper
* Added setting of limits
* Added setting of limits and secure flag for macro
* Added support for extensions included in the Warp 10 jar
* Added output on stdin of endpoint we listen on
* Initial commit of AGO
* Do not broacast the estimators if they have expired
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Added caching of classes
* Added check for useradd/adduser
* Added initial check for OSX when creating the warp10 user
* Added check that the caller is root
## 1.1.0 (2016-11-02)
* Corrected splitting algorithm so we tolerate encountering a single value above threshold
* Removed useless code
* Added handling of expiring estimators
* Added handling of expiring estimators
* Added debug messages for extension loading
* Fixed key use
* Corrected wrong key
* Minor fix
* Added support for unencrypted metadata
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Modified the way timespan is handled for packed GTS
* Refactored packing so we use the size of the generated Wrapper as a threshold instead of the size of the underlying encoder
* Initial commit
* Added pack/unpack in /fetch endpoint
* Adjusted the way count is computed for generated GTSEncoder instances
* Added configuration parameter max.encoder.size
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Fixed incorrect output when input is a byte array.
* Corrected output handling
* Added safety check before outputing serialized GTS name in JSON output
* Added try/catch around parsing
* Initial commit of REPLACE. Exposed REPLACE and REPLACEALL
* Changed headers so they are modifiable
* Added WarpClassLoader
* Initial commit of Sensision extension
* Bumped Sensision to 1.0.11. Added missing TimeSource inner classes in warpscript jar
* Added methods set{BucketCount,LastBucket,BucketSpan}
* Added ingress.delete.reject
* Removed dead code
* Removed archive mode
* Removed kafka.archive configs
* Removed store.zk.quorum
* Refactored so the metadata consuming pool is optional
* Bumped GeoXPLib to 1.0.0-rc5
* Changed Exception to Throwable
* Added catch of exception in defineClass call
* Cleaned imports
* Refactored class loading for both JarRepository and Extensions. We now use a WarpClassLoader which gives priority to the classes in the jar.
* Added informational message on init
* Changed the initial value of mustRecalibrate to 'true' so we trigger an initial recalibration as soon as the calibration thread is started.
## 1.0.18 (2016-10-23)
* Changed datalog.dir
* Corrected incorrect handling of forwarded DatalogRequests which prevented DatalogRequest from being initially stored
* Added mergeViaEncoders, changed MERGE to use this method
* Added method wrapMacro
* Added ignoring expired estimators in fuse()
* Corrected incorrect snapshot of 'false'
* Removed PLASMA_BACKEND_KAFKA_OUT_TOPIC as the out topic used by plasmabe is dynamic
## 1.0.17 (2016-10-20)
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Added TODO comments
## 1.0.16 (2016-10-19)
* Initial commit of DEFINEDMACRO.
* Corrected handling of parameter 'now' in method parse. Added forcing of 'now' in DatalogRequest
* Added try/catch for WarpScriptStopException to tolerate early script terminations.
* Added missing configs
## 1.0.15 (2016-10-17)
* Modified Store to handle deletes in a pool [#92](https://github.com/senx/warp10-platform/pull/92)
* Standalone datalog forwarder [#98](https://github.com/senx/warp10-platform/pull/98)
* Added missing datalog config params
* Standalone datalog forwarder [#97](https://github.com/senx/warp10-platform/pull/97)
* Bumped geoxplib to 1.0.0-rc4 and java-merge-sort to 1.0.0 to avoid conflicts.
* Added forcing of secure macro mode when in EVALSECURE. Corrected macro exec so an inner macro cannot lower the security level.
* Changed catch clause around retrieval of HBase connection
* Corrected METADATA_PATTERN
* Added support for blank lines in /update and /meta. Added support for comments in /update
* Added support for blank lines in /update and /meta. Added support for comments in /update
* Refactored WarpScriptExecutor to make it serializable [#96](https://github.com/senx/warp10-platform/pull/96)
* Added forced disconnect
* Datalogging for the standalone Warp 10 [#94](https://github.com/senx/warp10-platform/pull/94)
* warp10 init: rename heap dump file if it exist [#95](https://github.com/senx/warp10-platform/pull/95)
* Corrected possible NPE
* Fixed against possible NPE when accessing Metadatas for a class.
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Added support for vectors and sets.
* Fixed typo
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Fixed conflict
* Modified config loading
* Added WARP10_CONFIG
* Added method isPropertiesSet
* Added methods safeSetProperties which do nothing if properties were already set.
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Added auto.offset.reset config for ingress
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Corrected type of return value pushed onto the stack
* Corrected setting of first
* Added possibility to set auto.offset.reset
* Modified check for backward leaps
* Changed leap check relative to previously commited offset.
* Added nullity check
* Added ratchet mechanism to Kafka consumption in Directory
* Clarified the error messages when within a macro. Added WarpScriptATCException
* Added safety net when warp config is not available
* Added leading '0' when size is odd
* Added ingress.delete.shuffle
* Added shuffling of GTS prior to deleting.
* Corrected RpcController use
* Added call to failed()
* Ooops...
* Moved RPCController init
* Added check for controller encountered exception
* Removed calls to addAll, used concurrent collection iterators.
* Fixes #86 - Added safety net around calls to commitOffsets
* Added try/catch around Kafka commitOffset to recover properly when commitOffset encounters an error (such as an NPE in zkClient
* Added store.nthreads.kafka
* Added use of config param 'store.nthreads.kafka' to choose number of Kafka consuming threads
* Added STORE_NTHREADS_KAFKA
* Added handling of fetch errors for Warp10InputFormat
## 1.0.14 (2016-09-24)
* Fixed handling of store.skip.write
* Added custom hashCode method
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Fixed metadat ID
* Exposer WARP10_CONFIG
* Removed URLFETCH
* Changed serialized metadata cache keys.
* Removed Einstein reference
* Documented some config params
* Remove zookeeper.connect propertie for producerconfig [#82](https://github.com/senx/warp10-platform/pull/82)
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Removed zookeeper.connect from Kafka producer configs. Thanks to Alexis Sellier from BlaBlaCar.
* Exposed STACKTOLIST
* Initial commit of STACKTOLIST
* Corrected unsafe cache key.
* Added a ratchet mechanism to ignore rows which are not in the expected range. This is to mitigate possible problems in RS where getNextKeyHint is suspected of not being called.
* Added LOG output.
* Added delay loop to wait for the HBase connection to be closed once close() was called.
* Fixes #81 - Enforce result count so we do not emit too many datapoints for GTS spanning regions.
* Corrected level checking for bSAX
* Removed setting of content type so GzipHandler can do its job
* Removed setting of Content-Type so GzipHandler can compress
* Corrected encode to stream and writer so they do not use an intermediary buffer
* Changed the way OPB64 is performed on result Metadata.
* Added metrics for the serialized metadata cache.
* Modified METADATA_CACHE_SIZE to be an instance field.
* Added serialized metadata cache to reduce the number of allocated byte arrays
* Synchronized updates of metadatas on a ReentrantLock.
* Added missing setting of bucketization parameters when unwrapping.
* Initial commit of HEADER
* Added tracking of number of deleted GTS
* Added config param to set offset reset strategy. Changed call to commitOffsets to commitOffsets(true)
## 1.0.13 (2016-09-13)
* Added safety net for /meta handling when a DirectoryPlugin exists.
* Ignore metadata updates for unknown GTS, otherwise a single user could create millions of GTS
* Ignore metadata updates for unknown GTS, otherwise a single user could create millions of GTS
* Added missing scale
* Added nullity checks prior to adding owner classes
* Added Z{PATTERNS,PATTERNDETECTION,DISCORDS} which does not standardize the PAA step and assumes the GTS is already standardized
* Bumped GeoXP to 1.0.0-rc3
* Added LR
* Initial commit of LR
* Modified the splitting regexp
* Added method getCount
* Added method encodeToWriter
* Fixed incorrect PAA
* Corrected incorrect BigDecimal used
* Refactored the way deletes are sent to HBase, they are now in the same flow as Puts
* Changed to streaming OPB64 encoding.
* Added missing OPB64 encoding.
* Corrected URLConnection use.
* Added missing close
* Switched to using the stats http endpoint
* Added http endpoint for stats requests.
* Added parameter showerrors for /fetch so we can notify the caller an HBase error was encountered. Added exclusion of '#' lines in ingress.
* Added support for setting scanner lease time and RPC timeout. Added use of HConstants constants instead of explicit strings.
* Added attributes field in tokens
* Corrected incorrect parameters for DELETE
## 1.0.12 (2016-09-01)
* Corrected sanitization of strings so we support correctly simple and double quotes
* Corrected parsing of binary and hexadecimal numbers so we support negative numbers correctly
## 1.0.11 (2016-08-31)
* Added resetting of HBase connection if an error occurs while getting an HTable instance
* Modified Sensision metric update so we don't count GTS multiple times when adding or deleting them
* Modified Sensision metric update so we don't count GTS multiple times when adding or deleting them
* Modified initialization sequence, we now wait for the full initialization
* Added waiting loop until directory is initialized as the URL might still be known by callers for a duration equal to ZK session timeout
* Broadened the catch clause while reading from HBase as ZK session timing out do not produce an IOE
* Corrected nonce copying.
* Added support for RSA public/private keys.
* Added support for negated mask. Exposed RSA functions and PARSE.
* Initial commit of DUMP/PARSE
* Modified parse to skip over or parse the attributes
* Added explicit setting of parseAttribute parameter
* Modified parse to skip over or parse the attributes
* Modified dump to output attributes
* Added ops/fetched/elapsed metrics
* Initial commit of geo related functions
* Initial commit of RSA.... functions
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Added metrics for cell/result/iterator count.
* Made the filter threshold configurable
* Added metrics
* Switched to using OptimizedSlicedRowFilterGTSDecoderIterator to avoir opening useless regions.
* Initial commit of UNLIST/UNMAP
* Added response headers with number of operations and datapoints fetched during execution.
* Added option 'typeattr' to ventilate fetch results by type in up to 4 GTS per fetched GTS.
* Added header to instruct to expose the request headers in WarpScript
* Added configuration parameter for the update period
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Added LTTB/TLTTB
* Added method lttb
* Initial commit of LTTB
* Initial commit of optimized HBase scanning, by splitting the GTS in groups which do not contain regions with no relevant data.
* Added CORS handler
* Added clas+label
* Exposed the generation of start/end keys for a GTS in a separate method.
* Exposed SORTBY,GZIP,UNGZIP
* Initial commit of GZIP/UNGZIP
* Initial commit of SORTBY
* Added support for byte[]
* Adds bintray configuration for crypto & token's artefacts upload [#78](https://github.com/senx/warp10-platform/pull/78)
* Updated sensision. Corrected env variable
* Added support for filtering on attributes. Exposed MODE
* Initial commit of MODE
* Initial commit of AESWRAP/AESUNWRAP
* Added support for byte[]
* Added possibility to specify the write token in the URI path.
* Added possibility to use 'now' as the value of the now parameter.
* Initial commit of WarpScript Extensions
* Removed import of JavaLibrary
* Refactored WarpScriptLib by merging JavaLibrary
* Initial commit of GeoHash conversion functions
* Added support for JSON output
* Added support for converting Metadata to JSON
* Initial commit of TOVECTOR/VECTORTO, needed for warp10-pig
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Removed unused configuration parameters. Cleaned GeoDirectory initialization.
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Modified the way ATTRIBUTE_IN_SECURE_MACRO is tracked, this speeds up macro execution in loops.
* Added a check prior to setting OSS ACLs
* Modified exception messages
## 1.0.10 (2016-08-03)
* snapshot leveldb: fix error with 'find' command [#75](https://github.com/senx/warp10-platform/pull/75)
* standalone: disable default runner - update log4j default filepath during bootstrap [#74](https://github.com/senx/warp10-platform/pull/74)
* standalone bootstrap: fix errors when we don't use docker [#73](https://github.com/senx/warp10-platform/pull/73)
* Correcred typo
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Modified magic line
* Initial commit
* warp10 targz packaging: include call and runner [#71](https://github.com/senx/warp10-platform/pull/71)
* Added support for java.util.Date in TOTIMESTAMP
* Moved the test for the presence of '|' in the regexp. The previous setup would fail on regexps such as A\.1|A\.2
* Added missing classes.
## 1.0.9 (2016-07-26)
* Fix for logfile created as root instead of warp10 [#69](https://github.com/senx/warp10-platform/pull/69)
* call WarpInit to init leveldb directory [#68](https://github.com/senx/warp10-platform/pull/68)
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Added constant SNAPSHOTALL
## 1.0.8 (2016-07-21)
* update distributed config [#66](https://github.com/senx/warp10-platform/pull/66)
* Add Changelog [#65](https://github.com/senx/warp10-platform/pull/65)
* Initial commit of GETHOOK
* Modified stringification of macros with a call to Macro#toString
* Moved the creation of a secure script in a method of its own.
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Removed unused ConnectionHelper.
* Changelist to make Warp10 compatible with JDK7 again...
* Refactored to index classes per owner instead of per producer as producer is only rarely specified in ReadTokens.
* Added forcing of GC right after loading the initial GTS. Changed type of labelValues to use an array instead of a List
* Addec class statistics in LOG message
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Added INFO log message with detailed stats on directory search.
* Added support for specifying partition.assignment.strategy. Corrected minor tweaks for client.id configuration
* Added calls to maxLimits
* Modified a catch clause so we trap IllegalArgumentException which is thrown instead of IOException when closing a table.
* Added publishing or per server metrics for HBase client
* Changed the way we handle '|'
* Corrected escaping sequence
* Fixed incorrect index.
* Fixed incorrect labelValues size
* Optimized streaming requests Metadata selection. Refactored Metadata selection similarly for find and stats
* Sped up Metadata selection.
* Modified the way depth control is performed. Added interface Snapshotable
* Added missing reset of StringBuilder
* Added check of requested number of levels in dump
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Modified the way HBase connection reset are performed. This should solve a case when the pool is exhausted.
* Removed printStackTrace call
* Added WRAPPER output format for feeding into storm topologies.
* Added signature to limit number of compression passes.
* Initial commit of REXEC
* Added method maxLimits
* Initial commit
* Minor fixes
* Changed createIfMissing from true to false. Added WarpInit and WarpRepair.
* Replaced quote_plus by quote
* Added support for NamedWarpScriptFunction when representing a macro
* Replaced uses of URLEncoded with WarpURLEncoder
* Initial commit of Python skeleton callable.
* Added comment
* Addec nullity check for properties
* Modified input/output order
* Added support for NULLs
* Added NULL
* Corrected incorrect handling of byte[].
* warpscript: add Configuration.class [#60](https://github.com/senx/warp10-platform/pull/60)
## 1.0.7 (2016-06-09)
* Fix error in type of the config parameter + make WarpscriptExecutor Progressable [#59](https://github.com/senx/warp10-platform/pull/59)
* Added 'check' URI which always return 200 so services can be put behind a load balancer which only know how to do HTTP checks.
* Added overlapping parameter. This is a breaking change, but CHUNK is not yet used.
* Added setProperties which takes a Reader as parameter
* Changed buildSelector to use a TreeMap
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Added setting of client.id if configured.
* Added pyrolite. Bumped Kafka to 2.11/0.8.2.2
* Initial commit of CALL/PICKLETO/TOPICKLE/WRAPRAW/RTFM
* Added support for byte array
* Added try/catch Throwable around ref to WarpDist so we can work in lib mode
* Added reading of MAXWAIT config. Prepared for per producer/app maxwait values.
* Added doc URL
* Added CALL and THROTTLING related config keys.
* Wrapped call to WarpDist.getKeyStore into a try/catch so it does not fail in warpscript lib
* Refactored toString of many functions. Refactored SNAPSHOT.
* Cleaned imports
* Refactored to use StackUtils.toString
* Added method toString(Object)
* Initial commit of RANDPDF
* Initial commit of PACK/UNPACK/GEOPACK/GEOUNPACK
## 1.0.6 (2016-05-09)
* Added support for disabling proxy for Directory Streaming Requests.
* Initial commit of CPROB
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Intial commit of Morton code functions ->Z and Z->
* Intial commit of Morton code functions ->Z and Z->
* Moved configuration parameters into Configuration
* Added webcall configuration parameters. Added clientid params.
* Added client.id for Kafka producer/consumer
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Intial commit of function PROB
* Corrected bug for 'compact' when GTS is empty. Added methods 'prob' and 'cprob'
* Fixes #28 - Added dump of LKP index upon shutdown and load upon startup
* Fixes #53 - Added support for client.id Kafka property
* Added specific handling of exact class matches
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Corrected toString of STRICTMAPPER
* Added support for vectors and matrices in ADD/SUB/DIV/MUL
* Added linear algebra functions. Added STRICTREDUCER
* Added urlencoding and null string parameters to Join
* Initial commit of SNAPSHOT
* Added metrics for snapshot counting. Reduced waiting time.
* Added premature return when removing a stack attribute
* Corrected warp.timeunits value
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Removed ref to component 'delete' which no longer exists
* Added support for '> alone on a line instead of simply at the beginning of the line
* Added FIXME comment.
* Corrected Sensision labels for owner/app
* Added paramter 'showattr' for /fetch endpoint to output the attributes.
* Added method rewrap
* Corrected comment. Changed while check against compratio to a strict comparison
* Modified behaviour when compratio is < 1.0D
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Initial commit of BITCOUNT
* Removed function DEVICES. Added BYTESTOBITS and BITSTOBYTES
* Added methods which can set the compression ratio threshold
* Corrected check
* Modified B64-> B64URL-> HEX-> to output a byte array. Added BIN-> OPB64->. Modified the reverse functions to support byte arrays.
## 1.0.5 (2016-04-25)
* Initial commit of TOBOLOEAN. Refactored MAP/REDUCE so they can produce multiple GTS as output.
* Changed the way the property is retrieved for ipc pool size
* Corrected parsing of hexadecimal and binary numbers so it supports single digit representations.
* Added config parameter egress.hbase.client.ipc.pool.size
* Added config parameter store.hbase.client.ipc.pool.size
* Added detailed IOException message in WarpScript exception thrown
* Added nullification of conn.
* Added nullification of conn.
* Corrected output.
* Added support for token in header
* Added support for dryrun
* Added parameters for DELETE
* Initial commit of DELETE
* Initial commit of BITGET
* Changed logging level from error to debug. Changed catch clause to a more general Throwable instead of IOException.
* Refactored the HBase connection management and retrial on error.
* Added removal of GTS_DISTINCT metric when clearing the estimator.
* Added metric for number of committed puts in HBase.
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Replaced Thread.sleep by calls to LockSupport.parkNanos
* Modified thread name. Changed while condition.
## 1.0.4 (2016-04-13)
* Warp10InputFormat: add read timeout parameter - fix error when BufferReader is null [#45](https://github.com/senx/warp10-platform/pull/45)
* Optimized compression.
* Added support for using only the fallback fetchers
* Corrected the multi-pass compression so we do not use compression when it is not needed
* Corrected count.
* Added missing 'break'
* Added support for controlling number of splits
## 1.0.3 (2016-04-11)
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Added support for TSV format.
## 1.0.2 (2016-04-08)
* Added default constructor
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Added geodir.dump.prefix
* Added constructors
* Initial commit of gts2csv.py
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Added computation of mean of location and elevation
* Initial commit of CircularMean
* Initial commit of region cache clearing upon HBase IO Exception in Store
* Corrected depth increment to avoid overflow.
* Added support for validator in APPLY
* Changed the way extra languages are triggered. We now use WarpConfig.
* Added TODO
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Replaced uses of synchronized by ReentrantLock. Added setting of maximum URI size for streaming requests.
* Added support for converting GTS to string.
* Fixes #30 - Added support for multiple selectors.
* Initial commit of EXPORT
* Added setRaw(true) for the scanner used for the BulkDeleteEndpoint so we correctly delete versions for data still in Memstore
* Corrected DeleteType for the case when minage is set.
* Modified DeleteType to ROW instead of VERSION as the latter does not work as expected, see HBASE-15487
* Added synchronization
* Refactored sync again around metadataCache
* Corrected import for Arrays
* Modified the synchronization of metadataCache so we don't alter the ingestion performances too much
* Added synchronization around access to metadataCache so the dump works correctly.
* Replaced Thread.sleep by parkNanos
* Added comments
* Added regeneration of HBase connection.
* Added check for barrier nullity prior to resetting it.
* Removed twitter4j
* Removed TWITTERDM, this should be a UDF, not in WarpScript.
* Added egress.hbase.data.blockcache.gts.threshold
* Modified symbol table handling
* Added method fromGTSWrappertoGTSDecoder
* Replaced synchronized blocks with ReentrantLock
* Added getSynchronizer and explicit interrupt of synchronizer thread on shutdown.
* Fixes #27 - Added premature return when one of the GTS is empty
* Added generation number in thread name. Changed barrier synchronization to a timed one.
* Added barrier reset
* Added forcing of localabort when shutting down the executor
* Added logging
* Removed barrier reset
* Added barrier reset. Corrected reference to barrier so we do not await on the newly allocated one. Added error logging
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Corrected typo.
* Fixes #8 - Added configuration parameter to enable the block cache for scanners [#25](https://github.com/senx/warp10-platform/pull/25)
* Change on building.md to build Warp10 on Mac OS [#24](https://github.com/senx/warp10-platform/pull/24)
* Fixes #21 - Added cast to int for MAXDEPTH/MAXSYMBOLS limits
* Initial commit of Hadoop InputFormat
* Added method getId
* Added check for token nullity prior to updating Sensision metrics
* Added output of GTSWrapper ID
* Added support for split generation and retrieval [#20](https://github.com/senx/warp10-platform/pull/20)
* Corrected computation so result is in meters. Modified Earth radius with the WGS84 ellipsoid radius in meters
* Added key AES_FETCHER
* fix bug on ZIP function when handling a list with only singletons [#18](https://github.com/senx/warp10-platform/pull/18)
* Removed class loading restrictions, they were a residue of the time when Warp was distributed as a protected jar
* Added check for interrupted status
* Fixes #14 - Replaced joda-time with JSR-310. Dropped support for non zoned timestamps which should not have been supported anyway.
* Cleaned imports
* Added logging. Replaced calls to Thread.sleep with calls to LockSupport.park. Switched shutdown of Kafka connector and executor
* Added interruption of the synchronizer thread when the consumer is aborting.
* Added method fromGTSEncoderToGTSWrapper
* Added check if session is open before dispatching data to it. We get a chance to close a session for which we have missed the closing event
* Modified output format of URLFETCH so it is valid JSON (status msg was in the headers' map with a null key)
* Fix GTSHelper.quicksortByLocation [#12](https://github.com/senx/warp10-platform/pull/12)
* Added flag to disable StandalonePlasmaHandler thread start
* Added copy of raw array retrieved from NodeCache
* Corrected the clearing of subscriptions.
* Made UUID unique for a subscription, this will simplify identification of znodes
* Made sendDataMessage synchronized
* Added Sensision metrics for data consumption
* Added missing call to onChange on the subscriptionListener when clearing subscriptions
* Added support for 'raw' UDFs which will be called with the stack as parameter
* Refactored the way the Warp10 configuration is loaded. Initial commit of WarpConfig.
* Added support for 'null' File in readConfig so we can simply consider system properties
* Added support for loading macros from directories in the classpath.
* Added support for String in SIZE
* Merge branch 'master' of github.com:cityzendata/warp10-platform
* Added intermediary copy of metadataCache so we can iterate without risking CMEs
* Fixes #10 - Added tracking of expired estimators
* Added required authentication for URLFETCH
* Initial commit of OPB64TOHEX and URLFETCH
* Bumped Sensision rev to 1.0.2
* Corrected thread name. Corrected size of cyclic barrier
* Modified thread name for Synchronizer and Spawner
* Added flag to check for (re)init of the pool. Without this the Synchronizer could die. Also removed the 'return' from the Synchronizer loop
* Fixes #9 - Added configuration for setting Kafka request timeout for topic data
* Added closing of Table instance upon exit.
* Added bucketizers/mappers dealing with nulls in a specific way. Those were removed but they are needed since applying MAP/BUCKETIZE on a bucketized GTS will materialize the nulls.
* Fixes #6 - Changed default BootstrapManager period to 0L.
* Fixes #5 - Added missing close of BufferedReader
* Added forcing of charset when encoding bSAX
* Added comments
* Fixes #4 - Corrected maxtime used in loop
* Fixes #3 - Added output of attributes for /delete and /find in both standalone and distributed versions.
* Fixes #2 - Registered handler for /find
## 1.0.1 (2016-01-28)
* Fixes #1 - Added setting of 'previousLastXXXValue' when encountering identical values. Initial commit of migrated GTSEncoder/GTSDecoder tests.
## 1.0.0 (2016-01-28)
* Added missing Revision file
* Initial GitHub commit.
