### PR TITLE
force a flush of underlying PrintStream object in LOGMSG, STDOUT and STDERR

### DIFF
--- a/warp10/src/main/java/io/warp10/script/ext/debug/LOGMSG.java
+++ b/warp10/src/main/java/io/warp10/script/ext/debug/LOGMSG.java
@@ -31,18 +31,9 @@ public class LOGMSG extends NamedWarpScriptFunction implements WarpScriptStackFu
   public Object apply(WarpScriptStack stack) throws WarpScriptException {
     Object top = stack.pop();
 
-    boolean forceFlush = false;
-    if (top instanceof Boolean) {
-      forceFlush = Boolean.TRUE.equals(top);
-      top = stack.pop();
-    }
-    
     System.out.println("[" + System.currentTimeMillis() + "] " + ((null == top) ? "null" : top.toString()));
+    System.out.flush();
 
-    if (forceFlush) {
-      System.out.flush();
-    }
-    
     return stack;
   }
 }

--- a/warp10/src/main/java/io/warp10/script/ext/debug/LOGMSG.java
+++ b/warp10/src/main/java/io/warp10/script/ext/debug/LOGMSG.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 //
+
 package io.warp10.script.ext.debug;
 
 import io.warp10.script.NamedWarpScriptFunction;
@@ -29,8 +30,18 @@ public class LOGMSG extends NamedWarpScriptFunction implements WarpScriptStackFu
   @Override
   public Object apply(WarpScriptStack stack) throws WarpScriptException {
     Object top = stack.pop();
+
+    boolean forceFlush = false;
+    if (top instanceof Boolean) {
+      forceFlush = Boolean.TRUE.equals(top);
+      top = stack.pop();
+    }
     
     System.out.println("[" + System.currentTimeMillis() + "] " + ((null == top) ? "null" : top.toString()));
+
+    if (forceFlush) {
+      System.out.flush();
+    }
     
     return stack;
   }

--- a/warp10/src/main/java/io/warp10/script/ext/debug/STDERR.java
+++ b/warp10/src/main/java/io/warp10/script/ext/debug/STDERR.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 //
+
 package io.warp10.script.ext.debug;
 
 import io.warp10.script.NamedWarpScriptFunction;
@@ -31,6 +32,7 @@ public class STDERR extends NamedWarpScriptFunction implements WarpScriptStackFu
     Object top = stack.pop();
     
     System.err.println(top.toString());
+    System.err.flush();
     
     return stack;
   }

--- a/warp10/src/main/java/io/warp10/script/ext/debug/STDOUT.java
+++ b/warp10/src/main/java/io/warp10/script/ext/debug/STDOUT.java
@@ -29,8 +29,18 @@ public class STDOUT extends NamedWarpScriptFunction implements WarpScriptStackFu
   @Override
   public Object apply(WarpScriptStack stack) throws WarpScriptException {
     Object top = stack.pop();
+
+    boolean forceFlush = false;
+    if (top instanceof Boolean) {
+      forceFlush = Boolean.TRUE.equals(top);
+      top = stack.pop();
+    }
     
     System.out.println(top.toString());
+
+    if (forceFlush) {
+      System.out.flush();
+    }
     
     return stack;
   }

--- a/warp10/src/main/java/io/warp10/script/ext/debug/STDOUT.java
+++ b/warp10/src/main/java/io/warp10/script/ext/debug/STDOUT.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 //
+
 package io.warp10.script.ext.debug;
 
 import io.warp10.script.NamedWarpScriptFunction;
@@ -29,18 +30,9 @@ public class STDOUT extends NamedWarpScriptFunction implements WarpScriptStackFu
   @Override
   public Object apply(WarpScriptStack stack) throws WarpScriptException {
     Object top = stack.pop();
-
-    boolean forceFlush = false;
-    if (top instanceof Boolean) {
-      forceFlush = Boolean.TRUE.equals(top);
-      top = stack.pop();
-    }
     
     System.out.println(top.toString());
-
-    if (forceFlush) {
-      System.out.flush();
-    }
+    System.out.flush();
     
     return stack;
   }


### PR DESCRIPTION
To flush stdout when using LOGMSG or STDOUT.

It might be better to add a function STDOUT.FLUSH, or to flush per default.