### PR TITLE
allow double for limits related functions

### DIFF
--- a/warp10/src/main/java/io/warp10/script/functions/LIMIT.java
+++ b/warp10/src/main/java/io/warp10/script/functions/LIMIT.java
@@ -39,8 +39,8 @@ public class LIMIT extends NamedWarpScriptFunction implements WarpScriptStackFun
     
     Object top = stack.pop();
     
-    if (!(top instanceof Long)) {
-      throw new WarpScriptException(getName() + " expects a numeric (long) limit.");
+    if (!(top instanceof Number)) {
+      throw new WarpScriptException(getName() + " expects a numeric limit.");
     }
     
     long limit = ((Number) top).longValue();

--- a/warp10/src/main/java/io/warp10/script/functions/MAXBUCKETS.java
+++ b/warp10/src/main/java/io/warp10/script/functions/MAXBUCKETS.java
@@ -39,8 +39,8 @@ public class MAXBUCKETS extends NamedWarpScriptFunction implements WarpScriptSta
     
     Object top = stack.pop();
     
-    if (!(top instanceof Long)) {
-      throw new WarpScriptException(getName() + " expects a numeric (long) limit.");
+    if (!(top instanceof Number)) {
+      throw new WarpScriptException(getName() + " expects a numeric limit.");
     }
     
     long limit = ((Number) top).longValue();

--- a/warp10/src/main/java/io/warp10/script/functions/MAXDEPTH.java
+++ b/warp10/src/main/java/io/warp10/script/functions/MAXDEPTH.java
@@ -39,8 +39,8 @@ public class MAXDEPTH extends NamedWarpScriptFunction implements WarpScriptStack
     
     Object top = stack.pop();
         
-    if (!(top instanceof Long)) {
-      throw new WarpScriptException(getName() + " expects a numeric (long) limit.");
+    if (!(top instanceof Number)) {
+      throw new WarpScriptException(getName() + " expects a numeric limit.");
     }
     
     long limit = ((Number) top).longValue();

--- a/warp10/src/main/java/io/warp10/script/functions/MAXGEOCELLS.java
+++ b/warp10/src/main/java/io/warp10/script/functions/MAXGEOCELLS.java
@@ -39,8 +39,8 @@ public class MAXGEOCELLS extends NamedWarpScriptFunction implements WarpScriptSt
     
     Object top = stack.pop();
     
-    if (!(top instanceof Long)) {
-      throw new WarpScriptException(getName() + " expects a numeric (long) limit.");
+    if (!(top instanceof Number)) {
+      throw new WarpScriptException(getName() + " expects a numeric limit.");
     }
     
     long limit = ((Number) top).longValue();

--- a/warp10/src/main/java/io/warp10/script/functions/MAXGTS.java
+++ b/warp10/src/main/java/io/warp10/script/functions/MAXGTS.java
@@ -39,8 +39,8 @@ public class MAXGTS extends NamedWarpScriptFunction implements WarpScriptStackFu
     
     Object top = stack.pop();
     
-    if (!(top instanceof Long)) {
-      throw new WarpScriptException(getName() + " expects a numeric (long) limit.");
+    if (!(top instanceof Number)) {
+      throw new WarpScriptException(getName() + " expects a numeric limit.");
     }
     
     long limit = ((Number) top).longValue();

--- a/warp10/src/main/java/io/warp10/script/functions/MAXJSON.java
+++ b/warp10/src/main/java/io/warp10/script/functions/MAXJSON.java
@@ -39,8 +39,8 @@ public class MAXJSON extends NamedWarpScriptFunction implements WarpScriptStackF
     
     Object top = stack.pop();
     
-    if (!(top instanceof Long)) {
-      throw new WarpScriptException(getName() + " expects a numeric (long) limit.");
+    if (!(top instanceof Number)) {
+      throw new WarpScriptException(getName() + " expects a numeric limit.");
     }
     
     long limit = ((Number) top).longValue();

--- a/warp10/src/main/java/io/warp10/script/functions/MAXLOOP.java
+++ b/warp10/src/main/java/io/warp10/script/functions/MAXLOOP.java
@@ -39,8 +39,8 @@ public class MAXLOOP extends NamedWarpScriptFunction implements WarpScriptStackF
     
     Object top = stack.pop();
     
-    if (!(top instanceof Long)) {
-      throw new WarpScriptException(getName() + " expects a numeric (long) limit.");
+    if (!(top instanceof Number)) {
+      throw new WarpScriptException(getName() + " expects a numeric limit.");
     }
     
     long limit = ((Number) top).longValue();

--- a/warp10/src/main/java/io/warp10/script/functions/MAXOPS.java
+++ b/warp10/src/main/java/io/warp10/script/functions/MAXOPS.java
@@ -39,8 +39,8 @@ public class MAXOPS extends NamedWarpScriptFunction implements WarpScriptStackFu
     
     Object top = stack.pop();
     
-    if (!(top instanceof Long)) {
-      throw new WarpScriptException(getName() + " expects a numeric (long) limit.");
+    if (!(top instanceof Number)) {
+      throw new WarpScriptException(getName() + " expects a numeric limit.");
     }
     
     long limit = ((Number) top).longValue();

--- a/warp10/src/main/java/io/warp10/script/functions/MAXPIXELS.java
+++ b/warp10/src/main/java/io/warp10/script/functions/MAXPIXELS.java
@@ -39,8 +39,8 @@ public class MAXPIXELS extends NamedWarpScriptFunction implements WarpScriptStac
     
     Object top = stack.pop();
     
-    if (!(top instanceof Long)) {
-      throw new WarpScriptException(getName() + " expects a numeric (long) limit.");
+    if (!(top instanceof Number)) {
+      throw new WarpScriptException(getName() + " expects a numeric limit.");
     }
     
     long limit = ((Number) top).longValue();

--- a/warp10/src/main/java/io/warp10/script/functions/MAXRECURSION.java
+++ b/warp10/src/main/java/io/warp10/script/functions/MAXRECURSION.java
@@ -39,8 +39,8 @@ public class MAXRECURSION extends NamedWarpScriptFunction implements WarpScriptS
     
     Object top = stack.pop();
     
-    if (!(top instanceof Long)) {
-      throw new WarpScriptException(getName() + " expects a numeric (long) limit.");
+    if (!(top instanceof Number)) {
+      throw new WarpScriptException(getName() + " expects a numeric limit.");
     }
     
     long limit = ((Number) top).longValue();

--- a/warp10/src/main/java/io/warp10/script/functions/MAXSYMBOLS.java
+++ b/warp10/src/main/java/io/warp10/script/functions/MAXSYMBOLS.java
@@ -39,8 +39,8 @@ public class MAXSYMBOLS extends NamedWarpScriptFunction implements WarpScriptSta
     
     Object top = stack.pop();
     
-    if (!(top instanceof Long)) {
-      throw new WarpScriptException(getName() + " expects a numeric (long) limit.");
+    if (!(top instanceof Number)) {
+      throw new WarpScriptException(getName() + " expects a numeric limit.");
     }
     
     long limit = ((Number) top).longValue();


### PR DESCRIPTION
```
10e6 MAXOPS
```
more easy to read scientific notation for big numbers. fixed for all limit related function.