### PR TITLE
Fix BUCKETIZE.CALENDAR

### DIFF
--- a/warp10/src/main/java/io/warp10/script/functions/BUCKETIZECALENDAR.java
+++ b/warp10/src/main/java/io/warp10/script/functions/BUCKETIZECALENDAR.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2020-2022  SenX S.A.S.
+//   Copyright 2020-2023  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -178,35 +178,37 @@ public class BUCKETIZECALENDAR extends NamedWarpScriptFunction implements WarpSc
     }
 
     //
-    // Compute bucketindex of lastbucket and compute bucketoffset
+    // Compute lastbucketindex and compute bucketoffset
     //
 
     long flag = 0; // always equal to epoch modulo period
-    long bucketoffset;
+    long bucketoffset = 0;
     long lastbucketIndex;
 
     //
-    // Starting from Epoch, we make a hint and land the flag close to lastbucket
+    // We suppose for now that bucketoffset is zero, and try to land flag as the first tick that is not in the last bucket
+    // Then, we will obtain bucketoffset as the difference between flag - 1 and lastbucket
     //
 
-    long lastbucketIndexHint = lastbucket / averageSpan;
+    // starting from Epoch, we make a hint and land the flag close to lastbucket
+    long lastbucketIndexHint = lastbucket / averageSpan; // this is also a hint of the number of entire periods since Epoch
     if (lastbucket > 0) {
-      flag = addNonNegativePeriod(flag, bucketperiod, dtz, lastbucketIndexHint + 1);
+      flag = addNonNegativePeriod(0, bucketperiod, DateTimeZone.UTC, lastbucketIndexHint + 1); // if all periods had same span, flag would already be correct
       lastbucketIndex = lastbucketIndexHint;
 
     } else {
-      flag = addNonNegativePeriod(flag, bucketperiod, dtz, lastbucketIndexHint);
+      flag = addNonNegativePeriod(0, bucketperiod, DateTimeZone.UTC, lastbucketIndexHint); // lastbucketIndexHint is negative
       lastbucketIndex = lastbucketIndexHint - 1;
     }
 
     //
