### PR TITLE
Change generateChangelog to be a dependency of createTarArchive

### DIFF
--- a/warp10/build.gradle
+++ b/warp10/build.gradle
@@ -291,7 +291,7 @@ task generateChangelog(type: Exec) {
 // Tasks dependencies
 //
 compileJava.dependsOn("generateThrift")
-pack.dependsOn("generateChangelog")
+createTarArchive.dependsOn("generateChangelog")
 pack.dependsOn(":crypto:jar")
 pack.dependsOn(":token:jar")
 pack.dependsOn(":hbaseFilters:jar")


### PR DESCRIPTION
pack does not need the changelog, only the tar needs it.