### PR TITLE
Fix warpscript.maxbuckets in conf templates

### DIFF
--- a/etc/conf.templates/distributed/20-warpscript.conf.template
+++ b/etc/conf.templates/distributed/20-warpscript.conf.template
@@ -79,8 +79,8 @@ warpscript.maxops.hard = 2000
 // Maximum number of buckets which can result of a call to BUCKETIZE
 // Can be modified by MAXBUCKETS up to the hard limit below
 //
-warpscript.maxbuckets = 1000000
-warpscript.maxbuckets.hard = 100000
+warpscript.maxbuckets = 100000
+warpscript.maxbuckets.hard = 1000000
 
 //
 // Maximum number of cells in geographic shapes

--- a/etc/conf.templates/standalone/20-warpscript.conf.template
+++ b/etc/conf.templates/standalone/20-warpscript.conf.template
@@ -78,7 +78,7 @@ warpscript.maxops.hard = 20000
 // Maximum number of buckets which can result of a call to BUCKETIZE
 // Can be modified by MAXBUCKETS up to the hard limit below
 //
-warpscript.maxbuckets = 1000000
+warpscript.maxbuckets = 100000
 warpscript.maxbuckets.hard = 1000000
 
 //


### PR DESCRIPTION
In dist, soft and max were swapped and in standalone there were the same.