### PR TITLE
fix leveldb multiline ingestion

### DIFF
--- a/warp10/src/main/java/io/warp10/continuum/ingress/IngressStreamUpdateHandler.java
+++ b/warp10/src/main/java/io/warp10/continuum/ingress/IngressStreamUpdateHandler.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2022  SenX S.A.S.
+//   Copyright 2018-2023  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.

--- a/warp10/src/main/java/io/warp10/continuum/ingress/IngressStreamUpdateHandler.java
+++ b/warp10/src/main/java/io/warp10/continuum/ingress/IngressStreamUpdateHandler.java
@@ -29,6 +29,7 @@ import io.warp10.continuum.sensision.SensisionConstants;
 import io.warp10.continuum.store.Constants;
 import io.warp10.continuum.store.thrift.data.Metadata;
 import io.warp10.crypto.OrderPreservingBase64;
+import io.warp10.fdb.FDBUtils;
 import io.warp10.quasar.token.thrift.data.WriteToken;
 import io.warp10.sensision.Sensision;
 import io.warp10.standalone.StandaloneIngressHandler;
@@ -282,7 +283,7 @@ public class IngressStreamUpdateHandler extends WebSocketHandler.Simple {
               // Force PRODUCER/OWNER
               //
 
-              if (encoder != lastencoder || lastencoder.size() > StandaloneIngressHandler.ENCODER_SIZE_THRESHOLD) {
+              if (encoder != lastencoder || lastencoder.size() > StandaloneIngressHandler.ENCODER_SIZE_THRESHOLD || FDBUtils.hasCriticalTransactionSize(lastencoder, this.maxsize)) {
 
                 //
                 // Check throttling

--- a/warp10/src/main/java/io/warp10/fdb/FDBUtils.java
+++ b/warp10/src/main/java/io/warp10/fdb/FDBUtils.java
@@ -30,11 +30,16 @@ import io.warp10.WarpConfig;
 import io.warp10.continuum.Configuration;
 import io.warp10.continuum.gts.GTSEncoder;
 import io.warp10.continuum.sensision.SensisionConstants;
+import io.warp10.continuum.store.Constants;
 import io.warp10.json.JsonUtils;
 import io.warp10.script.WarpScriptException;
 import io.warp10.sensision.Sensision;
+import io.warp10.standalone.Warp;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class FDBUtils {
+  private static final Logger LOG = LoggerFactory.getLogger(FDBUtils.class);
 
   public static final String CAPABILITY_ADMIN = "fdb.admin";
   public static final String CAPABILITY_STATUS = "fdb.status";
@@ -51,8 +56,15 @@ public class FDBUtils {
   private static final String DEFAULT_FDB_API_VERSION = Integer.toString(710);
 
   static {
-    int version = Integer.parseInt(WarpConfig.getProperty(Configuration.FDB_API_VERSION, DEFAULT_FDB_API_VERSION));
-    FDB.selectAPIVersion(version);
+    if (!Warp.isStandaloneMode() || Constants.BACKEND_FDB.equals(WarpConfig.getProperty(Configuration.BACKEND))) {
+      int version = Integer.parseInt(WarpConfig.getProperty(Configuration.FDB_API_VERSION, DEFAULT_FDB_API_VERSION));
+      try {
+        FDB.selectAPIVersion(version);
+      } catch (Throwable t) {
+        LOG.error("Unable to initialize FoundationDB API version, please ensure the FoundationDB clients package is installed.");
+        throw new RuntimeException("Caught exception when initializing FoundationDB API version, please ensure the FoundationDB clients package is installed.");
+      }
+    }
   }
 
   public static FDB getFDB() {

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneIngressHandler.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneIngressHandler.java
@@ -34,7 +34,6 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import io.warp10.fdb.FDBStoreClient;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.joda.time.Instant;

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneIngressHandler.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneIngressHandler.java
@@ -197,7 +197,7 @@ public class StandaloneIngressHandler extends AbstractHandler {
 
     this.maxValueSize = Long.parseLong(WarpConfig.getProperty(Configuration.STANDALONE_VALUE_MAXSIZE, DEFAULT_VALUE_MAXSIZE));
     
-    this.isFDBStore = storeClient instanceof FDBStoreClient;
+    this.isFDBStore = Constants.BACKEND_FDB.equals(WarpConfig.getProperty(Configuration.BACKEND));
   }
 
   @Override


### PR DESCRIPTION
When trying to ingest compact gts input format on a levelDB standalone, it fails with error 500 and no explaination.
The root cause is that FDBUtils static method `hasCriticalTransactionSize` is not available, because FDBUtils class static block will fail (FDB.selectAPIVersion(version) will fail).

I can fix FDBUtils, but I think is is better to skip the test when not using FDB as a store, for performances.

To test, try to ingest `https://warp10.io/assets/files/ibtracs-2010-2015.gts` on a leveldb 3.x standalone...