### PR TITLE
make sure FETCH will handle unmodifiable label map

### DIFF
--- a/warp10/src/main/java/io/warp10/script/functions/FETCH.java
+++ b/warp10/src/main/java/io/warp10/script/functions/FETCH.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2021  SenX S.A.S.
+//   Copyright 2018-2022  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -451,7 +451,7 @@ public class FETCH extends NamedWarpScriptFunction implements WarpScriptStackFun
       } else {
         clsSels.add(params.get(PARAM_CLASS).toString());
 
-        Map<String,String> labelSelectors = (Map<String,String>) params.get(PARAM_LABELS);
+        Map<String, String> labelSelectors = new LinkedHashMap<>((Map<String, String>) params.get(PARAM_LABELS));
         labelSelectors.remove(Constants.PRODUCER_LABEL);
         labelSelectors.remove(Constants.OWNER_LABEL);
         labelSelectors.remove(Constants.APPLICATION_LABEL);


### PR DESCRIPTION
Fix a bug when using labels presented by MACROMAPPER for example (unmodifiable map). There is no clean way to test if the input is an instance of unmodifiablemap, the only way is to catch the unsupported operation, or to clone the object.
