### PR TITLE
check if MAP ticks input are sorted instead of sorting them

### DIFF
--- a/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
+++ b/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
@@ -5691,8 +5691,12 @@ public class GTSHelper {
         if (reversed) {
           boolean descending = true;
           int i = 1;
+          long lastElt = outputTicks.get(0);
+          long elt;
           while (i < outputTicks.size() && descending) {
-            descending = outputTicks.get(i) <= outputTicks.get(i - 1);
+            elt = outputTicks.get(i);
+            descending = elt <= lastElt;
+            lastElt = elt;
             i++;
           }
           if (!descending) {
@@ -5701,8 +5705,12 @@ public class GTSHelper {
         } else {
           boolean ascending = true;
           int i = 1;
+          long lastElt = outputTicks.get(0);
+          long elt;
           while (i < outputTicks.size() && ascending) {
-            ascending = outputTicks.get(i) >= outputTicks.get(i - 1);
+            elt = outputTicks.get(i);
+            ascending = elt >= lastElt;
+            lastElt = elt;
             i++;
           }
           if (!ascending) {

--- a/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
+++ b/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
@@ -5684,12 +5684,31 @@ public class GTSHelper {
     // Retrieve ticks if GTS is not bucketized.
     long[] ticks = isBucketized(gts) ? null : Arrays.copyOf(mapped.ticks, gts.values);
 
-    // Sort outputTicks
+    // Check if outputTicks is correctly sorted
+    // In case of a concurrent execution, sorting outputTicks here will lead to a ConcurrentModificationException
     if (null != outputTicks) {
-      if (reversed) {
-        Collections.sort(outputTicks, Collections.<Long>reverseOrder());
-      } else {
-        Collections.sort(outputTicks);
+      if (outputTicks.size() > 1) {
+        if (reversed) {
+          boolean descending = true;
+          int i = 1;
+          while (i < outputTicks.size() && descending) {
+            descending = outputTicks.get(i) <= outputTicks.get(i - 1);
+            i++;
+          }
+          if (!descending) {
+            throw new WarpScriptException("The tick list must be reverse sorted.");
+          }
+        } else {
+          boolean ascending = true;
+          int i = 1;
+          while (i < outputTicks.size() && ascending) {
+            ascending = outputTicks.get(i) >= outputTicks.get(i - 1);
+            i++;
+          }
+          if (!ascending) {
+            throw new WarpScriptException("The tick list must be sorted.");
+          }
+        }
       }
     }
 

--- a/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
+++ b/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2022  SenX S.A.S.
+//   Copyright 2018-2023  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -5604,6 +5604,18 @@ public class GTSHelper {
     unbucketize(gts);
   }
 
+  public static List<GeoTimeSerie> map(GeoTimeSerie gts, WarpScriptMapperFunction mapper, long prewindow, long postwindow, long occurrences, boolean reversed, int step, boolean overrideTick) throws WarpScriptException {
+    return map(gts, mapper, prewindow, postwindow, occurrences, reversed, step, overrideTick, null);
+  }
+
+  public static List<GeoTimeSerie> map(GeoTimeSerie gts, Object mapper, long prewindow, long postwindow, long occurrences, boolean reversed, int step, boolean overrideTick, WarpScriptStack stack) throws WarpScriptException {
+    return map(gts, mapper, prewindow, postwindow, occurrences, reversed, step, overrideTick, stack, null);
+  }
+
+  public static List<GeoTimeSerie> map(GeoTimeSerie gts, Object mapper, long prewindow, long postwindow, long occurrences, boolean reversed, int step, boolean overrideTick, WarpScriptStack stack,
+                                       List<Long> outputTicks) throws WarpScriptException {
+    return map(gts, mapper, prewindow, postwindow, occurrences, reversed, step, overrideTick, stack, outputTicks, false);
+  }
   /**
    * Apply a mapper on a GeoTimeSerie instance and produce a new
    * GTS instance with the result of the mapper application.
@@ -5620,23 +5632,11 @@ public class GTSHelper {
    *                    sums where the only result that might matter is that of the latest tick
    * @param reversed Compute ticks backwards, starting from most recent one
    * @param step How many ticks to move the sliding window after each mapper application (>=1)
+   * @param outputTicks Sorted list of ticks to use instead of the gts ticks (reverse sorted if <code>reversed</code> is true)
    * @param overrideTick If true, use the tick returned by the mapper instead of the current tick. This may lead to duplicate ticks, need to run DEDUP.
    *
    * @return A new GTS instance with the result of the Mapper.
    */
-  public static List<GeoTimeSerie> map(GeoTimeSerie gts, WarpScriptMapperFunction mapper, long prewindow, long postwindow, long occurrences, boolean reversed, int step, boolean overrideTick) throws WarpScriptException {
-    return map(gts, mapper, prewindow, postwindow, occurrences, reversed, step, overrideTick, null);
-  }
-
-  public static List<GeoTimeSerie> map(GeoTimeSerie gts, Object mapper, long prewindow, long postwindow, long occurrences, boolean reversed, int step, boolean overrideTick, WarpScriptStack stack) throws WarpScriptException {
-    return map(gts, mapper, prewindow, postwindow, occurrences, reversed, step, overrideTick, stack, null);
-  }
-
-  public static List<GeoTimeSerie> map(GeoTimeSerie gts, Object mapper, long prewindow, long postwindow, long occurrences, boolean reversed, int step, boolean overrideTick, WarpScriptStack stack,
-                                       List<Long> outputTicks) throws WarpScriptException {
-    return map(gts, mapper, prewindow, postwindow, occurrences, reversed, step, overrideTick, stack, outputTicks, false);
-  }
-
   public static List<GeoTimeSerie> map(GeoTimeSerie gts, Object mapper, long prewindow, long postwindow, long occurrences, boolean reversed, int step, boolean overrideTick, WarpScriptStack stack,
                                        List<Long> outputTicks, boolean dedup) throws WarpScriptException {
 
@@ -5683,42 +5683,6 @@ public class GTSHelper {
     sort(mapped, reversed);
     // Retrieve ticks if GTS is not bucketized.
     long[] ticks = isBucketized(gts) ? null : Arrays.copyOf(mapped.ticks, gts.values);
-
-    // Check if outputTicks is correctly sorted
-    // In case of a concurrent execution, sorting outputTicks here will lead to a ConcurrentModificationException
-    if (null != outputTicks) {
-      if (outputTicks.size() > 1) {
-        if (reversed) {
-          boolean descending = true;
-          int i = 1;
-          long lastElt = outputTicks.get(0);
-          long elt;
-          while (i < outputTicks.size() && descending) {
-            elt = outputTicks.get(i);
-            descending = elt <= lastElt;
-            lastElt = elt;
-            i++;
-          }
-          if (!descending) {
-            throw new WarpScriptException("The tick list must be reverse sorted.");
-          }
-        } else {
-          boolean ascending = true;
-          int i = 1;
-          long lastElt = outputTicks.get(0);
-          long elt;
-          while (i < outputTicks.size() && ascending) {
-            elt = outputTicks.get(i);
-            ascending = elt >= lastElt;
-            lastElt = elt;
-            i++;
-          }
-          if (!ascending) {
-            throw new WarpScriptException("The tick list must be sorted.");
-          }
-        }
-      }
-    }
 
     // Clear clone
     GTSHelper.clear(mapped);

--- a/warp10/src/main/java/io/warp10/script/functions/MAP.java
+++ b/warp10/src/main/java/io/warp10/script/functions/MAP.java
@@ -232,7 +232,7 @@ public class MAP extends NamedWarpScriptFunction implements WarpScriptStackFunct
             i++;
           }
           if (!descending) {
-            throw new WarpScriptException(getName() + " expects a reverse sorted list for "+ PARAM_OUTPUTTICKS + " parameter.");
+            throw new WarpScriptException(getName() + " expects a reverse sorted list for " + PARAM_OUTPUTTICKS + " parameter.");
           }
         } else {
           boolean ascending = true;
@@ -246,7 +246,7 @@ public class MAP extends NamedWarpScriptFunction implements WarpScriptStackFunct
             i++;
           }
           if (!ascending) {
-            throw new WarpScriptException(getName() + " expects a sorted list for "+ PARAM_OUTPUTTICKS + " parameter.");
+            throw new WarpScriptException(getName() + " expects a sorted list for " + PARAM_OUTPUTTICKS + " parameter.");
           }
         }
       }

--- a/warp10/src/main/java/io/warp10/script/functions/MAP.java
+++ b/warp10/src/main/java/io/warp10/script/functions/MAP.java
@@ -188,6 +188,7 @@ public class MAP extends NamedWarpScriptFunction implements WarpScriptStackFunct
     if (Long.MIN_VALUE == occurrences) {
       occurrences = Long.MIN_VALUE + 1;
     }
+    final boolean reversed = occurrences < 0;
 
     Object stepParam = params.get(PARAM_STEP);
     if (stepParam instanceof Long) {
@@ -205,7 +206,7 @@ public class MAP extends NamedWarpScriptFunction implements WarpScriptStackFunct
     }
 
     Object outputTicks = params.get(PARAM_OUTPUTTICKS);
-    // Make sure outputTicks is a List<Long>, and that it the list is sorted accordingly.
+    // Make sure outputTicks is a List<Long>, and that the list is sorted accordingly.
     if (null != outputTicks) {
       if (!(outputTicks instanceof List)) {
         throw new WarpScriptException(getName() + " expects '" + PARAM_OUTPUTTICKS + "' to be list of LONG values.");
@@ -217,9 +218,9 @@ public class MAP extends NamedWarpScriptFunction implements WarpScriptStackFunct
       }
 
       // Check if outputTicks is correctly sorted
-      // In case of a concurrent execution, sorting outputTicks here will lead to a ConcurrentModificationException
+      // In case of a concurrent execution, sorting outputTicks here would lead to a ConcurrentModificationException
       if (((List<Long>) outputTicks).size() > 1) {
-        if (occurrences < 0) { // reversed
+        if (reversed) { // reversed
           boolean descending = true;
           int i = 1;
           long lastElt = ((List<Long>) outputTicks).get(0);
@@ -231,7 +232,7 @@ public class MAP extends NamedWarpScriptFunction implements WarpScriptStackFunct
             i++;
           }
           if (!descending) {
-            throw new WarpScriptException("The tick list must be reverse sorted.");
+            throw new WarpScriptException(getName() + " expects a reverse sorted list for "+ PARAM_OUTPUTTICKS + " parameter.");
           }
         } else {
           boolean ascending = true;
@@ -245,7 +246,7 @@ public class MAP extends NamedWarpScriptFunction implements WarpScriptStackFunct
             i++;
           }
           if (!ascending) {
-            throw new WarpScriptException("The tick list must be sorted.");
+            throw new WarpScriptException(getName() + " expects a sorted list for "+ PARAM_OUTPUTTICKS + " parameter.");
           }
         }
       }
@@ -299,7 +300,7 @@ public class MAP extends NamedWarpScriptFunction implements WarpScriptStackFunct
     for (GeoTimeSerie gts: series) {
       List<GeoTimeSerie> res;
       try {
-        res = GTSHelper.map(gts, mapper, prewindow, postwindow, Math.abs(occurrences), occurrences < 0, step, overrideTick, mapper instanceof Macro ? stack : null, (List<Long>) outputTicks);
+        res = GTSHelper.map(gts, mapper, prewindow, postwindow, Math.abs(occurrences), reversed, step, overrideTick, mapper instanceof Macro ? stack : null, (List<Long>) outputTicks);
       } catch (WarpScriptATCException wsatce) {
         // Do not handle WarpScriptATCException (STOP in MACROMAPPER for instance)
         throw wsatce;

--- a/warp10/src/main/java/io/warp10/script/functions/MAP.java
+++ b/warp10/src/main/java/io/warp10/script/functions/MAP.java
@@ -26,7 +26,6 @@ import io.warp10.script.WarpScriptStackFunction;
 import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptStack;
 
-import java.awt.peer.LabelPeer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;


### PR DESCRIPTION
In case of a concurrent execution of MAP, sorting the outputTicks will lead to a concurrent modification exception.

So, I just check if the input is correctly sorted instead of always calling Collections.sort()
