### PR TITLE
System property support for setting time units.

### DIFF
--- a/warp10/src/main/java/io/warp10/continuum/store/Constants.java
+++ b/warp10/src/main/java/io/warp10/continuum/store/Constants.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2021  SenX S.A.S.
+//   Copyright 2018-2022  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -515,10 +515,24 @@ public class Constants {
 
   static {
     if (1 != Constants.DEFAULT_MODULUS) {
-      throw new RuntimeException("DEFAULT_MODULUS cannot be diffrent than 1.");
+      throw new RuntimeException("DEFAULT_MODULUS cannot be different from 1.");
     }
 
     String tu = WarpConfig.getProperty(Configuration.WARP_TIME_UNITS);
+
+    //
+    // If the time units were not set in the config or the configuration not loaded
+    // we will attempt to use the System property. This is to allow some classes
+    // which depend on other constants in this class to still work even though no
+    // Warp 10 config was loaded. Before introducing this the lack of Warp 10 configuration
+    // would trigger a RuntimeException reporting missing time units and attempts to
+    // access any other constant from this class would throw a NoClassDefFoundException.
+    // Adding support for reading time units from system properties
+    //
+
+    if (null == tu) {
+      tu = System.getProperty(Configuration.WARP_TIME_UNITS);
+    }
 
     EXPOSE_OWNER_PRODUCER = "true".equals(WarpConfig.getProperty(Configuration.WARP10_EXPOSE_OWNER_PRODUCER));
 

--- a/warp10/src/main/java/io/warp10/script/functions/EVAL.java
+++ b/warp10/src/main/java/io/warp10/script/functions/EVAL.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2020  SenX S.A.S.
+//   Copyright 2018-2022  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -23,15 +23,15 @@ import io.warp10.script.WarpScriptStack;
 import io.warp10.script.WarpScriptStack.Macro;
 
 public class EVAL extends NamedWarpScriptFunction implements WarpScriptStackFunction {
-  
+
   public EVAL(String name) {
     super(name);
   }
-  
+
   @Override
   public Object apply(WarpScriptStack stack) throws WarpScriptException {
     Object o = stack.pop();
-    
+
     if (o instanceof String) {
       // Execute single statement which may span multiple lines
       stack.execMulti((String) o);
@@ -40,7 +40,7 @@ public class EVAL extends NamedWarpScriptFunction implements WarpScriptStackFunc
     } else if (o instanceof WarpScriptStackFunction) {
       ((WarpScriptStackFunction) o).apply(stack);
     } else {
-      throw new WarpScriptException(getName() + " expects a Macro, a function of a String.");
+      throw new WarpScriptException(getName() + " expects a Macro, a function or a String.");
     }
     return stack;
   }

--- a/warp10/src/main/java/io/warp10/script/functions/REPORT.java
+++ b/warp10/src/main/java/io/warp10/script/functions/REPORT.java
@@ -65,7 +65,6 @@ public class REPORT extends NamedWarpScriptFunction implements WarpScriptStackFu
 
     if (defaultSecret.equals(SECRET)) {
       LOG.info("REPORT secret not set, using '" + defaultSecret + "'.");
-      System.out.println("REPORT secret not set, using '" + defaultSecret + "'.");
     }
   }
 


### PR DESCRIPTION
    //
    // If the time units were not set in the config or the configuration not loaded
    // we will attempt to use the System property. This is to allow some classes
    // which depend on other constants in this class to still work even though no
    // Warp 10 config was loaded. Before introducing this the lack of Warp 10 configuration
    // would trigger a RuntimeException reporting missing time units and attempts to
    // access any other constant from this class would throw a NoClassDefFoundException.
    // Adding support for reading time units from system properties 
    //
