### PR TITLE
uniform support of empty buckets among available mappers

### DIFF
--- a/warp10/src/main/java/io/warp10/script/mapper/MapperAbs.java
+++ b/warp10/src/main/java/io/warp10/script/mapper/MapperAbs.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2020  SenX S.A.S.
+//   Copyright 2018-2022  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -39,6 +39,10 @@ public class MapperAbs extends NamedWarpScriptFunction implements WarpScriptMapp
     long[] elevations = (long[]) args[5];
     Object[] values = (Object[]) args[6];
 
+    if (0 == values.length) {
+      return new Object[] {0L, GeoTimeSerie.NO_LOCATION, GeoTimeSerie.NO_ELEVATION, null};
+    }
+    
     if (values.length > 1) {
       throw new WarpScriptException(getName() + " can only be applied to a single value.");
     }

--- a/warp10/src/main/java/io/warp10/script/mapper/MapperCeil.java
+++ b/warp10/src/main/java/io/warp10/script/mapper/MapperCeil.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2020  SenX S.A.S.
+//   Copyright 2018-2022  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.warp10.script.mapper;
 
+import io.warp10.continuum.gts.GeoTimeSerie;
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptMapperFunction;
 import io.warp10.script.WarpScriptException;
@@ -38,6 +39,10 @@ public class MapperCeil extends NamedWarpScriptFunction implements WarpScriptMap
     long[] elevations = (long[]) args[5];
     Object[] values = (Object[]) args[6];
 
+    if (0 == values.length) {
+      return new Object[] {0L, GeoTimeSerie.NO_LOCATION, GeoTimeSerie.NO_ELEVATION, null};
+    }
+    
     if (1 != values.length) {
       throw new WarpScriptException(getName() + " can only be applied to a single value.");
     }

--- a/warp10/src/main/java/io/warp10/script/mapper/MapperDateTime.java
+++ b/warp10/src/main/java/io/warp10/script/mapper/MapperDateTime.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2020  SenX S.A.S.
+//   Copyright 2022  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.warp10.script.mapper;
 
+import io.warp10.continuum.gts.GeoTimeSerie;
 import io.warp10.continuum.store.Constants;
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.StackUtils;
@@ -44,6 +45,15 @@ public abstract class MapperDateTime extends NamedWarpScriptFunction implements 
     long tick = (long) args[0];
     long[] locations = (long[]) args[4];
     long[] elevations = (long[]) args[5];
+    Object[] values = (Object[]) args[6];
+
+    if (0 == values.length) {
+      return new Object[] {0L, GeoTimeSerie.NO_LOCATION, GeoTimeSerie.NO_ELEVATION, null};
+    }
+
+    if (1 != values.length) {
+      throw new WarpScriptException(getName() + " can only be applied to a single value.");
+    }
 
     long location = locations[0];
     long elevation = elevations[0];

--- a/warp10/src/main/java/io/warp10/script/mapper/MapperFinite.java
+++ b/warp10/src/main/java/io/warp10/script/mapper/MapperFinite.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2020  SenX S.A.S.
+//   Copyright 2018-2022  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package io.warp10.script.mapper;
 
 import io.warp10.DoubleUtils;
+import io.warp10.continuum.gts.GeoTimeSerie;
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptMapperFunction;
 import io.warp10.script.WarpScriptException;
@@ -39,6 +40,10 @@ public class MapperFinite extends NamedWarpScriptFunction implements WarpScriptM
     long[] elevations = (long[]) args[5];
     Object[] values = (Object[]) args[6];
 
+    if (0 == values.length) {
+      return new Object[] {0L, GeoTimeSerie.NO_LOCATION, GeoTimeSerie.NO_ELEVATION, null};
+    }
+    
     if (1 != values.length) {
       throw new WarpScriptException(getName() + " can only be applied to a single value.");
     }

--- a/warp10/src/main/java/io/warp10/script/mapper/MapperFloor.java
+++ b/warp10/src/main/java/io/warp10/script/mapper/MapperFloor.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2020  SenX S.A.S.
+//   Copyright 2018-2022  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.warp10.script.mapper;
 
+import io.warp10.continuum.gts.GeoTimeSerie;
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptMapperFunction;
 import io.warp10.script.WarpScriptException;
@@ -38,6 +39,10 @@ public class MapperFloor extends NamedWarpScriptFunction implements WarpScriptMa
     long[] elevations = (long[]) args[5];
     Object[] values = (Object[]) args[6];
 
+    if (0 == values.length) {
+      return new Object[] {0L, GeoTimeSerie.NO_LOCATION, GeoTimeSerie.NO_ELEVATION, null};
+    }
+    
     if (1 != values.length) {
       throw new WarpScriptException(getName() + " can only be applied to a single value.");
     }

