### PR TITLE
Bootstrap shell check

### DIFF
--- a/warp10/src/main/java/io/warp10/continuum/egress/EgressFetchHandler.java
+++ b/warp10/src/main/java/io/warp10/continuum/egress/EgressFetchHandler.java
@@ -178,6 +178,12 @@ public class EgressFetchHandler extends AbstractHandler {
 
       resp.setHeader("Access-Control-Allow-Origin", "*");
 
+      //
+      // Add header with the platform time unit
+      //
+
+      resp.setHeader(Constants.HTTP_HEADER_TIMEUNIT, Long.toString(Constants.TIME_UNITS_PER_S));
+
       long now = Long.MIN_VALUE;
       long then = Long.MIN_VALUE;
       long gcount = Long.MAX_VALUE;

--- a/warp10/src/main/java/io/warp10/continuum/store/Constants.java
+++ b/warp10/src/main/java/io/warp10/continuum/store/Constants.java
@@ -124,6 +124,11 @@ public class Constants {
   private static final Map<String,String> HEADERS = new HashMap<String,String>();
 
   /**
+   * Header to indicate the platform time unit (in time units per second)
+   */
+  public static final String HTTP_HEADER_TIMEUNIT = "X-Warp10-Timeunit";
+
+  /**
    * Header to set to enable line numbering
    */
   public static final String HTTP_HEADER_LINES = "X-Warp10-Lines";

--- a/warp10/src/main/sh/warp10-standalone.sh
+++ b/warp10/src/main/sh/warp10-standalone.sh
@@ -228,6 +228,16 @@ bootstrap() {
   fi
 
   #
+  # Make sure warp10 user is not using another shell that does unexpected expansion
+  #
+  WARP10_USER_SHELL=$(su ${WARP10_USER} -c 'echo $SHELL')
+  if [[ $WARP10_USER_SHELL != *"/bash" ]]; then
+    echo "ERROR: ${WARP10_USER} user is not using bash as default shell. Please fix this manually with:"
+    echo " sudo chsh -s /bin/bash ${WARP10_USER}"
+    exit 1
+  fi
+
+  #
   # If config file already exists then.. exit
   #
   getConfigFiles


### PR DESCRIPTION
When a user create warp10 user manually, it may set zsh or another default shell. 
Globbing and expansion will then fail during bootstrap.

