### PR TITLE
Added checking of thread interruption to allow for early exit

### DIFF
--- a/warp10/src/main/java/io/warp10/script/functions/FETCH.java
+++ b/warp10/src/main/java/io/warp10/script/functions/FETCH.java
@@ -467,7 +467,9 @@ public class FETCH extends NamedWarpScriptFunction implements WarpScriptStackFun
     }
 
     try {
-      while(iter.hasNext()) {
+      Thread thread = Thread.currentThread();
+
+      while(iter.hasNext() && !thread.isInterrupted()) {
 
         metadatas.add(iter.next());
 
@@ -591,7 +593,7 @@ public class FETCH extends NamedWarpScriptFunction implements WarpScriptStackFun
 
 
         try (GTSDecoderIterator gtsiter = gtsStore.fetch(req)) {
-          while(gtsiter.hasNext()) {
+          while(gtsiter.hasNext() && !thread.isInterrupted()) {
             GTSDecoder decoder = gtsiter.next();
 
             //

--- a/warp10/src/main/java/io/warp10/script/functions/FIND.java
+++ b/warp10/src/main/java/io/warp10/script/functions/FIND.java
@@ -63,27 +63,27 @@ import org.apache.thrift.protocol.TCompactProtocol;
  * Find Geo Time Series matching some criteria
  *
  * The top of the stack must contain a list of the following parameters
- * 
+ *
  * @param token The token to use for data retrieval
  * @param classSelector  Class selector.
  * @param labelsSelectors Map of label name to label selector.
  */
 public class FIND extends NamedWarpScriptFunction implements WarpScriptStackFunction {
-  
+
   public static final List<String> DEFAULT_LABELS_PRIORITY;
-  
+
   static {
     String def = WarpConfig.getProperty(Configuration.WARPSCRIPT_LABELS_PRIORITY);
-    
+
     List<String> order = new ArrayList<String>();
-    
+
     if (null != def) {
       String[] tokens = def.split(",");
       for (String token: tokens) {
         try {
           token = WarpURLDecoder.decode(token.trim(), StandardCharsets.UTF_8);
           order.add(token);
-        } catch (UnsupportedEncodingException uee) {          
+        } catch (UnsupportedEncodingException uee) {
         }
       }
     } else {
@@ -91,35 +91,35 @@ public class FIND extends NamedWarpScriptFunction implements WarpScriptStackFunc
       order.add(Constants.APPLICATION_LABEL);
       order.add(Constants.OWNER_LABEL);
     }
-    
+
     DEFAULT_LABELS_PRIORITY = Collections.unmodifiableList(order);
   }
-  
+
   private WarpScriptStackFunction listTo = new LISTTO("");
-  
+
   /**
    * Flag indicating whether we want to include the detail of GTS or only the
    * elements (class / labels) values
    */
   private final boolean elements;
-  
+
   /**
    * Flag indicating if we want to build a MetaSet
    */
   private final boolean metaset;
-  
+
   private byte[] METASETS_KEY;
-  
+
   public FIND(String name, boolean elements) {
     super(name);
     this.elements = elements;
     this.metaset = false;
     this.METASETS_KEY = null;
   }
-  
+
   public FIND(String name, boolean elements, boolean metaset) {
     super(name);
-    
+
     if (elements && metaset) {
       throw new RuntimeException("Invalid parameter combination.");
     }
@@ -127,31 +127,31 @@ public class FIND extends NamedWarpScriptFunction implements WarpScriptStackFunc
     this.elements = false;
     this.metaset = metaset;
   }
-  
+
   @Override
   public Object apply(WarpScriptStack stack) throws WarpScriptException {
     if (this.metaset && null == this.METASETS_KEY) {
       synchronized(FIND.class) {
-        this.METASETS_KEY = WarpDist.getKeyStore().getKey(KeyStore.AES_METASETS);      
+        this.METASETS_KEY = WarpDist.getKeyStore().getKey(KeyStore.AES_METASETS);
       }
     }
-    
+
     if (this.metaset && null == this.METASETS_KEY) {
       throw new WarpScriptException(getName() + " is disabled, as no key is set in '" + Configuration.WARP_AES_METASETS + "'.");
     }
-    
+
     //
     // Extract parameters from the stack
     //
 
     Object top = stack.peek();
-  
+
     boolean hasUUIDFlag = false;
-    
+
     boolean mapparams = false;
-    
+
     if (top instanceof List) {
-      
+
       if (!this.metaset) {
         if (3 != ((List) top).size() && 4 != ((List) top).size()) {
           stack.drop();
@@ -161,23 +161,23 @@ public class FIND extends NamedWarpScriptFunction implements WarpScriptStackFunc
         //
         // Explode list and remove its size
         //
-        
+
         listTo.apply(stack);
         Object n = stack.pop();
-        
-        hasUUIDFlag = 4 == ((Number) n).intValue() ? Boolean.TRUE.equals(stack.pop()) : false;        
+
+        hasUUIDFlag = 4 == ((Number) n).intValue() ? Boolean.TRUE.equals(stack.pop()) : false;
       } else {
-        
+
         if (7 != ((List) top).size()) {
           throw new WarpScriptException(getName() + " expects 7 parameters.");
         }
-        
+
         //
         // Explode list and remove its size
         //
-        
+
         listTo.apply(stack);
-        Object n = stack.pop();        
+        Object n = stack.pop();
       }
     } else if (top instanceof Map) {
       if (this.metaset) {
@@ -194,25 +194,25 @@ public class FIND extends NamedWarpScriptFunction implements WarpScriptStackFunc
         throw new WarpScriptException(getName() + " expects a list or map of parameters.");
       }
     }
-    
+
     MetaSet set = null;
-    
+
     Map<String,String> labelSelectors = null;
     String classSelector = null;
-    
+
     String token = null;
-    
+
     Long activeAfter = null;
     Long quietAfter = null;
-    
+
     DirectoryRequest drequest = null;
-    
+
     List<String> order = DEFAULT_LABELS_PRIORITY;
-    
+
     if (mapparams) {
       top = stack.pop();
       Map<String,Object> params = paramsFromMap((Map) top);
-            
+
       if (params.containsKey(FETCH.PARAM_SELECTOR_PAIRS)) {
         List<Pair<Object, Object>> selectors = (List<Pair<Object, Object>>) params.get(FETCH.PARAM_SELECTOR_PAIRS);
         drequest = new DirectoryRequest();
@@ -224,102 +224,102 @@ public class FIND extends NamedWarpScriptFunction implements WarpScriptStackFunc
         }
       } else if (params.containsKey(FETCH.PARAM_CLASS) && params.containsKey(FETCH.PARAM_LABELS)) {
         classSelector = (String) params.get(FETCH.PARAM_CLASS);
-        labelSelectors = new LinkedHashMap<String,String>((Map<String,String>) params.get(FETCH.PARAM_LABELS));        
+        labelSelectors = new LinkedHashMap<String,String>((Map<String,String>) params.get(FETCH.PARAM_LABELS));
       } else {
         throw new WarpScriptException(getName() + " missing parameters '" + FETCH.PARAM_CLASS + "', '" + FETCH.PARAM_LABELS + "', '" + FETCH.PARAM_SELECTOR + "' or '" + FETCH.PARAM_SELECTORS + "'.");
       }
-                  
+
       token = (String) params.get(FETCH.PARAM_TOKEN);
-      
+
       activeAfter = (Long) params.get(FETCH.PARAM_ACTIVE_AFTER);
       quietAfter = (Long) params.get(FETCH.PARAM_QUIET_AFTER);
-      
+
       if (params.containsKey(FETCH.PARAM_LABELS_PRIORITY)) {
         order = (List<String>) params.get(FETCH.PARAM_LABELS_PRIORITY);
       }
     } else {
       if (this.metaset) {
-        
+
         set = new MetaSet();
-        
+
         top = stack.pop();
-        
+
         if (!(top instanceof Long)) {
           throw new WarpScriptException(getName() + " expects a metaset TTL (in time units) on top of the stack.");
         }
-        
+
         set.setExpiry(System.currentTimeMillis() + (((long) top) / Constants.TIME_UNITS_PER_MS));
-        
+
         top = stack.pop();
-        
+
         if (!(top instanceof Long) && !(top instanceof Double && Double.isNaN((double) top))) {
-          throw new WarpScriptException(getName() + " expects a maximum duration or NaN below the expiration.");      
+          throw new WarpScriptException(getName() + " expects a maximum duration or NaN below the expiration.");
         }
-        
+
         if (top instanceof Long) {
           set.setMaxduration((long) top);
         }
-        
+
         top = stack.pop();
-        
+
         if (!(top instanceof Long) && !(top instanceof Double && Double.isNaN((double) top))) {
-          throw new WarpScriptException(getName() + " expects a 'notafter' parameter below the maximum duration.");      
+          throw new WarpScriptException(getName() + " expects a 'notafter' parameter below the maximum duration.");
         }
-        
+
         if (top instanceof Long) {
           set.setNotafter((long) top);
         }
-        
+
         top = stack.pop();
-        
+
         if (!(top instanceof Long) && !(top instanceof Double && Double.isNaN((double) top))) {
-          throw new WarpScriptException(getName() + " expects a 'notbefore' parameter below 'notafter'.");      
+          throw new WarpScriptException(getName() + " expects a 'notbefore' parameter below 'notafter'.");
         }
-        
+
         if (top instanceof Long) {
           set.setNotbefore((long) top);
         }
       }
-      
+
       //
       // Extract labels selector
       //
-      
+
       Object oLabelsSelector = stack.pop();
-      
+
       if (!(oLabelsSelector instanceof Map)) {
         throw new WarpScriptException("Label selectors must be a map.");
       }
-      
+
       labelSelectors = new LinkedHashMap<String,String>((Map<String,String>) oLabelsSelector);
 
       //
       // Extract class selector
       //
-      
+
       Object oClassSelector = stack.pop();
 
       if (!(oClassSelector instanceof String)) {
         throw new WarpScriptException("Class selector must be a string.");
       }
-      
+
       classSelector = (String) oClassSelector;
 
       //
       // Extract token
       //
-      
+
       Object oToken = stack.pop();
-      
+
       if (!(oToken instanceof String)) {
         throw new WarpScriptException("Token must be a string.");
       }
-      
-      token = (String) oToken;      
+
+      token = (String) oToken;
     }
-    
+
     DirectoryClient directoryClient = stack.getDirectoryClient();
-    
+
     ReadToken rtoken;
     try {
       rtoken = Tokens.extractReadToken(token);
@@ -338,7 +338,7 @@ public class FIND extends NamedWarpScriptFunction implements WarpScriptStackFunc
     }
 
     boolean expose = rtoken.getAttributesSize() > 0 && rtoken.getAttributes().containsKey(Constants.TOKEN_ATTR_EXPOSE);
-    
+
     List<String> clsSels = new ArrayList<String>();
     List<Map<String,String>> lblsSels = new ArrayList<Map<String,String>>();
 
@@ -346,9 +346,9 @@ public class FIND extends NamedWarpScriptFunction implements WarpScriptStackFunc
       labelSelectors.remove(Constants.PRODUCER_LABEL);
       labelSelectors.remove(Constants.OWNER_LABEL);
       labelSelectors.remove(Constants.APPLICATION_LABEL);
-      labelSelectors.putAll(Tokens.labelSelectorsFromReadToken(rtoken));      
+      labelSelectors.putAll(Tokens.labelSelectorsFromReadToken(rtoken));
       clsSels.add(classSelector);
-      
+
       // Re-order the labels
       Map<String,String> ordered = new LinkedHashMap<String,String>(labelSelectors.size() > 0 ? labelSelectors.size() : 1);
       for (String label: order) {
@@ -367,13 +367,13 @@ public class FIND extends NamedWarpScriptFunction implements WarpScriptStackFunc
     }
 
     if (this.metaset) {
-      set.setToken(token);      
+      set.setToken(token);
     }
-    
+
     Iterator<Metadata> iter = null;
-    
+
     try {
-      
+
       if (null == drequest) {
         drequest = new DirectoryRequest();
         drequest.setClassSelectors(clsSels);
@@ -411,7 +411,7 @@ public class FIND extends NamedWarpScriptFunction implements WarpScriptStackFunc
       }
       if (null != quietAfter) {
         drequest.setQuietAfter(quietAfter);
-      }        
+      }
       iter = directoryClient.iterator(drequest);
     } catch (Exception e) {
       throw new WarpScriptException(e);
@@ -419,13 +419,13 @@ public class FIND extends NamedWarpScriptFunction implements WarpScriptStackFunc
 
     long gtsLimit = (long) stack.getAttribute(WarpScriptStack.ATTRIBUTE_GTS_LIMIT);
 
-    AtomicLong gtscount = (AtomicLong) stack.getAttribute(WarpScriptStack.ATTRIBUTE_GTS_COUNT);    
-    
+    AtomicLong gtscount = (AtomicLong) stack.getAttribute(WarpScriptStack.ATTRIBUTE_GTS_COUNT);
+
     List<GeoTimeSerie> series = null;
     Set<String> classes = null;
     Map<String,Set<String>> labels = null;
     Map<String,Set<String>> attributes = null;
-    
+
     if (!elements) {
       if (!this.metaset) {
         series = new ArrayList<GeoTimeSerie>();
@@ -435,14 +435,15 @@ public class FIND extends NamedWarpScriptFunction implements WarpScriptStackFunc
       labels = new LinkedHashMap<String, Set<String>>();
       attributes = new LinkedHashMap<String, Set<String>>();
     }
-    
+
     try {
-      while(iter.hasNext()) {
+      Thread thread = Thread.currentThread();
+      while(iter.hasNext() && !thread.isInterrupted()) {
         Metadata metadata = iter.next();
-        
+
         if (elements) {
           classes.add(metadata.getName());
-          
+
           if (metadata.getLabelsSize() > 0) {
             for (Entry<String,String> entry: metadata.getLabels().entrySet()) {
               Set<String> values = labels.get(entry.getKey());
@@ -453,7 +454,7 @@ public class FIND extends NamedWarpScriptFunction implements WarpScriptStackFunc
               values.add(entry.getValue());
             }
           }
-          
+
           if (metadata.getAttributesSize() > 0) {
             for (Entry<String,String> entry: metadata.getAttributes().entrySet()) {
               Set<String> values = attributes.get(entry.getKey());
@@ -467,31 +468,31 @@ public class FIND extends NamedWarpScriptFunction implements WarpScriptStackFunc
 
           continue;
         }
-        
+
         if (gtscount.incrementAndGet() > gtsLimit) {
           throw new WarpScriptException(getName() + " exceeded limit of " + gtsLimit + " Geo Time Series, current count is " + gtscount.get());
         }
 
         stack.handleSignal();
-        
+
         GeoTimeSerie gts = new GeoTimeSerie();
-        
+
         // Use safeSetMetadata since the Metadata were newly created by 'find'
         gts.safeSetMetadata(metadata);
 
         //
         // Add a .uuid attribute if instructed to do so
         //
-        
+
         if (hasUUIDFlag) {
           java.util.UUID uuid = new java.util.UUID(gts.getClassId(), gts.getLabelsId());
           gts.getMetadata().putToAttributes(Constants.UUID_ATTRIBUTE, uuid.toString());
         }
-        
+
         //
         // Remove producer/owner labels
         //
-        
+
         if (!this.metaset) {
           Map<String,String> gtslabels = new LinkedHashMap<String, String>();
           gtslabels.putAll(gts.getLabels());
@@ -499,27 +500,27 @@ public class FIND extends NamedWarpScriptFunction implements WarpScriptStackFunc
             gtslabels.remove(Constants.PRODUCER_LABEL);
             gtslabels.remove(Constants.OWNER_LABEL);
           }
-          gts.setLabels(gtslabels);          
+          gts.setLabels(gtslabels);
           series.add(gts);
         } else {
           set.addToMetadatas(gts.getMetadata());
-        }      
-      }      
+        }
+      }
     } catch (Throwable t) {
       throw t;
     } finally {
       if (iter instanceof MetadataIterator) {
         try {
           ((MetadataIterator) iter).close();
-        } catch (Exception e) {        
+        } catch (Exception e) {
         }
       }
     }
-    
+
     //
     // Put all 'count' GTS into a list
     //
-    
+
     if (!elements) {
       if (!this.metaset) {
         stack.push(series);
@@ -533,23 +534,23 @@ public class FIND extends NamedWarpScriptFunction implements WarpScriptStackFunc
         //
         // Encode the MetaSet
         //
-        
+
         TSerializer serializer = new TSerializer(new TCompactProtocol.Factory());
-        
+
         try {
           byte[] serialized = serializer.serialize(set);
-          
+
           // Compress the serialized content
           ByteArrayOutputStream baos = new ByteArrayOutputStream();
           GZIPOutputStream out = new GZIPOutputStream(baos);
           out.write(serialized);
           out.close();
-          
+
           byte[] compressed = baos.toByteArray();
-          
-          // Now encrypt the content          
+
+          // Now encrypt the content
           byte[] wrapped = CryptoUtils.wrap(METASETS_KEY, compressed);
-          
+
           // Encode it and push it on the stack
           stack.push(new String(OrderPreservingBase64.encode(wrapped), StandardCharsets.UTF_8));
         } catch (TException | IOException e) {
@@ -560,14 +561,14 @@ public class FIND extends NamedWarpScriptFunction implements WarpScriptStackFunc
       List<String> list = new ArrayList<String>();
       list.addAll(classes);
       stack.push(list);
-      
+
       Map<String,List<String>> map = new HashMap<String,List<String>>();
       for (Entry<String,Set<String>> entry: labels.entrySet()) {
         list = new ArrayList<String>();
         list.addAll(entry.getValue());
         map.put(entry.getKey(), list);
       }
-      
+
       stack.push(map);
 
       map = new HashMap<String,List<String>>();
@@ -576,21 +577,21 @@ public class FIND extends NamedWarpScriptFunction implements WarpScriptStackFunc
         list.addAll(entry.getValue());
         map.put(entry.getKey(), list);
       }
-      
+
       stack.push(map);
     }
-    
+
     return stack;
   }
-  
+
   private Map<String,Object> paramsFromMap(Map<String,Object> map) throws WarpScriptException {
     Map<String,Object> params = new HashMap<String, Object>();
-            
+
     if (!map.containsKey(FETCH.PARAM_TOKEN)) {
       throw new WarpScriptException(getName() + " Missing '" + FETCH.PARAM_TOKEN + "' parameter");
     }
-      
-    params.put(FETCH.PARAM_TOKEN, map.get(FETCH.PARAM_TOKEN));      
+
+    params.put(FETCH.PARAM_TOKEN, map.get(FETCH.PARAM_TOKEN));
 
     if (map.containsKey(FETCH.PARAM_SELECTORS)) {
       Object sels = map.get(FETCH.PARAM_SELECTORS);
@@ -598,7 +599,7 @@ public class FIND extends NamedWarpScriptFunction implements WarpScriptStackFunc
         throw new WarpScriptException(getName() + " Invalid parameter '" + FETCH.PARAM_SELECTORS + "'");
       }
       List<Pair<Object, Object>> selectors = new ArrayList<Pair<Object,Object>>();
-      
+
       for (Object sel: (List) sels) {
         Object[] clslbls = PARSESELECTOR.parse(sel.toString());
         selectors.add(Pair.of(clslbls[0], clslbls[1]));
@@ -612,7 +613,7 @@ public class FIND extends NamedWarpScriptFunction implements WarpScriptStackFunc
       params.put(FETCH.PARAM_CLASS, map.get(FETCH.PARAM_CLASS));
       params.put(FETCH.PARAM_LABELS, map.get(FETCH.PARAM_LABELS));
     }
-        
+
     if (map.containsKey(FETCH.PARAM_ACTIVE_AFTER)) {
       if (!(map.get(FETCH.PARAM_ACTIVE_AFTER) instanceof Long)) {
         throw new WarpScriptException(getName() + " Invalid type for parameter '" + FETCH.PARAM_ACTIVE_AFTER + "'.");
@@ -640,6 +641,6 @@ public class FIND extends NamedWarpScriptFunction implements WarpScriptStackFunc
     }
 
     return params;
-    
+
   }
 }


### PR DESCRIPTION
When FIND or FETCH are called within a TIMEBOX call we may end up with long scans continuing some time after TIMEBOX interrupted the threads.

This PR adds a check for thread interrupted status in order to ensure early exit from the loops.