### PR TITLE
change SLEEP implementation for concurrent execution

### DIFF
--- a/warp10/src/main/java/io/warp10/script/functions/SLEEP.java
+++ b/warp10/src/main/java/io/warp10/script/functions/SLEEP.java
@@ -56,16 +56,16 @@ public class SLEEP extends NamedWarpScriptFunction implements WarpScriptStackFun
     }
     long t = ((Long) o).longValue();
     // convert to milliseconds
-    if ((t / Constants.TIME_UNITS_PER_MS) > maxSleepMs) {
+    t = t / Constants.TIME_UNITS_PER_MS;
+    if (t > maxSleepMs) {
       throw new WarpScriptException(getName() + " cannot sleep during more than " + maxSleepMs + " ms, as defined in " + WarpScriptStack.CAPABILITY_SLEEP_MAXTIME + " capability.");
     }
-    // convert to nanoseconds, check for overflow
-    if (t > (Long.MAX_VALUE / Constants.NS_PER_TIME_UNIT)) {
-      t = Long.MAX_VALUE / Constants.NS_PER_TIME_UNIT;
-    }
-    
-    LockSupport.parkNanos(t * Constants.NS_PER_TIME_UNIT);
 
+    try {
+      Thread.sleep(t);
+    } catch (InterruptedException e) {
+      throw new WarpScriptException(getName() + " interrupted");
+    }
     return stack;
   }
 


### PR DESCRIPTION
fix #1183 

Here is a test that randomly fails (sleep lasts nearly 0 second) with parkNanos method :

```
// it should return lists of empty lists.
1 10
<%
  DROP
  [
    1 20
    <%
      DROP 
      <%
        DROP
        NOW 't1start' STORE
          5 s SLEEP
          //'sleep 5 done'
        NOW $t1start -  'executionTime' STORE
        $executionTime 5 s  200 ms ~= ! // execution time is not around 5s
        <% $executionTime HUMANDURATION %> IFT
      %> <% %> +
    %> FOR
  ] 20 CEVAL
%> FOR
```

Here is a test to show that Thread interrupt is correctly managed by SLEEP:

```
// this should output "running" one or two times, 
// then the SLEEP interrupted exception

[
  <% 
    DROP
    1 10 
    <% 
      'running' STDOUT 
      <% 1 s SLEEP  %>
      <% ERROR ->JSON STDOUT FAIL %>
      <% %>
      TRY
    %> FOR 
  %>

  <% 
    DROP
    1 s SLEEP
    'nope' MSGFAIL
  %>

] 2 CEVAL
```

Both tests pass with Thread.sleep().

