### PR TITLE
Added support for macro placeholder in repo URLs

### DIFF
--- a/etc/conf.templates/distributed/20-warpfleet.conf.template
+++ b/etc/conf.templates/distributed/20-warpfleet.conf.template
@@ -1,5 +1,5 @@
 //
-//   Copyright 2019  SenX S.A.S.
+//   Copyright 2019-2022  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 //
 
 // Comma separated list of default WarpFleet™ repositories
-warpfleet.macros.repos = https://warpfleet.senx.io/macros
+warpfleet.macros.repos = https://warpfleet.senx.io/macros/{macro}
 
 // Read timeout when fetching macro source code from a repository, in ms. Defaults to 10s.
 #warpfleet.timeout.read =

--- a/etc/conf.templates/standalone/20-warpfleet.conf.template
+++ b/etc/conf.templates/standalone/20-warpfleet.conf.template
@@ -1,5 +1,5 @@
 //
-//   Copyright 2019  SenX S.A.S.
+//   Copyright 2019-2022  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 //
 
 // Comma separated list of default WarpFleet™ repositories
-warpfleet.macros.repos = https://warpfleet.senx.io/macros
+warpfleet.macros.repos = https://warpfleet.senx.io/macros/{macro}
 
 // Read timeout when fetching macro source code from a repository, in ms. Defaults to 10s.
 #warpfleet.timeout.read =

--- a/warp10/src/main/java/io/warp10/script/WarpFleetMacroRepository.java
+++ b/warp10/src/main/java/io/warp10/script/WarpFleetMacroRepository.java
@@ -60,6 +60,8 @@ public class WarpFleetMacroRepository {
   private static final ADD ADD_FUNC = new ADD(WarpScriptLib.ADD);
   private static final HUMANDURATION HUMANDURATION_FUNC = new HUMANDURATION(WarpScriptLib.HUMANDURATION);
 
+  private static final String MACRO_PLACEHOLDER = "{macro}";
+
   private static final int FINGERPRINT_UNKNOWN = -1;
 
   /**
@@ -180,7 +182,11 @@ public class WarpFleetMacroRepository {
         // Check the macro cache
         //
 
-        macroURL = repo + (repo.endsWith("/") ? "" : "/") + name;
+        if (repo.contains(MACRO_PLACEHOLDER)) {
+          macroURL = repo.replace(MACRO_PLACEHOLDER, name + ".mc2");
+        } else {
+          macroURL = repo + (repo.endsWith("/") ? "" : "/") + name + ".mc2";
+        }
 
         synchronized(macros) {
           macro = macros.get(macroURL);
@@ -216,7 +222,7 @@ public class WarpFleetMacroRepository {
 
         try {
           hconn = null;
-          URL url = new URL(macroURL + ".mc2");
+          URL url = new URL(macroURL);
           URLConnection conn = url.openConnection();
 
           if (conn instanceof HttpURLConnection) {


### PR DESCRIPTION
Some URLs may require parameters which would need to appear after the macro name. This PR adds the possibility to specify a macro placeholder '{macro}' in the repo URLs. If present, the macro path will be inserted where the placeholder is thus allowing for URLs of the type:

http://host/path/to/root/{macro}?param=foo