### PR TITLE
Aggregator nameset cleaning

### DIFF
--- a/warp10/src/main/java/io/warp10/script/WarpScriptLib.java
+++ b/warp10/src/main/java/io/warp10/script/WarpScriptLib.java
@@ -2630,7 +2630,6 @@ public class WarpScriptLib {
     addNamedWarpScriptFunction(new MapperKernelUniform("mapper.kernel.uniform"));
 
     addNamedWarpScriptFunction(new Percentile.Builder("mapper.percentile", false));
-    addNamedWarpScriptFunction(new Percentile.Builder("mapper.percentile.forbid-nulls", true));
 
     //functions.put("mapper.abscissa", new MapperSAX.Builder());
 
@@ -3010,31 +3009,18 @@ public class WarpScriptLib {
     addNamedWarpScriptFunction(new Max("bucketizer.max", true));
     addNamedWarpScriptFunction(new Mean("bucketizer.mean", false));
     addNamedWarpScriptFunction(new Median("bucketizer.median", false));
-    addNamedWarpScriptFunction(new Median("bucketizer.median.forbid-nulls", true));
     addNamedWarpScriptFunction(new MAD("bucketizer.mad"));
     addNamedWarpScriptFunction(new Or("bucketizer.or", false));
     addNamedWarpScriptFunction(new Sum("bucketizer.sum", true));
     addNamedWarpScriptFunction(new Join.Builder("bucketizer.join", true, false, null));
     addNamedWarpScriptFunction(new Count("bucketizer.count", false));
     addNamedWarpScriptFunction(new Percentile.Builder("bucketizer.percentile", false));
-    addNamedWarpScriptFunction(new Percentile.Builder("bucketizer.percentile.forbid-nulls", true));
-
-    addNamedWarpScriptFunction(new Min("bucketizer.min.forbid-nulls", false));
-    addNamedWarpScriptFunction(new Max("bucketizer.max.forbid-nulls", false));
-    addNamedWarpScriptFunction(new Mean("bucketizer.mean.exclude-nulls", true));
-    addNamedWarpScriptFunction(new Sum("bucketizer.sum.forbid-nulls", false));
-    addNamedWarpScriptFunction(new Join.Builder("bucketizer.join.forbid-nulls", false, false, null));
-    addNamedWarpScriptFunction(new Count("bucketizer.count.exclude-nulls", true));
-    addNamedWarpScriptFunction(new Count("bucketizer.count.include-nulls", false));
-    addNamedWarpScriptFunction(new Count("bucketizer.count.nonnull", true));
     addNamedWarpScriptFunction(new CircularMean.Builder("bucketizer.mean.circular", true));
-    addNamedWarpScriptFunction(new CircularMean.Builder("bucketizer.mean.circular.exclude-nulls", false));
     addNamedWarpScriptFunction(new RMS("bucketizer.rms", false));
     addNamedWarpScriptFunction(new Variance.Builder("bucketizer.var", false));
     addNamedWarpScriptFunction(new Variance.Builder("bucketizer.var.welford", false, true));
     addNamedWarpScriptFunction(new StandardDeviation.Builder("bucketizer.sd", false));
     addNamedWarpScriptFunction(new StandardDeviation.Builder("bucketizer.sd.welford", false, true));
-    addNamedWarpScriptFunction(new StandardDeviation.Builder("bucketizer.sd.forbid-nulls", true));
 
     //
     // Mappers
@@ -3048,7 +3034,6 @@ public class WarpScriptLib {
     addNamedWarpScriptFunction(new Max(MAPPER_MAX, true));
     addNamedWarpScriptFunction(new Mean("mapper.mean", false));
     addNamedWarpScriptFunction(new Median("mapper.median", false));
-    addNamedWarpScriptFunction(new Median("mapper.median.forbid-nulls", true));
     addNamedWarpScriptFunction(new MAD("mapper.mad"));
     addNamedWarpScriptFunction(new Or("mapper.or", false));
     addNamedWarpScriptFunction(new Highest(MAPPER_HIGHEST));
@@ -3078,18 +3063,7 @@ public class WarpScriptLib {
     addNamedWarpScriptFunction(new MapperTanh("mapper.tanh"));
     addNamedWarpScriptFunction(new MapperSigmoid("mapper.sigmoid"));
     addNamedWarpScriptFunction(new MapperProduct("mapper.product"));
-    addNamedWarpScriptFunction(new Count("mapper.count.exclude-nulls", true));
-    addNamedWarpScriptFunction(new Count("mapper.count.include-nulls", false));
-    addNamedWarpScriptFunction(new Count("mapper.count.nonnull", true));
-    addNamedWarpScriptFunction(new Min("mapper.min.forbid-nulls", false));
-    addNamedWarpScriptFunction(new Max("mapper.max.forbid-nulls", false));
-    addNamedWarpScriptFunction(new Mean("mapper.mean.exclude-nulls", true));
-    addNamedWarpScriptFunction(new Sum("mapper.sum.forbid-nulls", false));
-    addNamedWarpScriptFunction(new Join.Builder("mapper.join.forbid-nulls", false, false, null));
-    addNamedWarpScriptFunction(new Variance.Builder("mapper.var.forbid-nulls", true));
-    addNamedWarpScriptFunction(new StandardDeviation.Builder("mapper.sd.forbid-nulls", true));
     addNamedWarpScriptFunction(new CircularMean.Builder("mapper.mean.circular", true));
-    addNamedWarpScriptFunction(new CircularMean.Builder("mapper.mean.circular.exclude-nulls", false));
     addNamedWarpScriptFunction(new MapperMod.Builder("mapper.mod"));
     addNamedWarpScriptFunction(new RMS("mapper.rms", false));
     addNamedWarpScriptFunction(new MapperRegExpMatch.Builder("mapper.regexp.match"));


### PR DESCRIPTION
This is a work in progress.

To do: remove duplicate reducers and fix naming incoherences.

To help define the correct changes to implement, in the following the reducers are grouped by their null handling behavior.

Remove null values:
- reducer.and.exclude-nulls
- reducer.min
- reducer.max
- reducer.mean.exclude-nulls
- reducer.median
- reducer.mad
- reducer.or.exclude-nulls
- reducer.sum
- reducer.join.forbid-nulls
- reducer.join.nonnull
- reducer.join.urlencoded
- reducer.var
- reducer.var.welford
- reducer.sd
- reducer.sd.welford
- reducer.count.exclude-nulls
- reducer.count.nonnull
- reducer.mean.circular.exclude-nulls
- reducer.rms.exclude-nulls

Keep null values:
- reducer.count
- reducer.count.include-nulls

Skip timestamp if there is at least one null value:
- reducer.and
- reducer.min.forbid-nulls
- reducer.min.nonnull
- reducer.max.forbid-nulls
- reducer.max.nonnull
- reducer.mean
- reducer.or
- reducer.sum.forbid-nulls
- reducer.sum.nonnull
- reducer.join
- reducer.var.forbid-nulls
- reducer.var.welford.forbid-nulls
- reducer.sd.forbid-nulls
- reducer.sd.welford.forbid-nulls
- reducer.mean.circular
- reducer.rms

Fail if there is at least one null value:
- reducer.median.forbid-nulls
- reducer.percentile.forbid-nulls

