### PR TITLE
Plasma.handler.interface

### DIFF
--- a/warp10/src/main/java/io/warp10/script/functions/EVAL.java
+++ b/warp10/src/main/java/io/warp10/script/functions/EVAL.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2020  SenX S.A.S.
+//   Copyright 2018-2022  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -23,15 +23,15 @@ import io.warp10.script.WarpScriptStack;
 import io.warp10.script.WarpScriptStack.Macro;
 
 public class EVAL extends NamedWarpScriptFunction implements WarpScriptStackFunction {
-  
+
   public EVAL(String name) {
     super(name);
   }
-  
+
   @Override
   public Object apply(WarpScriptStack stack) throws WarpScriptException {
     Object o = stack.pop();
-    
+
     if (o instanceof String) {
       // Execute single statement which may span multiple lines
       stack.execMulti((String) o);
@@ -40,7 +40,7 @@ public class EVAL extends NamedWarpScriptFunction implements WarpScriptStackFunc
     } else if (o instanceof WarpScriptStackFunction) {
       ((WarpScriptStackFunction) o).apply(stack);
     } else {
-      throw new WarpScriptException(getName() + " expects a Macro, a function of a String.");
+      throw new WarpScriptException(getName() + " expects a Macro, a function or a String.");
     }
     return stack;
   }

--- a/warp10/src/main/java/io/warp10/script/functions/REPORT.java
+++ b/warp10/src/main/java/io/warp10/script/functions/REPORT.java
@@ -65,7 +65,6 @@ public class REPORT extends NamedWarpScriptFunction implements WarpScriptStackFu
 
     if (defaultSecret.equals(SECRET)) {
       LOG.info("REPORT secret not set, using '" + defaultSecret + "'.");
-      System.out.println("REPORT secret not set, using '" + defaultSecret + "'.");
     }
   }
 

--- a/warpscript/build.gradle
+++ b/warpscript/build.gradle
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2021  SenX S.A.S.
+//   Copyright 2018-2022  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -65,6 +65,7 @@ sourceSets {
             include 'io/warp10/hadoop/**'
             include 'io/warp10/standalone/AcceleratorConfig.*'
             include 'io/warp10/standalone/AcceleratorConfig$*.*'
+            include 'io/warp10/standalone/StandalonePlasmaHandlerInterface.*'
 
             srcDir new File(project(':warp10').projectDir, "src/generated/thrift/gen-java")
             include 'io/warp10/continuum/thrift/data/**'


### PR DESCRIPTION
The StoreClient interface has a method addPlasmaHandler which takes as parameter an interface which is not exported in the WarpScript jar. This prevents plugins from defining StoreClients. This PR exports this interface.