--- a/warp10/src/main/java/io/warp10/script/mapper/MapperGeoClearPosition.java
+++ b/warp10/src/main/java/io/warp10/script/mapper/MapperGeoClearPosition.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2020  SenX S.A.S.
+//   Copyright 2018-2022  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -37,6 +37,10 @@ public class MapperGeoClearPosition extends NamedWarpScriptFunction implements W
     long tick = (long) args[0];
     Object[] values = (Object[]) args[6];
 
+    if (0 == values.length) {
+      return new Object[] {0L, GeoTimeSerie.NO_LOCATION, GeoTimeSerie.NO_ELEVATION, null};
+    }
+    
     if (1 != values.length) {
       throw new WarpScriptException(getName() + " can only be applied to a single value.");
     }

--- a/warp10/src/main/java/io/warp10/script/mapper/MapperGeoElevation.java
+++ b/warp10/src/main/java/io/warp10/script/mapper/MapperGeoElevation.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2020  SenX S.A.S.
+//   Copyright 2018-2022  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -38,6 +38,10 @@ public class MapperGeoElevation extends NamedWarpScriptFunction implements WarpS
     long[] elevations = (long[]) args[5];
     Object[] values = (Object[]) args[6];
 
+    if (0 == values.length) {
+      return new Object[] {0L, GeoTimeSerie.NO_LOCATION, GeoTimeSerie.NO_ELEVATION, null};
+    }
+    
     if (1 != values.length) {
       throw new WarpScriptException(getName() + " can only be applied to a single value.");
     }

--- a/warp10/src/main/java/io/warp10/script/mapper/MapperGeoLatitude.java
+++ b/warp10/src/main/java/io/warp10/script/mapper/MapperGeoLatitude.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2020  SenX S.A.S.
+//   Copyright 2018-2022  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -40,6 +40,10 @@ public class MapperGeoLatitude extends NamedWarpScriptFunction implements WarpSc
     long[] locations = (long[]) args[4];
     Object[] values = (Object[]) args[6];
 
+    if (0 == values.length) {
+      return new Object[] {0L, GeoTimeSerie.NO_LOCATION, GeoTimeSerie.NO_ELEVATION, null};
+    }
+    
     if (1 != values.length) {
       throw new WarpScriptException(getName() + " can only be applied to a single value.");
     }

--- a/warp10/src/main/java/io/warp10/script/mapper/MapperGeoLongitude.java
+++ b/warp10/src/main/java/io/warp10/script/mapper/MapperGeoLongitude.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2020  SenX S.A.S.
+//   Copyright 2018-2022  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -40,6 +40,10 @@ public class MapperGeoLongitude extends NamedWarpScriptFunction implements WarpS
     long[] locations = (long[]) args[4];
     Object[] values = (Object[]) args[6];
 
+    if (0 == values.length) {
+      return new Object[] {0L, GeoTimeSerie.NO_LOCATION, GeoTimeSerie.NO_ELEVATION, null};
+    }
+    
     if (1 != values.length) {
       throw new WarpScriptException(getName() + " can only be applied to a single value.");
     }

--- a/warp10/src/main/java/io/warp10/script/mapper/MapperMaxX.java
+++ b/warp10/src/main/java/io/warp10/script/mapper/MapperMaxX.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2020  SenX S.A.S.
+//   Copyright 2018-2022  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.warp10.script.mapper;
 
+import io.warp10.continuum.gts.GeoTimeSerie;
 import io.warp10.continuum.gts.GeoTimeSerie.TYPE;
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.StackUtils;
@@ -74,6 +75,10 @@ public class MapperMaxX extends NamedWarpScriptFunction implements WarpScriptMap
     long[] elevations = (long[]) args[5];
     Object[] values = (Object[]) args[6];
 
+    if (0 == values.length) {
+      return new Object[] {0L, GeoTimeSerie.NO_LOCATION, GeoTimeSerie.NO_ELEVATION, null};
+    }
+    
     if (1 != values.length) {
       throw new WarpScriptException(getName() + " can only be applied to a single value.");
     }

--- a/warp10/src/main/java/io/warp10/script/mapper/MapperMinX.java
+++ b/warp10/src/main/java/io/warp10/script/mapper/MapperMinX.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2020  SenX S.A.S.
+//   Copyright 2018-2022  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.warp10.script.mapper;
 
+import io.warp10.continuum.gts.GeoTimeSerie;
 import io.warp10.continuum.gts.GeoTimeSerie.TYPE;
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.StackUtils;
@@ -75,6 +76,10 @@ public class MapperMinX extends NamedWarpScriptFunction implements WarpScriptMap
     long[] elevations = (long[]) args[5];
     Object[] values = (Object[]) args[6];
 
+    if (0 == values.length) {
+      return new Object[] {0L, GeoTimeSerie.NO_LOCATION, GeoTimeSerie.NO_ELEVATION, null};
+    }
+    
     if (1 != values.length) {
       throw new WarpScriptException(getName() + " can only be applied to a single value.");
     }

