### PR TITLE
Fix CHANGELOG.md output directory

### DIFF
--- a/warp10/build.gradle
+++ b/warp10/build.gradle
@@ -227,7 +227,7 @@ task generateChangelog(type: Exec) {
 
     standardOutput = new ByteArrayOutputStream()
 
-    File changelogFile = new File('.', "CHANGELOG.md")
+    File changelogFile = new File(project.parent.projectDir, "CHANGELOG.md")
     outputs.file changelogFile
 
     doLast {


### PR DESCRIPTION
Sometimes the `CHANGELOG.md` file was generated in the `warp10/` directory.
This PR makes sure the file is generated in the root directory of the project.