### PR TITLE
Bump GeoXPLib to 1.0.4

### DIFF
--- a/warp10/build.gradle
+++ b/warp10/build.gradle
@@ -120,7 +120,7 @@ dependencies {
     //
     // There are several jts-core (aka jts) packaging. The most up-to-date is org.locationtech.jts:jts-core but the versions
     // of the libs below use com.vividsolutions:jts/jts-core.
-    api('io.senx:geoxplib:1.0.3')
+    api('io.senx:geoxplib:1.0.4')
     api('org.wololo:jts2geojson:0.10.0') {
         // Conflicts with com.vividsolutions:jts pulled by io.senx:geoxplib
         exclude group: 'com.vividsolutions', module: 'jts-core'


### PR DESCRIPTION
Allows `HHCODEFUNC` to work at any resolution for 0 to 32, combined with #1025.

Tested with:
```
'1100011001011000000000000000000000000000000000000000000000000000' FROMBIN
'hhcode' STORE

NEWGTS
0 $hhcode HHCODE-> NaN 'pos' ADDVALUE
'original' RENAME

0 32
<%
  'res' STORE
  $hhcode $res HHCODE.BBOX
  [ 'latS' 'lonW' 'latN' 'lonE' ] STORE

  NEWGTS
  0  $latN $lonW NaN 'bbox_NW' ADDVALUE
  1  $latS $lonW NaN 'bbox_SW' ADDVALUE
  2  $latS $lonE NaN 'bbox_SE' ADDVALUE
  3  $latN $lonE NaN 'bbox_NE' ADDVALUE
  4  $latN $lonW NaN 'bbox_NW' ADDVALUE
  5  $hhcode $res HHCODE.NORTH.WEST HHCODE-> NaN 'NW' ADDVALUE
  6  $hhcode $res HHCODE.WEST       HHCODE-> NaN 'W' ADDVALUE
  7  $hhcode $res HHCODE.SOUTH.WEST HHCODE-> NaN 'SW' ADDVALUE
  8  $hhcode $res HHCODE.SOUTH      HHCODE-> NaN 'S' ADDVALUE
  9  $hhcode $res HHCODE.SOUTH.EAST HHCODE-> NaN 'SE' ADDVALUE
  10 $hhcode $res HHCODE.EAST       HHCODE-> NaN 'E' ADDVALUE
  11 $hhcode $res HHCODE.NORTH.EAST HHCODE-> NaN 'NE' ADDVALUE
  12 $hhcode $res HHCODE.NORTH      HHCODE-> NaN 'N' ADDVALUE
  13 $hhcode $res HHCODE.CENTER     NaN 'Center' ADDVALUE
  $res TOSTRING RENAME
%>
FOR
```