--- a/warp10/src/main/java/io/warp10/script/mapper/MapperMod.java
+++ b/warp10/src/main/java/io/warp10/script/mapper/MapperMod.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2020  SenX S.A.S.
+//   Copyright 2018-2022  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.warp10.script.mapper;
 
+import io.warp10.continuum.gts.GeoTimeSerie;
 import io.warp10.continuum.gts.GeoTimeSerie.TYPE;
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.StackUtils;
@@ -75,6 +76,10 @@ public class MapperMod extends NamedWarpScriptFunction implements WarpScriptMapp
     long[] elevations = (long[]) args[5];
     Object[] values = (Object[]) args[6];
 
+    if (0 == values.length) {
+      return new Object[] {0L, GeoTimeSerie.NO_LOCATION, GeoTimeSerie.NO_ELEVATION, null};
+    }
+    
     if (1 != values.length) {
       throw new WarpScriptException(getName() + " can only be applied to a single value.");
     }

--- a/warp10/src/main/java/io/warp10/script/mapper/MapperNPDF.java
+++ b/warp10/src/main/java/io/warp10/script/mapper/MapperNPDF.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2020  SenX S.A.S.
+//   Copyright 2018-2022  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.warp10.script.mapper;
 
+import io.warp10.continuum.gts.GeoTimeSerie;
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.StackUtils;
 import io.warp10.script.WarpScriptMapperFunction;
@@ -76,6 +77,10 @@ public class MapperNPDF extends NamedWarpScriptFunction implements WarpScriptMap
     long[] elevations = (long[]) args[5];
     Object[] values = (Object[]) args[6];
 
+    if (0 == values.length) {
+      return new Object[] {0L, GeoTimeSerie.NO_LOCATION, GeoTimeSerie.NO_ELEVATION, null};
+    }
+    
     if (1 != values.length) {
       throw new WarpScriptException(getName() + " can only be applied to a single value.");
     }

--- a/warp10/src/main/java/io/warp10/script/mapper/MapperParseDouble.java
+++ b/warp10/src/main/java/io/warp10/script/mapper/MapperParseDouble.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2020  SenX S.A.S.
+//   Copyright 2018-2022  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.warp10.script.mapper;
 
+import io.warp10.continuum.gts.GeoTimeSerie;
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptMapperFunction;
 import io.warp10.script.WarpScriptStack;
@@ -80,6 +81,10 @@ public class MapperParseDouble extends NamedWarpScriptFunction implements WarpSc
     long[] elevations = (long[]) args[5];
     Object[] values = (Object[]) args[6];
 
+    if (0 == values.length) {
+      return new Object[] {0L, GeoTimeSerie.NO_LOCATION, GeoTimeSerie.NO_ELEVATION, null};
+    }
+    
     if (1 != values.length) {
       throw new WarpScriptException(getName() + " can only be applied to a single value.");
     }

--- a/warp10/src/main/java/io/warp10/script/mapper/MapperRegExpReplace.java
+++ b/warp10/src/main/java/io/warp10/script/mapper/MapperRegExpReplace.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2021  SenX S.A.S.
+//   Copyright 2021-2022  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.warp10.script.mapper;
 
+import io.warp10.continuum.gts.GeoTimeSerie;
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptMapperFunction;
@@ -79,6 +80,10 @@ public class MapperRegExpReplace extends NamedWarpScriptFunction implements Warp
     long[] elevations = (long[]) args[5];
     Object[] values = (Object[]) args[6];
 
+    if (0 == values.length) {
+      return new Object[] {0L, GeoTimeSerie.NO_LOCATION, GeoTimeSerie.NO_ELEVATION, null};
+    }
+    
     if (values.length > 1) {
       throw new WarpScriptException(getName() + " can only be applied to a single value.");
     }

--- a/warp10/src/main/java/io/warp10/script/mapper/MapperRound.java
+++ b/warp10/src/main/java/io/warp10/script/mapper/MapperRound.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2020  SenX S.A.S.
+//   Copyright 2018-2022  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.warp10.script.mapper;
 
+import io.warp10.continuum.gts.GeoTimeSerie;
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptMapperFunction;
 import io.warp10.script.WarpScriptException;
@@ -38,6 +39,10 @@ public class MapperRound extends NamedWarpScriptFunction implements WarpScriptMa
     long[] elevations = (long[]) args[5];
     Object[] values = (Object[]) args[6];
 
+    if (0 == values.length) {
+      return new Object[] {0L, GeoTimeSerie.NO_LOCATION, GeoTimeSerie.NO_ELEVATION, null};
+    }
+    
     if (1 != values.length) {
       throw new WarpScriptException(getName() + " can only be applied to a single value.");
     }

