### PR TITLE
add SLEEP function and capability

### DIFF
--- a/warp10/src/main/java/io/warp10/script/WarpScriptLib.java
+++ b/warp10/src/main/java/io/warp10/script/WarpScriptLib.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2019-2022  SenX S.A.S.
+//   Copyright 2019-2023  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.

--- a/warp10/src/main/java/io/warp10/script/WarpScriptLib.java
+++ b/warp10/src/main/java/io/warp10/script/WarpScriptLib.java
@@ -842,6 +842,7 @@ import io.warp10.script.functions.LOGINIT;
 import io.warp10.script.functions.STDERR;
 import io.warp10.script.functions.STDOUT;
 import io.warp10.script.functions.TDESCRIBE;
+import io.warp10.script.functions.SLEEP;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1674,7 +1675,8 @@ public class WarpScriptLib {
   public static final String VARS = "VARS";
   public static final String ASREGS = "ASREGS";
   public static final String ASENCODERS = "ASENCODERS";
-
+  public static final String SLEEP = "SLEEP";
+  
   public static final String TOLIST = "->LIST";
   public static final String TOMAP = "->MAP";
   public static final String TOJSON = "->JSON";
@@ -3141,6 +3143,8 @@ public class WarpScriptLib {
     addNamedWarpScriptFunction(new NOLOG(NOLOG));
     addNamedWarpScriptFunction(new LOGINIT(LOGINIT));
     addNamedWarpScriptFunction(new TDESCRIBE(TDESCRIBE));
+    addNamedWarpScriptFunction(new SLEEP(SLEEP));
+
 
     /////////////////////////
 

--- a/warp10/src/main/java/io/warp10/script/WarpScriptStack.java
+++ b/warp10/src/main/java/io/warp10/script/WarpScriptStack.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2022  SenX S.A.S.
+//   Copyright 2018-2023  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.

--- a/warp10/src/main/java/io/warp10/script/WarpScriptStack.java
+++ b/warp10/src/main/java/io/warp10/script/WarpScriptStack.java
@@ -559,6 +559,7 @@ public interface WarpScriptStack {
   String CAPABILITY_WFSET = "wfset";
   String CAPABILITY_HTTP = "http";
   String CAPABILITY_TIMEBOX_MAXTIME = "timebox.maxtime";
+  String CAPABILITY_SLEEP_MAXTIME = "sleep.maxtime";
 
   /**
    * Retrieve the StoreClient instance associated with this stack.

--- a/warp10/src/main/java/io/warp10/script/functions/SLEEP.java
+++ b/warp10/src/main/java/io/warp10/script/functions/SLEEP.java
@@ -1,0 +1,70 @@
+//
+//   Copyright 2022 SenX S.A.S.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+package io.warp10.script.functions;
+
+import io.warp10.continuum.store.Constants;
+import io.warp10.script.NamedWarpScriptFunction;
+import io.warp10.script.WarpScriptException;
+import io.warp10.script.WarpScriptStack;
+import io.warp10.script.WarpScriptStackFunction;
+import io.warp10.warp.sdk.Capabilities;
+
+public class SLEEP extends NamedWarpScriptFunction implements WarpScriptStackFunction {
+
+  public SLEEP(String name) {
+    super(name);
+  }
+
+  @Override
+  public Object apply(WarpScriptStack stack) throws WarpScriptException {
+
+    if (null == Capabilities.get(stack, WarpScriptStack.CAPABILITY_SLEEP_MAXTIME)) {
+      throw new WarpScriptException(getName() + " requires capability " + WarpScriptStack.CAPABILITY_SLEEP_MAXTIME + ".");
+    }
+
+    // sleep max time capability is defined in milliseconds
+    long maxSleepMs;
+    try {
+      maxSleepMs = Long.parseLong(Capabilities.get(stack, WarpScriptStack.CAPABILITY_SLEEP_MAXTIME));
+    } catch (NumberFormatException e) {
+      throw new WarpScriptException(getName() + " cannot parse capability " + WarpScriptStack.CAPABILITY_SLEEP_MAXTIME + ": '" + Capabilities.get(stack, WarpScriptStack.CAPABILITY_SLEEP_MAXTIME) + "' is not a valid LONG");
+    }
+
+    if (maxSleepMs <= 0) {
+      throw new WarpScriptException(getName() + " requires capability " + WarpScriptStack.CAPABILITY_SLEEP_MAXTIME + " to be set to a value strictly greater than 0 ms.");
+    }
+
+    Object o = stack.pop();
+    if (!(o instanceof Long)) {
+      throw new WarpScriptException(getName() + " expects a LONG period as parameter.");
+    }
+    // convert to milliseconds    
+    long millis = ((Long) o).longValue() / Constants.TIME_UNITS_PER_MS;
+    if (millis > maxSleepMs) {
+      throw new WarpScriptException(getName() + " cannot sleep during more greater than " + maxSleepMs + " ms, as defined in " + WarpScriptStack.CAPABILITY_SLEEP_MAXTIME + " capability.");
+    }
+
+    try {
+      Thread.sleep(millis);
+    } catch (InterruptedException e) {
+      throw new WarpScriptException(getName() + " interrupted");
+    }
+
+    return stack;
+  }
+
+}

--- a/warp10/src/main/java/io/warp10/script/functions/SLEEP.java
+++ b/warp10/src/main/java/io/warp10/script/functions/SLEEP.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2022 SenX S.A.S.
+//   Copyright 2023 SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.


### PR DESCRIPTION
When pushing data to external services (using HTTP or WEBCALL), we might need to respect a minimum period between requests. Current solution to do so is an infinite loop bounded by TIMEBOX, quite CPU intensive.

Adds `sleep.maxtime` capability.
