### PR TITLE
Fix TCPClient stuck in LinkedBlockingQueue see #1022

### DIFF
--- a/warp10/src/main/java/io/warp10/plugins/tcp/TCPManager.java
+++ b/warp10/src/main/java/io/warp10/plugins/tcp/TCPManager.java
@@ -42,6 +42,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
@@ -177,7 +178,7 @@ public class TCPManager extends Thread {
 
     done = false;
 
-    clientsExecutor = new ThreadPoolExecutor(maxConnections, maxConnections, 30000L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<Runnable>(maxConnections), new CustomThreadFactory("Warp TCP Client for port " + port));
+    clientsExecutor = new ThreadPoolExecutor(maxConnections, maxConnections, 30000L, TimeUnit.MILLISECONDS, new SynchronousQueue<Runnable>(), new CustomThreadFactory("Warp TCP Client for port " + port));
     clientsExecutor.allowCoreThreadTimeOut(true);
 
     setDaemon(true);


### PR DESCRIPTION
Currently, to limit the number of parallel connections the following is done:
- All incoming connections are accepted
- After accepting a connection, it is immediately closed if there are already `maxConnections` `TCPClients` running.

While this is not ideal, it appears that are no other option to implement this.

There currently an issue with accepted and open connections which are not handled by a running `TCPClient`, see #1022.

This is because the `ThreadPoolExecutor` is created with a pool of core=max=maxConnections threads and a  `LinkedBlockingQueue` of capacity `maxConnections`. So `maxConnections` `TCPClient`s could be accepted and running (thread pool capacity) and `maxConnections` `TCPClient`s could be accepted and waiting to be run (in the Queue).

The fix is to change the `LinkedBlockingQueue` to a `SynchronousQueue` which as no capacity.