### PR TITLE
Implements Welford's algorithm in variance aggregator for better numerical stabilty

### DIFF
--- a/warp10/src/main/java/io/warp10/script/aggregator/Variance.java
+++ b/warp10/src/main/java/io/warp10/script/aggregator/Variance.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2020  SenX S.A.S.
+//   Copyright 2018-2021  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -17,52 +17,56 @@
 package io.warp10.script.aggregator;
 
 import io.warp10.continuum.gts.GeoTimeSerie;
-import io.warp10.continuum.gts.GeoTimeSerie.TYPE;
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptBucketizerFunction;
+import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptMapperFunction;
 import io.warp10.script.WarpScriptReducerFunction;
-import io.warp10.script.WarpScriptStackFunction;
-import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptStack;
+import io.warp10.script.WarpScriptStackFunction;
 
+/**
+ * Aggregator to compute the variance on a list of datapoints.
+ * This implements Welford's algorithm for numerical stability, see
+ * https://www.johndcook.com/blog/2008/09/26/comparing-three-methods-of-computing-standard-deviation/
+ */
 public class Variance extends NamedWarpScriptFunction implements WarpScriptMapperFunction, WarpScriptReducerFunction, WarpScriptBucketizerFunction {
-  
+
   private final boolean useBessel;
   private final boolean forbidNulls;
-  
+
   public Variance(String name, boolean useBessel, boolean forbidNulls) {
     super(name);
     this.useBessel = useBessel;
     this.forbidNulls = forbidNulls;
   }
-  
+
   public static class Builder extends NamedWarpScriptFunction implements WarpScriptStackFunction {
-    
+
     private final boolean forbidNulls;
-    
+
     public Builder(String name, boolean forbidNulls) {
       super(name);
       this.forbidNulls = forbidNulls;
     }
-    
+
     @Override
     public Object apply(WarpScriptStack stack) throws WarpScriptException {
       Object o = stack.pop();
-      
+
       if (!(o instanceof Boolean)) {
         throw new WarpScriptException(getName() + " expects a boolean parameter to determine whether or not to apply Bessel's correction.");
       }
-      
+
       stack.push(new Variance(getName(), (boolean) o, this.forbidNulls));
-      
+
       return stack;
     }
-    
+
   }
-  
+
   @Override
-  public Object apply(Object[] args) throws io.warp10.script.WarpScriptException {
+  public Object apply(Object[] args) throws WarpScriptException {
     long[] ticks = (long[]) args[3];
     long[] locations = (long[]) args[4];
     long[] elevations = (long[]) args[5];
@@ -71,81 +75,72 @@ public class Variance extends NamedWarpScriptFunction implements WarpScriptMappe
     if (0 == ticks.length) {
       return new Object[] { Long.MAX_VALUE, GeoTimeSerie.NO_LOCATION, GeoTimeSerie.NO_ELEVATION, null };
     }
-    
-    double sum = 0.0D;
-    double sumsq = 0.0D;
 
-    TYPE type = null;
-    
+    double m = 0.0D;
+    double s = 0.0D;
+
     long location = GeoTimeSerie.NO_LOCATION;
     long elevation = GeoTimeSerie.NO_ELEVATION;
     long timestamp = Long.MIN_VALUE;
-    
+
     int nticks = 0;
-    
+
     for (int i = 0; i < values.length; i++) {
       Object value = values[i];
 
-      if (null == value && this.forbidNulls) {
-        return new Object[] { Long.MAX_VALUE, GeoTimeSerie.NO_LOCATION, GeoTimeSerie.NO_ELEVATION, null };
-      } else if (null == value) {
-        continue;
+      if (null == value) {
+        if (this.forbidNulls) {
+          return new Object[] {Long.MAX_VALUE, GeoTimeSerie.NO_LOCATION, GeoTimeSerie.NO_ELEVATION, null};
+        } else {
+          continue;
+        }
       }
-    
+
       nticks++;
-      
+
       if (ticks[i] > timestamp) {
         location = locations[i];
         elevation = elevations[i];
         timestamp = ticks[i];
       }
-      
-      if (null == type) {
-        // No type detected yet,
-        // check value
-        
-        if (value instanceof Long) {
-          type = TYPE.LONG;
-          sum = ((Number) value).doubleValue();
-          sumsq = sum * sum;
-        } else if (value instanceof Double) {
-          type = TYPE.DOUBLE;
-          sum = ((Number) value).doubleValue();
-          sumsq = sum * sum;
+
+      if (value instanceof Number) {
+        double x = ((Number) value).doubleValue();
+        if (0 == i) {
+          m = x;
+          s = 0.0D;
         } else {
-          //
-          // Mean of String or Boolean has no meaning
-          //
-          return new Object[] { Long.MAX_VALUE, GeoTimeSerie.NO_LOCATION, GeoTimeSerie.NO_ELEVATION, null };
-        }        
+          double mnew = m + (x - m) / (i + 1);
+          s = s + (x - m) * (x - mnew);
+          m = mnew;
+        }
       } else {
-        double v = ((Number) value).doubleValue(); 
-        sum += v;
-        sumsq += v * v;
+        //
+        // Mean of String or Boolean has no meaning
+        //
+        return new Object[] {Long.MAX_VALUE, GeoTimeSerie.NO_LOCATION, GeoTimeSerie.NO_ELEVATION, null};
       }
     }
 
     //
     // Compute variance
-    // E[X-mu^2] = E[X^2] - (E[X])^2
-    // @see <a href="http://en.wikipedia.org/wiki/Variance">http://en.wikipedia.org/wiki/Variance</a>
     //
-    
+
     int n = nticks;
-    double variance = (sumsq / (double) n) - (sum * sum) / (((double) n) * ((double) n));
-    
+    double variance = s / n;
+
     //
     // Apply Bessel's correction
     // @see <a href="http://en.wikipedia.org/wiki/Bessel's_correction">http://en.wikipedia.org/wiki/Bessel's_correction</a>
     //
-    
+
     if (n > 1 && useBessel) {
       variance = variance * ((double) n) / (((double) n) - 1.0D);
     }
-    
+
     return new Object[] { 0L, location, elevation, variance };
   }
-  
+
   @Override
   public String toString() {
     return Boolean.toString(this.forbidNulls) + " " + this.getName();


### PR DESCRIPTION
With the current variance implementation some problem can arise, see:
```
[ "T07oF2SaOaOaOaNoF2SaOaOaOaJL0.." UNWRAP F mapper.var MAXLONG MAXLONG 1 ] MAP
0 GET 0 ATINDEX 4 GET
```
which gives a negative variance of:
```
[-1.1368683772161603E-13]
```

This is because the variance is orders of magnitude lower than the values, see [this article](johndcook.com/blog/2008/09/26/comparing-three-methods-of-computing-standard-deviation/).

The solution is to implement Welford's algorithm which gives the positive variance:
```
[6.3108872417680944E-30]
```

This implementation is slower by 10% but is much more stable.

This passes the tests and give very similar result to the sum of square method when used on non-extreme cases.