### PR TITLE
allow to remove property

### DIFF
--- a/warp10/src/main/java/io/warp10/WarpConfig.java
+++ b/warp10/src/main/java/io/warp10/WarpConfig.java
@@ -326,6 +326,15 @@ public class WarpConfig {
       }
 
       //
+      // Remove properties if value is -
+      //
+
+      if ("-".equals(tokens[1])) {
+        properties.remove(tokens[0]);
+        continue;
+      }
+      
+      //
       // Ignore empty properties
       //
 

--- a/warp10/src/main/java/io/warp10/WarpConfig.java
+++ b/warp10/src/main/java/io/warp10/WarpConfig.java
@@ -309,11 +309,6 @@ public class WarpConfig {
         continue;
       }
 
-      if (tokens.length < 2) {
-        LOG.warn("Empty value for property '" + tokens[0] + "' on line " + lineno + ", ignoring.");
-        continue;
-      }
-
       // Remove URL encoding if a '%' sign is present in the token
       try {
         for (int i = 0; i < tokens.length; i++) {
@@ -325,14 +320,16 @@ public class WarpConfig {
         continue;
       }
 
-      //
-      // Remove property when empty
-      //
-
-      if ("".equals(tokens[1])) {
-        properties.remove(tokens[0]);
+      if (tokens.length < 2) {
+        if (properties.containsKey(tokens[0])) {
+          LOG.warn("Empty value for property '" + tokens[0] + "' on line " + lineno + ", has cleared the previous value of '" + properties.getProperty(tokens[0]) + "'");
+          properties.remove(tokens[0]);
+        } else {
+          LOG.warn("Empty value for property '" + tokens[0] + "' on line " + lineno + ", ignoring.");
+        }
         continue;
       }
+
 
       //
       // Set property

--- a/warp10/src/main/java/io/warp10/WarpConfig.java
+++ b/warp10/src/main/java/io/warp10/WarpConfig.java
@@ -320,7 +320,7 @@ public class WarpConfig {
         continue;
       }
 
-      if (tokens.length < 2) {
+      if (tokens.length < 2 || "".equals(tokens[1])) {
         if (properties.containsKey(tokens[0])) {
           LOG.warn("Empty value for property '" + tokens[0] + "' on line " + lineno + ", has cleared the previous value of '" + properties.getProperty(tokens[0]) + "'");
           properties.remove(tokens[0]);

--- a/warp10/src/main/java/io/warp10/WarpConfig.java
+++ b/warp10/src/main/java/io/warp10/WarpConfig.java
@@ -309,11 +309,16 @@ public class WarpConfig {
         continue;
       }
 
-      // Remove URL encoding if a '%' sign is present in the token
+      // 
+      // x =      // remove the property when previously set.
+      // x = %20  // property value = " "
+      // empty string value is therefore not possible
+      //
+      
       try {
         for (int i = 0; i < tokens.length; i++) {
-          tokens[i] = WarpURLDecoder.decode(tokens[i], StandardCharsets.UTF_8);
           tokens[i] = tokens[i].trim();
+          tokens[i] = WarpURLDecoder.decode(tokens[i], StandardCharsets.UTF_8);
         }
       } catch (IllegalArgumentException iae) {
         linesInError.add(lineno);

--- a/warp10/src/main/java/io/warp10/WarpConfig.java
+++ b/warp10/src/main/java/io/warp10/WarpConfig.java
@@ -326,19 +326,11 @@ public class WarpConfig {
       }
 
       //
-      // Remove property if value is -
-      //
-
-      if ("-".equals(tokens[1])) {
-        properties.remove(tokens[0]);
-        continue;
-      }
-      
-      //
-      // Ignore empty properties
+      // Remove property when empty
       //
 
       if ("".equals(tokens[1])) {
+        properties.remove(tokens[0]);
         continue;
       }
 

--- a/warp10/src/main/java/io/warp10/WarpConfig.java
+++ b/warp10/src/main/java/io/warp10/WarpConfig.java
@@ -326,7 +326,7 @@ public class WarpConfig {
       }
 
       //
-      // Remove properties if value is -
+      // Remove property if value is -
       //
 
       if ("-".equals(tokens[1])) {


### PR DESCRIPTION
Allow to generate easily a 999-migration3x.conf file that remove some configurations.

Example:
```
# remove extensions
warpscript.extension.debug = 
warpscript.extension.hbase=     
warpscript.extension.inventory= 
```

Also allows space as a configuration value, when url encoded:
```
x = %20
```

Empty value are still not possible for configuration.