--- a/warp10/src/main/java/io/warp10/script/mapper/MapperTick.java
+++ b/warp10/src/main/java/io/warp10/script/mapper/MapperTick.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2020  SenX S.A.S.
+//   Copyright 2018-2022  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.warp10.script.mapper;
 
+import io.warp10.continuum.gts.GeoTimeSerie;
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptMapperFunction;
 import io.warp10.script.WarpScriptStackFunction;
@@ -51,6 +52,10 @@ public class MapperTick extends NamedWarpScriptFunction implements WarpScriptMap
     long[] elevations = (long[]) args[5];
     Object[] values = (Object[]) args[6];
 
+    if (0 == values.length) {
+      return new Object[] {0L, GeoTimeSerie.NO_LOCATION, GeoTimeSerie.NO_ELEVATION, null};
+    }
+    
     if (1 != values.length) {
       throw new WarpScriptException(getName() + " can only be applied to a single value.");
     }

--- a/warp10/src/main/java/io/warp10/script/mapper/MapperToBoolean.java
+++ b/warp10/src/main/java/io/warp10/script/mapper/MapperToBoolean.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2020  SenX S.A.S.
+//   Copyright 2018-2022  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.warp10.script.mapper;
 
+import io.warp10.continuum.gts.GeoTimeSerie;
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptMapperFunction;
 import io.warp10.script.WarpScriptException;
@@ -38,6 +39,9 @@ public class MapperToBoolean extends NamedWarpScriptFunction implements WarpScri
     long[] elevations = (long[]) args[5];
     Object[] values = (Object[]) args[6];
 
+    if (0 == values.length) {
+      return new Object[] {0L, GeoTimeSerie.NO_LOCATION, GeoTimeSerie.NO_ELEVATION, null};
+    }
     if (1 != values.length) {
       throw new WarpScriptException(getName() + " can only be applied to a single value.");
     }

--- a/warp10/src/main/java/io/warp10/script/mapper/MapperToDouble.java
+++ b/warp10/src/main/java/io/warp10/script/mapper/MapperToDouble.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2020  SenX S.A.S.
+//   Copyright 2018-2022  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.warp10.script.mapper;
 
+import io.warp10.continuum.gts.GeoTimeSerie;
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptMapperFunction;
 import io.warp10.script.WarpScriptException;
@@ -38,6 +39,9 @@ public class MapperToDouble extends NamedWarpScriptFunction implements WarpScrip
     long[] elevations = (long[]) args[5];
     Object[] values = (Object[]) args[6];
 
+    if (0 == values.length) {
+      return new Object[] {0L, GeoTimeSerie.NO_LOCATION, GeoTimeSerie.NO_ELEVATION, null};
+    }
     if (1 != values.length) {
       throw new WarpScriptException(getName() + " can only be applied to a single value.");
     }

--- a/warp10/src/main/java/io/warp10/script/mapper/MapperToLong.java
+++ b/warp10/src/main/java/io/warp10/script/mapper/MapperToLong.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2020  SenX S.A.S.
+//   Copyright 2018-2022  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.warp10.script.mapper;
 
+import io.warp10.continuum.gts.GeoTimeSerie;
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptMapperFunction;
 import io.warp10.script.WarpScriptException;
@@ -38,6 +39,10 @@ public class MapperToLong extends NamedWarpScriptFunction implements WarpScriptM
     long[] elevations = (long[]) args[5];
     Object[] values = (Object[]) args[6];
 
+    if (0 == values.length) {
+      return new Object[] {0L, GeoTimeSerie.NO_LOCATION, GeoTimeSerie.NO_ELEVATION, null};
+    }
+    
     if (1 != values.length) {
       throw new WarpScriptException(getName() + " can only be applied to a single value.");
     }

--- a/warp10/src/main/java/io/warp10/script/mapper/MapperToString.java
+++ b/warp10/src/main/java/io/warp10/script/mapper/MapperToString.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2020  SenX S.A.S.
+//   Copyright 2018-2022  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.warp10.script.mapper;
 
+import io.warp10.continuum.gts.GeoTimeSerie;
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptMapperFunction;
 import io.warp10.script.WarpScriptException;
@@ -38,6 +39,10 @@ public class MapperToString extends NamedWarpScriptFunction implements WarpScrip
     long[] elevations = (long[]) args[5];
     Object[] values = (Object[]) args[6];
 
+    if (0 == values.length) {
+      return new Object[] {0L, GeoTimeSerie.NO_LOCATION, GeoTimeSerie.NO_ELEVATION, null};
+    }
+    
     if (1 != values.length) {
       throw new WarpScriptException(getName() + " can only be applied to a single value.");
     }


### PR DESCRIPTION
Some mappers did support empty buckets, some failed with `can only be applied to a single value` error message. This was confusing, as the error message leads to DEDUP, not to UNBUCKETIZE.



