### PR TITLE
Add order selection to GOLDWRAP

### DIFF
--- a/warp10/src/main/java/io/warp10/script/functions/GOLDWRAP.java
+++ b/warp10/src/main/java/io/warp10/script/functions/GOLDWRAP.java
@@ -79,7 +79,7 @@ public class GOLDWRAP extends ListRecursiveStackFunction {
             deser.deserialize(wrapper, bytes);
             encoder = GTSWrapperHelper.fromGTSWrapperToGTSEncoder(wrapper);
           } else {
-            throw new WarpScriptException(getName() + " can only be applied to Geo Time Series™, GTS Encoders or wrapped instances of those types.");
+            return UNHANDLED;
           }
 
           GTSEncoder enc = null;

--- a/warp10/src/main/java/io/warp10/script/functions/GOLDWRAP.java
+++ b/warp10/src/main/java/io/warp10/script/functions/GOLDWRAP.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2019  SenX S.A.S.
+//   Copyright 2019-2022  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package io.warp10.script.functions;
 
 import java.io.IOException;
-import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.TreeMap;
@@ -27,7 +26,6 @@ import org.apache.thrift.TException;
 import org.apache.thrift.TSerializer;
 import org.apache.thrift.protocol.TCompactProtocol;
 
-import io.warp10.continuum.gts.GTSDecoder;
 import io.warp10.continuum.gts.GTSEncoder;
 import io.warp10.continuum.gts.GTSHelper;
 import io.warp10.continuum.gts.GTSWrapperHelper;
@@ -35,33 +33,35 @@ import io.warp10.continuum.gts.GeoTimeSerie;
 import io.warp10.continuum.store.thrift.data.GTSWrapper;
 import io.warp10.continuum.store.thrift.data.Metadata;
 import io.warp10.crypto.OrderPreservingBase64;
-import io.warp10.script.ElementOrListStackFunction;
+import io.warp10.script.ListRecursiveStackFunction;
 import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptStack;
 
-public class GOLDWRAP extends ElementOrListStackFunction {
-  
+public class GOLDWRAP extends ListRecursiveStackFunction {
+
   private final ElementStackFunction function;
-  
-  
+  private final ElementStackFunction reversedFunction;
+
+
   public GOLDWRAP(String name) {
     super(name);
-    function = generateFunctionOnce();
+    function = generateFunctionOnce(false);
+    reversedFunction = generateFunctionOnce(true);
   }
 
-  private ElementStackFunction generateFunctionOnce() {
+  private ElementStackFunction generateFunctionOnce(final boolean reversed) {
     return new ElementStackFunction() {
       @Override
       public Object applyOnElement(Object element) throws WarpScriptException {
         GTSEncoder encoder = null;
-        
+
         boolean sortedEncoder = false;
-        
+
         try {
           if (element instanceof GeoTimeSerie) {
             encoder = new GTSEncoder(0L);
             encoder.setMetadata(((GeoTimeSerie) element).getMetadata());
-            GTSHelper.fullsort((GeoTimeSerie) element, false);
+            GTSHelper.fullsort((GeoTimeSerie) element, reversed);
             sortedEncoder = true;
             encoder.encodeOptimized((GeoTimeSerie) element);
           } else if (element instanceof GTSEncoder) {
@@ -69,7 +69,7 @@ public class GOLDWRAP extends ElementOrListStackFunction {
           } else if (element instanceof String || element instanceof byte[]) {
             TDeserializer deser = new TDeserializer(new TCompactProtocol.Factory());
             byte[] bytes;
-            
+
             if (element instanceof String) {
               bytes = OrderPreservingBase64.decode(element.toString().getBytes(StandardCharsets.US_ASCII));
             } else {
@@ -77,45 +77,45 @@ public class GOLDWRAP extends ElementOrListStackFunction {
             }
             GTSWrapper wrapper = new GTSWrapper();
             deser.deserialize(wrapper, bytes);
-            encoder = GTSWrapperHelper.fromGTSWrapperToGTSEncoder(wrapper);      
+            encoder = GTSWrapperHelper.fromGTSWrapperToGTSEncoder(wrapper);
           } else {
             throw new WarpScriptException(getName() + " can only be applied to Geo Time Series™, GTS Encoders or wrapped instances of those types.");
-          } 
-          
+          }
+
           GTSEncoder enc = null;
-          
+
           if (sortedEncoder) {
             // We had a single GeoTimeSerie instance that we sorted and encoded
             // as an optimized encoder, so take a fastpath!
             enc = encoder;
           } else {
-            enc = GTSHelper.fullsort(encoder, false, 0L);
+            enc = GTSHelper.fullsort(encoder, reversed, 0L);
           }
-          
+
           // Save the current metadata
-          
+
           Metadata metadata = enc.getRawMetadata();
-          
+
           // Create an empty Metadata instance which will be populated
           // using class, labels and attributes only
-          
+
           enc.setMetadata(new Metadata());
-                    
+
           try {
             //
             // We need to ensure the metadata (labels/attributes) are in a deterministic order
             //
-                      
+
             if (metadata.getLabelsSize() > 0) {
               Map<String,String> smap = new TreeMap<String,String>();
               smap.putAll(metadata.getLabels());
               enc.getRawMetadata().setLabels(smap);
             }
-            
+
             if (metadata.getAttributesSize() > 0) {
               Map<String,String> smap = new TreeMap<String,String>();
               smap.putAll(metadata.getAttributes());
-              enc.getRawMetadata().setAttributes(smap);            
+              enc.getRawMetadata().setAttributes(smap);
             }
 
             // Copy the elements which we need
@@ -124,12 +124,12 @@ public class GOLDWRAP extends ElementOrListStackFunction {
             GTSWrapper wrapper = GTSWrapperHelper.fromGTSEncoderToGTSWrapper(enc, true, 1.0D, Integer.MAX_VALUE);
             TSerializer ser = new TSerializer(new TCompactProtocol.Factory());
             byte[] bytes = ser.serialize(wrapper);
-            
-            return bytes;            
+
+            return bytes;
           } finally {
             // Restore the original metadata
             enc.safeSetMetadata(metadata);
-          }                    
+          }
         } catch (TException te) {
           throw new WarpScriptException(getName() + " encountered an error while manipulating GTS Wrapper.", te);
         } catch (IOException ioe) {
@@ -138,9 +138,26 @@ public class GOLDWRAP extends ElementOrListStackFunction {
       }
     };
   }
-  
+
   @Override
-  public ElementStackFunction generateFunction(WarpScriptStack stack) throws WarpScriptException {        
-    return function;
+  public ElementStackFunction generateFunction(WarpScriptStack stack) throws WarpScriptException {
+
+    boolean reversed = false;
+
+    // Check if order was specified
+    if (stack.peek() instanceof Boolean) {
+      reversed = Boolean.TRUE.equals(stack.pop());
+    }
+
+    if (reversed) {
+      return reversedFunction;
+    } else {
+      return function;
+    }
+  }
+
+  @Override
+  public String getUnhandledErrorMessage() {
+    return getName() + " can only handle GTS, ENCODERs and list thereof.";
   }
 }


### PR DESCRIPTION
In some contexts wrappers are always stored in reverse chronological order, it is therefore useful to have an option to build "gold" wrappers with the choice of order.

The behavior of GOLDWRAP is unchanged, it is the equivalent of 'false GOLDWRAP'. Gold wrappers in reverse chronological order can be created using 'true GOLDWRAP'.