-    // We move the flag left and right on the time axis to make sure lastbucket is its leftmost bucketend
+    // If we landed too far, we try to get closer by using another hint on the number of steps left
     //
 
     while (flag > lastbucket) {
       long N = - ((flag - lastbucket) / averageSpan - 1);
       if (N < -1) {
-        flag = addNonNegativePeriod(flag, bucketperiod, dtz, N);
+        flag = addNonNegativePeriod(0, bucketperiod, DateTimeZone.UTC,lastbucketIndex + N + 1);
         lastbucketIndex = lastbucketIndex + N;
       } else {
         break;
@@ -216,20 +218,24 @@ public class BUCKETIZECALENDAR extends NamedWarpScriptFunction implements WarpSc
     while (flag <= lastbucket) {
       long N = (lastbucket - flag) / averageSpan - 1;
       if (N > 1) {
-        flag = addNonNegativePeriod(flag, bucketperiod, dtz, N);
+        flag = addNonNegativePeriod(0, bucketperiod, DateTimeZone.UTC, lastbucketIndex + N + 1);
         lastbucketIndex = lastbucketIndex + N;
       } else {
         break;
       }
     }
 
+    //
+    // We close up step by step
+    //
+
     while (flag > lastbucket) {
-      flag = addNonNegativePeriod(flag, bucketperiod, dtz, -1);
+      flag = addNonNegativePeriod(0, bucketperiod, DateTimeZone.UTC, lastbucketIndex);
       lastbucketIndex--;
     }
 
     while (flag <= lastbucket) {
-      flag = addNonNegativePeriod(flag, bucketperiod, dtz, 1);
+      flag = addNonNegativePeriod(0, bucketperiod, DateTimeZone.UTC, lastbucketIndex + 2);
       lastbucketIndex++;
     }
 
@@ -335,7 +341,7 @@ public class BUCKETIZECALENDAR extends NamedWarpScriptFunction implements WarpSc
 
     long lastTick = GTSHelper.lasttick(gts);
     long firstTick = GTSHelper.firsttick(gts);
-    int hint = Math.min(gts.size(), (int) (1.05 * (lastTick - firstTick) / addNonNegativePeriod(0, bucketperiod, dtz, 1)));
+    int hint = Math.min(gts.size(), (int) (1.05 * (lastTick - firstTick) / addNonNegativePeriod(0, bucketperiod, DateTimeZone.UTC, 1)));
 
     GeoTimeSerie durationBucketized = gts.cloneEmpty(hint);
 
@@ -383,8 +389,7 @@ public class BUCKETIZECALENDAR extends NamedWarpScriptFunction implements WarpSc
 
       // update bucketstart and bucketindex
       while (tick < bucketstart) {
-        bucketstart = addNonNegativePeriod(bucketstart, bucketperiod, dtz, -1);
-        bucketindex--;
+        bucketstart = addNonNegativePeriod(lastbucket, bucketperiod, dtz, --bucketindex - lastbucketIndex - 1) + 1;
       }
 
       //

--- a/warp10/src/main/java/io/warp10/script/functions/UNBUCKETIZECALENDAR.java
+++ b/warp10/src/main/java/io/warp10/script/functions/UNBUCKETIZECALENDAR.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2020  SenX S.A.S.
+//   Copyright 2020-2023  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -73,6 +73,8 @@ public class UNBUCKETIZECALENDAR extends GTSStackFunction {
 
     ADDDURATION.ReadWritablePeriodWithSubSecondOffset bucketperiod = ADDDURATION.durationToPeriod(gts.getMetadata().getAttributes().get(BUCKETIZECALENDAR.DURATION_ATTRIBUTE_KEY));
     long bucketoffset = Long.parseLong(gts.getMetadata().getAttributes().get(BUCKETIZECALENDAR.OFFSET_ATTRIBUTE_KEY));
+    long lastbucketIndex = GTSHelper.lasttick(gts);
+    long lastbucket = BUCKETIZECALENDAR.addNonNegativePeriod(0, bucketperiod, DateTimeZone.UTC, lastbucketIndex + 1) - 1 - bucketoffset;
     DateTimeZone dtz = DateTimeZone.forID(gts.getMetadata().getAttributes().get(BUCKETIZECALENDAR.TIMEZONE_ATTRIBUTE_KEY));
 
     GTSHelper.unbucketize(result);
@@ -81,8 +83,7 @@ public class UNBUCKETIZECALENDAR extends GTSStackFunction {
     result.getMetadata().getAttributes().remove(BUCKETIZECALENDAR.TIMEZONE_ATTRIBUTE_KEY);
 
     for (int i = 0; i < gts.size(); i++) {
-
-      long tick = ADDDURATION.addPeriod(0, bucketperiod, dtz, GTSHelper.tickAtIndex(gts, i) + 1) - 1 - bucketoffset;
+      long tick = BUCKETIZECALENDAR.addNonNegativePeriod(lastbucket, bucketperiod, dtz,  i - (gts.size() - 1));
       GTSHelper.setValue(result, tick, GTSHelper.locationAtIndex(gts, i), GTSHelper.elevationAtIndex(gts, i), GTSHelper.valueAtIndex(gts, i), false);
     }
 


### PR DESCRIPTION
In BUCKETIZE.CALENDAR, the computation of the underlying bucketoffset wasn't correct in some cases.

In the preliminary calculations of bucketoffset and bucket index of lastbucket, we were sliding Epoch up to its congruent timestamp contained in the lastbucket using provided timezone parameter. Instead, we now use UTC timezone so this calculation does not depend on the timezone.

Also, for each addition or subtraction of multiple periods from an origin timestamp, we now always add all periods at once instead of adding a single period from a previous intermediate timestamp. With this change we avoid cases where less duration would have been added than expected if an intermediate timestamp would have landed in the margin of a period component (for example 28th of February instead of 29th).