### PR TITLE
Remove outputs.file for tasks generateChangelog

### DIFF
--- a/warp10/build.gradle
+++ b/warp10/build.gradle
@@ -226,7 +226,6 @@ task generateChangelog(type: Exec) {
     standardOutput = new ByteArrayOutputStream()
 
     File changelogFile = new File(project.parent.projectDir, "CHANGELOG.md")
-    outputs.file changelogFile
 
     doLast {
         changelogFile.write("# Warp 10 Changelog\n")


### PR DESCRIPTION
Remove outputs.file definition to always run generateChanglog (no UP-TO-DATE state)