### PR TITLE
fix IDENT function

### DIFF
--- a/warp10/src/main/java/io/warp10/script/functions/IDENT.java
+++ b/warp10/src/main/java/io/warp10/script/functions/IDENT.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018  SenX S.A.S.
+//   Copyright 2018-2023  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.warp10.script.functions;
 
+import io.warp10.WarpConfig;
 import io.warp10.continuum.Configuration;
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptStackFunction;
@@ -27,10 +28,16 @@ public class IDENT extends NamedWarpScriptFunction implements WarpScriptStackFun
   public IDENT(String name) {
     super(name);
   }
-  
+
+  private static final String ident;
+
+  static {
+    ident = WarpConfig.getProperty(Configuration.WARP_IDENT);
+  }
+
   @Override
   public Object apply(WarpScriptStack stack) throws WarpScriptException {
-    stack.push(System.getProperty(Configuration.WARP_IDENT));
+    stack.push(ident);
     return stack;
   }
 }


### PR DESCRIPTION
`warp.ident` is defined into 00-warp.conf, but `IDENT` only look at System variables.
