### PR TITLE
Add audit tools

### DIFF
--- a/warp10/src/main/java/io/warp10/continuum/egress/EgressExecHandler.java
+++ b/warp10/src/main/java/io/warp10/continuum/egress/EgressExecHandler.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2022  SenX S.A.S.
+//   Copyright 2018-2023  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -437,7 +437,7 @@ public class EgressExecHandler extends AbstractHandler {
             stack.exec("'[Line #" + Long.toString(lineno) + "]'");
             stack.exec(WarpScriptLib.SECTION);
           }
-          stack.exec(line);
+          stack.exec(line, lineno);
         } catch (WarpScriptStopException ese) {
           // Do nothing, this is simply an early termination which should not generate errors
           terminate = true;

--- a/warp10/src/main/java/io/warp10/json/JsonUtils.java
+++ b/warp10/src/main/java/io/warp10/json/JsonUtils.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2020-2021  SenX S.A.S.
+//   Copyright 2020-2023  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -170,6 +170,7 @@ public class JsonUtils {
     module.addSerializer(new RealVectorSerializer());
     module.addSerializer(new RealMatrixSerializer());
     module.addSerializer(new COWListSerializer());
+    module.addSerializer(new WarpScriptTraceableStatementSerializer());
 
     //
     // Common configuration for both strict and loose mappers.

--- a/warp10/src/main/java/io/warp10/json/WarpScriptTraceableStatementSerializer.java
+++ b/warp10/src/main/java/io/warp10/json/WarpScriptTraceableStatementSerializer.java
@@ -1,0 +1,41 @@
+//
+//   Copyright 2023  SenX S.A.S.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+package io.warp10.json;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import io.warp10.script.WarpScriptTraceableStatement;
+
+import java.io.IOException;
+
+public class WarpScriptTraceableStatementSerializer extends StdSerializer<WarpScriptTraceableStatement> {
+
+  protected WarpScriptTraceableStatementSerializer() {
+    super(WarpScriptTraceableStatement.class);
+  }
+
+  @Override
+  public void serialize(WarpScriptTraceableStatement st, JsonGenerator gen, SerializerProvider provider) throws IOException {
+    gen.writeStartObject();
+    gen.writeStringField("type",st.type.name());
+    gen.writeNumberField("line",st.lineNumber);
+    gen.writeNumberField("position",st.positionNumber);
+    gen.writeStringField("statement",st.statement);
+    gen.writeEndObject();
+  }
+}

--- a/warp10/src/main/java/io/warp10/script/MemoryWarpScriptStack.java
+++ b/warp10/src/main/java/io/warp10/script/MemoryWarpScriptStack.java
@@ -153,6 +153,7 @@ public class MemoryWarpScriptStack implements WarpScriptStack, Progressable {
 
   private StringBuilder multiline;
 
+  private boolean auditMode = false;
   /**
    * (re)defined functions
    */
@@ -467,6 +468,31 @@ public class MemoryWarpScriptStack implements WarpScriptStack, Progressable {
   }
 
   /**
+   * Turn on/off auditMode. In auditMode, macros contains special statements with line numbers or WarpScript parsing errors.
+   * Parsing errors are also stored into ATTRIBUTE_PARSING_ERRORS stack attribute, to avoid walking in macros.
+   * auditMode exits after the closing the first last macro level, leaving on stack a macro object.
+   */
+  @Override
+  public void auditMode(boolean auditMode) {
+    if (auditMode) {
+      setAttribute(ATTRIBUTE_PARSING_ERRORS, new ArrayList<WarpScriptTraceableStatement>());
+    }
+    this.auditMode = auditMode;
+  }
+
+  /**
+   * Saves the statement to the error list contained in ATTRIBUTE_PARSING_ERRORS stack attribute.
+   *
+   * @param st list of unknown functions or exceptions
+   */
+  private void addAuditError(WarpScriptTraceableStatement st) {
+    Object o = getAttribute(ATTRIBUTE_PARSING_ERRORS);
+    if (o instanceof List) {
+      ((List) o).add(st);
+    }
+  }
+  
+  /**
    * Consume the top of the stack and interpret it as
    * an int number.
    *
@@ -533,6 +559,10 @@ public class MemoryWarpScriptStack implements WarpScriptStack, Progressable {
 
   @Override
   public void exec(String line) throws WarpScriptException {
+    exec(line, -1);
+  }
+
+  public void exec(String line, long lineNumber) throws WarpScriptException {
 
     String rawline = line;
 
@@ -611,7 +641,13 @@ public class MemoryWarpScriptStack implements WarpScriptStack, Progressable {
 
           if (WarpScriptStack.MULTILINE_END.equals(stmt)) {
             if (!inMultiline.get()) {
-              throw new WarpScriptException("Not inside a multiline.");
+              if (auditMode && !(macros.isEmpty() || macros.size() == forcedMacro)) {
+                WarpScriptTraceableStatement err = new WarpScriptTraceableStatement(WarpScriptTraceableStatement.STATEMENT_TYPE.WS_EXCEPTION, null, "Not inside a multiline.", lineNumber, st);
+                macros.get(0).add(err);
+                addAuditError(err);
+              } else {
+                throw new WarpScriptException("Not inside a multiline.");
+              }
             }
             inMultiline.set(false);
 
@@ -643,7 +679,13 @@ public class MemoryWarpScriptStack implements WarpScriptStack, Progressable {
           } else if (!allowLooseBlockComments && WarpScriptStack.COMMENT_END.equals(stmt)) {
             // Legacy comments block: Comments block must start with /* and end with */ .
             if (!inComment.get()) {
-              throw new WarpScriptException("Not inside a comment.");
+              if (auditMode && !(macros.isEmpty() || macros.size() == forcedMacro)) {
+                WarpScriptTraceableStatement err = new WarpScriptTraceableStatement(WarpScriptTraceableStatement.STATEMENT_TYPE.WS_EXCEPTION, null, "Not inside a comment.", lineNumber, st);
+                macros.get(0).add(err);
+                addAuditError(err);
+              } else {
+                throw new WarpScriptException("Not inside a comment.");
+              }
             }
             inComment.set(false);
             continue;
@@ -666,7 +708,13 @@ public class MemoryWarpScriptStack implements WarpScriptStack, Progressable {
             continue;
           } else if (WarpScriptStack.MULTILINE_START.equals(stmt)) {
             if (1 != statements.length) {
-              throw new WarpScriptException("Can only start multiline strings by using " + WarpScriptStack.MULTILINE_START + " on a line by itself.");
+              if (auditMode && !(macros.isEmpty() || macros.size() == forcedMacro)) {
+                WarpScriptTraceableStatement err = new WarpScriptTraceableStatement(WarpScriptTraceableStatement.STATEMENT_TYPE.WS_EXCEPTION, null, "Can only start multiline strings by using " + WarpScriptStack.MULTILINE_START + " on a line by itself.", lineNumber, st);
+                macros.get(0).add(err);
+                addAuditError(err);
+              } else {
+                throw new WarpScriptException("Can only start multiline strings by using " + WarpScriptStack.MULTILINE_START + " on a line by itself.");
+              }
             }
             inMultiline.set(true);
             multiline = new StringBuilder();
@@ -678,7 +726,13 @@ public class MemoryWarpScriptStack implements WarpScriptStack, Progressable {
 
           if (WarpScriptStack.SECURE_SCRIPT_END.equals(stmt)) {
             if (null == secureScript) {
-              throw new WarpScriptException("Not inside a secure script definition.");
+              if (auditMode && !(macros.isEmpty() || macros.size() == forcedMacro)) {
+                WarpScriptTraceableStatement err = new WarpScriptTraceableStatement(WarpScriptTraceableStatement.STATEMENT_TYPE.WS_EXCEPTION, null, "Not inside a secure script definition.", lineNumber, st);
+                macros.get(0).add(err);
+                addAuditError(err);
+              } else {
+                throw new WarpScriptException("Not inside a secure script definition.");
+              }             
             } else {
               this.push(secureScript.toString());
               secureScript = null;
@@ -688,7 +742,13 @@ public class MemoryWarpScriptStack implements WarpScriptStack, Progressable {
             if (null == secureScript) {
               secureScript = new StringBuilder();
             } else {
-              throw new WarpScriptException("Already inside a secure script definition.");
+              if (auditMode && !(macros.isEmpty() || macros.size() == forcedMacro)) {
+                WarpScriptTraceableStatement err = new WarpScriptTraceableStatement(WarpScriptTraceableStatement.STATEMENT_TYPE.WS_EXCEPTION, null, "Already inside a secure script definition.", lineNumber, st);
+                macros.get(0).add(err);
+                addAuditError(err);
+              } else {
+                throw new WarpScriptException("Already inside a secure script definition.");
+              }
             }
           } else if (null != secureScript) {
             secureScript.append(" ");
@@ -698,7 +758,9 @@ public class MemoryWarpScriptStack implements WarpScriptStack, Progressable {
               throw new WarpScriptException("Not inside a macro definition.");
             } else {
               Macro lastmacro = macros.remove(0);
-
+              if (auditMode && (macros.isEmpty() || macros.size() == forcedMacro)) {
+                auditMode = false;  // the only way to exit audit mode is to close the last level of opened macro.
+              }
               boolean secure = Boolean.TRUE.equals(this.getAttribute(WarpScriptStack.ATTRIBUTE_IN_SECURE_MACRO));
 
               if (!Boolean.TRUE.equals(this.getAttribute(WarpScriptStack.ATTRIBUTE_IN_XEVAL))) {
@@ -806,26 +868,45 @@ public class MemoryWarpScriptStack implements WarpScriptStack, Progressable {
 
               push(o);
             } else {
-              macros.get(0).add(stmt.substring(1));
-              macros.get(0).add(WarpScriptLib.getFunction(WarpScriptLib.LOAD));
+              if (auditMode) {
+                macros.get(0).add(new WarpScriptTraceableStatement(WarpScriptTraceableStatement.STATEMENT_TYPE.WS_LOAD,
+                    stmt.substring(1), stmt, lineNumber, st));
+              } else {
+                macros.get(0).add(stmt.substring(1));
+                macros.get(0).add(WarpScriptLib.getFunction(WarpScriptLib.LOAD));
+              }
             }
           } else if (stmt.startsWith("!$")) {
             //
             // This is an immediate variable dereference
             //
-            Object o = load(stmt.substring(2));
+            if (auditMode && macros.size() > 1) {
+              macros.get(0).add(new WarpScriptTraceableStatement(WarpScriptTraceableStatement.STATEMENT_TYPE.WS_EARLY_BINDING, null, stmt.substring(2), lineNumber, st));
+            } else {
+              Object o = load(stmt.substring(2));
 
-            if (null == o) {
-              if (!getSymbolTable().containsKey(stmt.substring(2))) {
-                throw new WarpScriptException("Unknown symbol '" + stmt.substring(2) + "'");
+              if (null == o) {
+                if (!getSymbolTable().containsKey(stmt.substring(2))) {
+                  if (forcedMacro == 0) {
+                    if (macros.size() > 1) {
+                      throw new WarpScriptException("Early binding is not possible inside a macro.");
+                    } else {
+                      throw new WarpScriptException("Unknown symbol '" + stmt.substring(2) + "'");
+                    }
+                  } else {
+                    throw new WarpScriptException("Early binding is not compatible with time execution limits such as " + Configuration.EGRESS_MAXTIME +
+                        " configuration or " + WarpScriptStack.CAPABILITY_TIMEBOX_MAXTIME + " capability.");
+                  }
+                }
+              }
+
+              if (macros.isEmpty()) {
+                push(o);
+              } else {
+                macros.get(0).add(o);
               }
             }
 
-            if (macros.isEmpty()) {
-              push(o);
-            } else {
-              macros.get(0).add(o);
-            }
           } else if (stmt.startsWith("@")) {
             if (macros.isEmpty()) {
               //
@@ -837,47 +918,62 @@ public class MemoryWarpScriptStack implements WarpScriptStack, Progressable {
               run(symbol);
             } else {
               macros.get(0).add(stmt.substring(1));
-              macros.get(0).add(WarpScriptLib.getFunction(WarpScriptLib.RUN));
+              if (auditMode) {
+                macros.get(0).add(new WarpScriptTraceableStatement(WarpScriptTraceableStatement.STATEMENT_TYPE.WS_LOAD,
+                    stmt.substring(1), stmt, lineNumber, st));
+              } else {
+                macros.get(0).add(WarpScriptLib.getFunction(WarpScriptLib.RUN));
+              }
             }
           } else {
             //
             // This is a function call
             //
-
-            Object func = findFunction(stmt);
-
-            //
-            // Check WarpScript functions
-            //
-
-            Map<String,String> labels = new HashMap<String,String>();
-            labels.put(SensisionConstants.SENSISION_LABEL_FUNCTION, stmt);
-
-            long nano = System.nanoTime();
-
-            try {
-              if (func instanceof WarpScriptStackFunction && macros.isEmpty()) {
-                //
-                // Function is an WarpScriptStackFunction, call it on this stack
-                //
-
-                WarpScriptStackFunction esf = (WarpScriptStackFunction) func;
-
-                esf.apply(this);
-              } else {
-                //
-                // Push any other type of function onto the stack
-                //
-                if (macros.isEmpty()) {
-                  push(func);
-                } else {
-                  macros.get(0).add(func);
-                }
+            if (auditMode && !(macros.isEmpty() || macros.size() == forcedMacro)) {
+              try {
+                Object func = findFunction(stmt);
+                macros.get(0).add(new WarpScriptTraceableStatement(WarpScriptTraceableStatement.STATEMENT_TYPE.FUNCTION_CALL, func, stmt, lineNumber, st));
+              } catch (WarpScriptException e) {
+                WarpScriptTraceableStatement err = new WarpScriptTraceableStatement(WarpScriptTraceableStatement.STATEMENT_TYPE.UNKNOWN, null, stmt, lineNumber, st);
+                macros.get(0).add(err);
+                addAuditError(err);
               }
-            } finally {
-              if (functionMetrics) {
-                Sensision.update(SensisionConstants.SENSISION_CLASS_WARPSCRIPT_FUNCTION_COUNT, labels, 1);
-                Sensision.update(SensisionConstants.SENSISION_CLASS_WARPSCRIPT_FUNCTION_TIME_US, labels, (System.nanoTime() - nano) / 1000L);
+            } else {
+              Object func = findFunction(stmt);
+
+              //
+              // Check WarpScript functions
+              //
+
+              Map<String, String> labels = new HashMap<String, String>();
+              labels.put(SensisionConstants.SENSISION_LABEL_FUNCTION, stmt);
+
+              long nano = System.nanoTime();
+
+              try {
+                if (func instanceof WarpScriptStackFunction && macros.isEmpty()) {
+                  //
+                  // Function is an WarpScriptStackFunction, call it on this stack
+                  //
+
+                  WarpScriptStackFunction esf = (WarpScriptStackFunction) func;
+
+                  esf.apply(this);
+                } else {
+                  //
+                  // Push any other type of function onto the stack
+                  //
+                  if (macros.isEmpty()) {
+                    push(func);
+                  } else {
+                    macros.get(0).add(func);
+                  }
+                }
+              } finally {
+                if (functionMetrics) {
+                  Sensision.update(SensisionConstants.SENSISION_CLASS_WARPSCRIPT_FUNCTION_COUNT, labels, 1);
+                  Sensision.update(SensisionConstants.SENSISION_CLASS_WARPSCRIPT_FUNCTION_TIME_US, labels, (System.nanoTime() - nano) / 1000L);
+                }
               }
             }
           }

--- a/warp10/src/main/java/io/warp10/script/WarpScriptLib.java
+++ b/warp10/src/main/java/io/warp10/script/WarpScriptLib.java
@@ -108,6 +108,8 @@ import io.warp10.script.filter.FilterLastLE;
 import io.warp10.script.filter.FilterLastLT;
 import io.warp10.script.filter.FilterLastNE;
 import io.warp10.script.filter.LatencyFilter;
+import io.warp10.script.functions.WSAUDIT;
+import io.warp10.script.functions.WSAUDITMODE;
 import io.warp10.script.functions.math.GETEXPONENT;
 import io.warp10.script.functions.math.RANDOM;
 import io.warp10.script.functions.math.ROUND;
@@ -899,7 +901,9 @@ public class WarpScriptLib {
   public static final String STDERR = "STDERR";
   public static final String LOGMSG = "LOGMSG";
   public static final String TDESCRIBE = "TDESCRIBE";
-
+  public static final String WSAUDIT = "WSAUDIT";
+  public static final String WSAUDITMODE = "WSAUDITMODE";
+  
   public static final String REF = "REF";
   public static final String COMPILE = "COMPILE";
   public static final String SAFECOMPILE = "SAFECOMPILE";
@@ -3183,6 +3187,8 @@ public class WarpScriptLib {
     addNamedWarpScriptFunction(new LOGINIT(LOGINIT));
     addNamedWarpScriptFunction(new TDESCRIBE(TDESCRIBE));
     addNamedWarpScriptFunction(new SLEEP(SLEEP));
+    addNamedWarpScriptFunction(new WSAUDIT(WSAUDIT));
+    addNamedWarpScriptFunction(new WSAUDITMODE(WSAUDITMODE));
 
     //
     // LevelDB

--- a/warp10/src/main/java/io/warp10/script/WarpScriptStack.java
+++ b/warp10/src/main/java/io/warp10/script/WarpScriptStack.java
@@ -469,12 +469,27 @@ public interface WarpScriptStack {
               sb.append(((Macro) o).snapshot(hideSecure));
               sb.append(" ");
             } else if (o instanceof WarpScriptStackFunction) {
-              String funcSnapshot = o.toString();
 
               // In the case the snapshot of the function is 'MYFUNC' FUNCREF, instead of adding
               // 'MYFUNC' FUNCREF EVAL to the snapshot, MYFUNC can simply be added.
               // This can be done only if the name of function contains no special character.
               boolean simplified = false;
+
+              if (o instanceof WarpScriptTraceableStatement) {
+                if (((WarpScriptTraceableStatement) o).type == WarpScriptTraceableStatement.STATEMENT_TYPE.FUNCTION_CALL
+                    && ((WarpScriptTraceableStatement) o).statementObject instanceof WarpScriptStackFunction) {
+                  // replace o by the object wrapped into the WarpScriptTraceableStatement
+                  o = ((WarpScriptTraceableStatement) o).statementObject;
+                } else {
+                  // the other types are handled by WarpScriptTraceableStatement directly
+                  sb.append(o.toString());
+                  simplified = true;
+                }
+              }
+              if (o.toString().equals("reducer.max")) {
+                System.out.println("popop");
+              }
+              String funcSnapshot = o.toString();
 
               if (o instanceof NamedWarpScriptFunction) {
                 NamedWarpScriptFunction namedWarpScriptFunction = (NamedWarpScriptFunction) o;

--- a/warp10/src/main/java/io/warp10/script/WarpScriptStack.java
+++ b/warp10/src/main/java/io/warp10/script/WarpScriptStack.java
@@ -123,6 +123,11 @@ public interface WarpScriptStack {
   public static final String ATTRIBUTE_INFOMODE = "infomode";
 
   /**
+   * List of parsing errors generated in WarpScript audit mode
+   */
+  public static final String ATTRIBUTE_PARSING_ERRORS = "wsaudit.errors";
+  
+  /**
    * Debug depth of the stack. This is the number
    * of elements to return when an error occurs.
    */
@@ -774,6 +779,14 @@ public interface WarpScriptStack {
   public void exec(String line) throws WarpScriptException;
 
   /**
+   * Execute a series of statements against the stack.
+   *
+   * @param line       String containing a space separated list of statements to execute
+   * @param lineNumber is the WarpScript line number, when known by exec() caller. Default value is -1.
+   */
+  public void exec(String line, long lineNumber) throws WarpScriptException;
+
+  /**
    * Empty the stack
    *
    */
@@ -971,4 +984,11 @@ public interface WarpScriptStack {
    * If macroOpen was not previously called, this function has no effect.
    */
   public void macroClose() throws WarpScriptException;
+  
+  /**
+   * Turn on/off auditMode. In auditMode, Macros contains WarpScriptTraceableStatement with line numbers or WarpScript parsing errors.
+   * auditMode exits automatically after closing the first macro level, leaving on stack a macro object.
+   */
+  public void auditMode(boolean auditMode);
+  
 }

--- a/warp10/src/main/java/io/warp10/script/WarpScriptTraceableStatement.java
+++ b/warp10/src/main/java/io/warp10/script/WarpScriptTraceableStatement.java
@@ -36,7 +36,7 @@ public class WarpScriptTraceableStatement implements WarpScriptStackFunction {
   public String statement;
   public Long lineNumber;      // first line is numbered 1
   public int positionNumber;   // first statement in line is numbered 0
-  private Object statementObject;
+  public Object statementObject;
 
   public WarpScriptTraceableStatement(WarpScriptTraceableStatement.STATEMENT_TYPE type, Object statementObject, String statement, Long lineNumber, int statementNumber) {
     this.type = type;
@@ -95,22 +95,18 @@ public class WarpScriptTraceableStatement implements WarpScriptStackFunction {
   @Override
   public String toString() {
     switch (type) {
-      case FUNCTION_CALL:  // valid function
-        if (statementObject instanceof WarpScriptStackFunction) {
-          return StackUtils.toString(statement) + " " + WarpScriptLib.FUNCREF;
-        } else {
-          return StackUtils.toString(statement);
-        }
+      case FUNCTION_CALL:
+        return StackUtils.toString(statement) + " " + WarpScriptLib.FUNCREF;
       case UNKNOWN:  // invalid function 
         return StackUtils.toString("Unknown function (" + statement + ")" + formatWSAuditPosition() + ".") + " " + WarpScriptLib.MSGFAIL;
       case WS_EXCEPTION:  // other parsing exception
         return StackUtils.toString("Exception (" + statement + ")" + formatWSAuditPosition() + ".") + " " + WarpScriptLib.MSGFAIL;
-      case WS_EARLY_BINDING:
+      case WS_EARLY_BINDING:  // early binding execution will fail
         return StackUtils.toString(WarpScriptLib.WSAUDITMODE + " does not support indirect binding. (" + statement + ")" + formatWSAuditPosition() + ".") + " " + WarpScriptLib.MSGFAIL;
       case WS_LOAD:
-        return StackUtils.toString(statement.substring(1)) + " " + StackUtils.toString(WarpScriptLib.LOAD) + " " + WarpScriptLib.FUNCREF;
+        return StackUtils.toString(statement.substring(1)) + " " + WarpScriptLib.LOAD;
       case WS_RUN:
-        return StackUtils.toString(statement.substring(1)) + " " + StackUtils.toString(WarpScriptLib.RUN) + " " + WarpScriptLib.FUNCREF;
+        return StackUtils.toString(statement.substring(1)) + " " + WarpScriptLib.RUN;
       default:
         return "";
     }

--- a/warp10/src/main/java/io/warp10/script/WarpScriptTraceableStatement.java
+++ b/warp10/src/main/java/io/warp10/script/WarpScriptTraceableStatement.java
@@ -1,0 +1,120 @@
+//
+//   Copyright 2023  SenX S.A.S.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+package io.warp10.script;
+
+/**
+ * Stores a statement, a type, and its position.
+ * This class is json serializable, snapshotable and, is a WarpScriptStackFunction.
+ * Type is defined by {@link WarpScriptTraceableStatement.STATEMENT_TYPE}
+ */
+public class WarpScriptTraceableStatement implements WarpScriptStackFunction {
+
+  public enum STATEMENT_TYPE {
+    FUNCTION_CALL,    // function present in WarpScriptLib
+    WS_EXCEPTION,     // in this case, statementObject will be a string that contains the exception message 
+    WS_EARLY_BINDING, // managed as a simple load for the moment
+    WS_LOAD,          // load action is stored as one statement, to store the right statement position
+    WS_RUN,           // run action is stored as one statement, to store the right statement position
+    UNKNOWN           // syntax error (missing space, [5 is not a function), function call to a REDEF function, or unknown extension.
+  }
+
+  public WarpScriptTraceableStatement.STATEMENT_TYPE type;
+  public String statement;
+  public Long lineNumber;      // first line is numbered 1
+  public int positionNumber;   // first statement in line is numbered 0
+  private Object statementObject;
+
+  public WarpScriptTraceableStatement(WarpScriptTraceableStatement.STATEMENT_TYPE type, Object statementObject, String statement, Long lineNumber, int statementNumber) {
+    this.type = type;
+    this.statement = statement;
+    this.lineNumber = lineNumber;
+    this.positionNumber = statementNumber;
+    this.statementObject = statementObject;
+  }
+
+  @Override
+  public Object apply(WarpScriptStack stack) throws WarpScriptException {
+    if (type == STATEMENT_TYPE.FUNCTION_CALL) {
+      if (statementObject instanceof WarpScriptStackFunction) {
+        try {
+          ((WarpScriptStackFunction) statementObject).apply(stack);
+        } catch (WarpScriptException e) {
+          throw new WarpScriptException("Exception" + formatWSAuditPosition() + ".", e);
+        }
+      } else {
+        stack.push(statementObject);  // aggregators for example
+      }
+    } else if (type == STATEMENT_TYPE.UNKNOWN) {
+      throw new WarpScriptException("Unknown function " + statement + formatWSAuditPosition() + ".");
+    } else if (type == STATEMENT_TYPE.WS_EXCEPTION) {
+      throw new WarpScriptException(statement + formatWSAuditPosition());
+    } else if (type == STATEMENT_TYPE.WS_EARLY_BINDING) {
+      throw new WarpScriptException(WarpScriptLib.WSAUDITMODE + " does not support indirect binding. (" + statement + ")" + formatWSAuditPosition() + ".");
+    } else if (type == STATEMENT_TYPE.WS_LOAD) {
+      Object o = stack.load(statement.substring(1));
+      if (null == o) {
+        if (!stack.getSymbolTable().containsKey(statement.substring(1))) {
+          throw new WarpScriptException("Unknown symbol '" + statement.substring(1) + "'" + formatWSAuditPosition() + ".");
+        }
+      }
+      stack.push(o);
+    } else if (type == STATEMENT_TYPE.WS_RUN) {
+      try {
+        stack.run(statement.substring(1));
+      } catch (WarpScriptException e) {
+        throw new WarpScriptException("Exception at line " + lineNumber + ", position " + positionNumber + ".", e);
+      }
+    }
+    return stack;
+  }
+
+  /**
+   * fix the format of position, in order to parse the exception message easily in other tools.
+   *
+   * @return " (line x, position y)", where x and y are numbers.
+   */
+  public String formatWSAuditPosition() {
+    return " (line " + lineNumber + ", position " + positionNumber + ")";
+  }
+
+  // used for SNAPSHOT
+  @Override
+  public String toString() {
+    switch (type) {
+      case FUNCTION_CALL:  // valid function
+        if (statementObject instanceof WarpScriptStackFunction) {
+          return StackUtils.toString(statement) + " " + WarpScriptLib.FUNCREF;
+        } else {
+          return StackUtils.toString(statement);
+        }
+      case UNKNOWN:  // invalid function 
+        return StackUtils.toString("Unknown function (" + statement + ")" + formatWSAuditPosition() + ".") + " " + WarpScriptLib.MSGFAIL;
+      case WS_EXCEPTION:  // other parsing exception
+        return StackUtils.toString("Exception (" + statement + ")" + formatWSAuditPosition() + ".") + " " + WarpScriptLib.MSGFAIL;
+      case WS_EARLY_BINDING:
+        return StackUtils.toString(WarpScriptLib.WSAUDITMODE + " does not support indirect binding. (" + statement + ")" + formatWSAuditPosition() + ".") + " " + WarpScriptLib.MSGFAIL;
+      case WS_LOAD:
+        return StackUtils.toString(statement.substring(1)) + " " + StackUtils.toString(WarpScriptLib.LOAD) + " " + WarpScriptLib.FUNCREF;
+      case WS_RUN:
+        return StackUtils.toString(statement.substring(1)) + " " + StackUtils.toString(WarpScriptLib.RUN) + " " + WarpScriptLib.FUNCREF;
+      default:
+        return "";
+    }
+
+  }
+
+}

--- a/warp10/src/main/java/io/warp10/script/functions/WSAUDIT.java
+++ b/warp10/src/main/java/io/warp10/script/functions/WSAUDIT.java
@@ -1,0 +1,37 @@
+//
+//   Copyright 2023  SenX S.A.S.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+package io.warp10.script.functions;
+
+import io.warp10.script.NamedWarpScriptFunction;
+import io.warp10.script.WarpScriptException;
+import io.warp10.script.WarpScriptStack;
+import io.warp10.script.WarpScriptStackFunction;
+
+public class WSAUDIT extends NamedWarpScriptFunction implements WarpScriptStackFunction {
+
+  public WSAUDIT(String name) {
+    super(name);
+  }
+
+  @Override
+  public Object apply(WarpScriptStack stack) throws WarpScriptException {
+
+    stack.push(stack.getAttribute(WarpScriptStack.ATTRIBUTE_PARSING_ERRORS));
+
+    return stack;
+  }
+}

--- a/warp10/src/main/java/io/warp10/script/functions/WSAUDITMODE.java
+++ b/warp10/src/main/java/io/warp10/script/functions/WSAUDITMODE.java
@@ -1,0 +1,35 @@
+//
+//   Copyright 2023  SenX S.A.S.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+package io.warp10.script.functions;
+
+import io.warp10.script.NamedWarpScriptFunction;
+import io.warp10.script.WarpScriptException;
+import io.warp10.script.WarpScriptStack;
+import io.warp10.script.WarpScriptStackFunction;
+
+public class WSAUDITMODE extends NamedWarpScriptFunction implements WarpScriptStackFunction {
+
+  public WSAUDITMODE(String name) {
+    super(name);
+  }
+
+  @Override
+  public Object apply(WarpScriptStack stack) throws WarpScriptException {
+    stack.auditMode(true);
+    return stack;
+  }
+}


### PR DESCRIPTION
Add an audit mode to WarpScript.
After calling `WSAUDITMODE`, the parser create macros with WarpScriptTraceableStatement. These special statements can contain errors, function call, variable load. 
The errors are also listed in *ATTRIBUTE_PARSING_ERRORS* attributes of the stack. `WSAUDIT` returns a json of this error list.
The macros produced in this mode are executable and snapshotable (errors statements are replaced by MSGFAIL).

This PR also clarify the error message linked to early binding.

Examples:
```
WSAUDITMODE 
[ 42 ] 'info' STORE 
<%
  !$info INFO [ 43] +!
%>  
WSAUDIT
```
Will return the error with the missing space line 4, position 3 (position starts at 0)

```
WSAUDITMODE 
[ 42 ] 'info' STORE 
<%
  !$info INFO [ 43] +!
%>  
MACRO->
```
Will return a list of traced statements (with line and position), that will be easy to use for audit tools.
