### PR TITLE
Add LFILTER and MFILTER

### DIFF
--- a/warp10/src/main/java/io/warp10/script/WarpScriptLib.java
+++ b/warp10/src/main/java/io/warp10/script/WarpScriptLib.java
@@ -553,6 +553,8 @@ public class WarpScriptLib {
   public static final String LINEOFF = "LINEOFF";
   public static final String LMAP = "LMAP";
   public static final String MMAP = "MMAP";
+  public static final String LFILTER = "LFILTER";
+  public static final String MFILTER = "MFILTER";
   public static final String NONNULL = "NONNULL";
   public static final String LFLATMAP = "LFLATMAP";
   public static final String STACKTOLIST = "STACKTOLIST";
@@ -1373,6 +1375,8 @@ public class WarpScriptLib {
     addNamedWarpScriptFunction(new LINEOFF(LINEOFF));
     addNamedWarpScriptFunction(new LMAP(LMAP));
     addNamedWarpScriptFunction(new MMAP(MMAP));
+    addNamedWarpScriptFunction(new LFILTER(LFILTER));
+    addNamedWarpScriptFunction(new MFILTER(MFILTER));
     addNamedWarpScriptFunction(new NONNULL(NONNULL));
     addNamedWarpScriptFunction(new LMAP(LFLATMAP, true));
     addNamedWarpScriptFunction(new EMPTYLIST(EMPTY_LIST));

--- a/warp10/src/main/java/io/warp10/script/functions/LFILTER.java
+++ b/warp10/src/main/java/io/warp10/script/functions/LFILTER.java
@@ -1,0 +1,81 @@
+//
+//   Copyright 2021  SenX S.A.S.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+package io.warp10.script.functions;
+
+import io.warp10.script.NamedWarpScriptFunction;
+import io.warp10.script.WarpScriptException;
+import io.warp10.script.WarpScriptStack;
+import io.warp10.script.WarpScriptStack.Macro;
+import io.warp10.script.WarpScriptStackFunction;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class LFILTER extends NamedWarpScriptFunction implements WarpScriptStackFunction {
+
+  public LFILTER(String name) {
+    super(name);
+  }
+
+  @Override
+  public Object apply(WarpScriptStack stack) throws WarpScriptException {
+
+    Object top = stack.pop();
+
+    boolean pushIndex = true;
+    if (top instanceof Boolean) {
+      pushIndex = (Boolean) top;
+      top = stack.pop();
+    }
+
+    if (!(top instanceof Macro)) {
+      throw new WarpScriptException(getName() + " expects a macro on top of the stack.");
+    }
+
+    Object list = stack.pop();
+
+    if (!(list instanceof List)) {
+      throw new WarpScriptException(getName() + " expects a list below the macro on top of the stack.");
+    }
+
+    int n = ((List) list).size();
+    ArrayList<Object> result = new ArrayList<Object>(n);
+
+    for (int i = 0; i < n; i++) {
+      Object element = ((List) list).get(i);
+      stack.push(element);
+      if (pushIndex) {
+        stack.push((long) i);
+      }
+      stack.exec((Macro) top);
+
+      Object o = stack.pop();
+
+      if (!(o instanceof Boolean)) {
+        throw new WarpScriptException(getName() + " expect the filter macro to return a BOOLEAN for each element.");
+      }
+
+      if (Boolean.TRUE.equals(o)) {
+        result.add(element);
+      }
+    }
+
+    stack.push(result);
+
+    return stack;
+  }
+}

--- a/warp10/src/main/java/io/warp10/script/functions/LFILTER.java
+++ b/warp10/src/main/java/io/warp10/script/functions/LFILTER.java
@@ -43,17 +43,17 @@ public class LFILTER extends NamedWarpScriptFunction implements WarpScriptStackF
     }
 
     if (!(top instanceof Macro)) {
-      throw new WarpScriptException(getName() + " expects a macro on top of the stack.");
+      throw new WarpScriptException(getName() + " expects a MACRO.");
     }
 
     Object list = stack.pop();
 
     if (!(list instanceof List)) {
-      throw new WarpScriptException(getName() + " expects a list below the macro on top of the stack.");
+      throw new WarpScriptException(getName() + " expects a LIST.");
     }
 
     int n = ((List) list).size();
-    ArrayList<Object> result = new ArrayList<Object>(n);
+    ArrayList<Object> result = new ArrayList<Object>();
 
     for (int i = 0; i < n; i++) {
       Object element = ((List) list).get(i);
@@ -66,7 +66,7 @@ public class LFILTER extends NamedWarpScriptFunction implements WarpScriptStackF
       Object o = stack.pop();
 
       if (!(o instanceof Boolean)) {
-        throw new WarpScriptException(getName() + " expect the filter macro to return a BOOLEAN for each element.");
+        throw new WarpScriptException(getName() + " expects the filter macro to return a BOOLEAN for each element.");
       }
 
       if (Boolean.TRUE.equals(o)) {

--- a/warp10/src/main/java/io/warp10/script/functions/MFILTER.java
+++ b/warp10/src/main/java/io/warp10/script/functions/MFILTER.java
@@ -43,7 +43,7 @@ public class MFILTER extends NamedWarpScriptFunction implements WarpScriptStackF
     }
     
     if (!(top instanceof Macro)) {
-      throw new WarpScriptException(getName() + " expects a macro on top of the stack.");
+      throw new WarpScriptException(getName() + " expects a MACRO.");
     }
 
     Macro macro = (Macro) top;
@@ -51,12 +51,12 @@ public class MFILTER extends NamedWarpScriptFunction implements WarpScriptStackF
     top = stack.pop();
     
     if (!(top instanceof Map)) {
-      throw new WarpScriptException(getName() + " expects a MAP below the macro on top of the stack.");
+      throw new WarpScriptException(getName() + " expects a MAP.");
     }
 
     Map<?, ?> map = (Map) top;
 
-    LinkedHashMap<Object, Object> result = new LinkedHashMap<Object, Object>(map.size());
+    LinkedHashMap<Object, Object> result = new LinkedHashMap<Object, Object>();
 
     int i = 0;
     for (Map.Entry entry: map.entrySet()) {
@@ -75,7 +75,7 @@ public class MFILTER extends NamedWarpScriptFunction implements WarpScriptStackF
       Object o = stack.pop();
 
       if(!(o instanceof Boolean)) {
-        throw new WarpScriptException(getName() + " expect the filter macro to return a BOOLEAN for each element.");
+        throw new WarpScriptException(getName() + " expects the filter macro to return a BOOLEAN for each element.");
       }
 
       if (Boolean.TRUE.equals(o)) {

--- a/warp10/src/main/java/io/warp10/script/functions/MFILTER.java
+++ b/warp10/src/main/java/io/warp10/script/functions/MFILTER.java
@@ -1,0 +1,92 @@
+//
+//   Copyright 2021  SenX S.A.S.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+package io.warp10.script.functions;
+
+import io.warp10.script.NamedWarpScriptFunction;
+import io.warp10.script.WarpScriptException;
+import io.warp10.script.WarpScriptStack;
+import io.warp10.script.WarpScriptStack.Macro;
+import io.warp10.script.WarpScriptStackFunction;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class MFILTER extends NamedWarpScriptFunction implements WarpScriptStackFunction {
+
+  public MFILTER(String name) {
+    super(name);
+  }
+
+  @Override
+  public Object apply(WarpScriptStack stack) throws WarpScriptException {
+
+    Object top = stack.pop();
+
+    boolean pushIndex = true;
+    if (top instanceof Boolean) {
+      pushIndex = (Boolean) top;
+      top = stack.pop();
+    }
+    
+    if (!(top instanceof Macro)) {
+      throw new WarpScriptException(getName() + " expects a macro on top of the stack.");
+    }
+
+    Macro macro = (Macro) top;
+    
+    top = stack.pop();
+    
+    if (!(top instanceof Map)) {
+      throw new WarpScriptException(getName() + " expects a MAP below the macro on top of the stack.");
+    }
+
+    Map<?, ?> map = (Map) top;
+
+    LinkedHashMap<Object, Object> result = new LinkedHashMap<Object, Object>(map.size());
+
+    int i = 0;
+    for (Map.Entry entry: map.entrySet()) {
+      Object key = entry.getKey();
+      Object value = entry.getValue();
+
+      stack.push(key);
+      stack.push(value);
+
+      if (pushIndex) {
+        stack.push((long) i);
+      }
+
+      stack.exec(macro);
+
+      Object o = stack.pop();
+
+      if(!(o instanceof Boolean)) {
+        throw new WarpScriptException(getName() + " expect the filter macro to return a BOOLEAN for each element.");
+      }
+
+      if (Boolean.TRUE.equals(o)) {
+        result.put(key, value);
+      }
+
+      i++;
+    }
+    
+    stack.push(result);
+    
+    return stack;
+  }
+}


### PR DESCRIPTION
Introduces two new functions `LFILTER` and `MFILTER` with a lot of similarities with `LMAP` and `MMAP`. Instead of mapping the element, those functions filter the element according to a boolean-returning macro.

Like `LMAP` and `MMAP`, is is possible to push the index of the element or not. It is pushed by default.

While this logic is achievable through a macro, those functions execute in 2/3 of the time of the macro version.