### PR TITLE
Added forced sorting of GTS when gskip/gcount is specified.

### DIFF
--- a/warp10/src/main/java/io/warp10/continuum/egress/EgressFetchHandler.java
+++ b/warp10/src/main/java/io/warp10/continuum/egress/EgressFetchHandler.java
@@ -190,6 +190,7 @@ public class EgressFetchHandler extends AbstractHandler {
       long gcount = Long.MAX_VALUE;
       long gskip = 0;
       long count = -1;
+      boolean mustSort = false;
       long skip = 0;
       long step = 1L;
       long timestep = 1L;
@@ -382,10 +383,12 @@ public class EgressFetchHandler extends AbstractHandler {
 
       if (null != gcountParam) {
         gcount = Long.parseLong(gcountParam);
+        mustSort = true;
       }
 
       if (null != gskipParam) {
         gskip = Long.parseLong(gskipParam);
+        mustSort = true;
       }
 
       if (null != stepParam) {
@@ -652,6 +655,7 @@ public class EgressFetchHandler extends AbstractHandler {
           lblsSels.add(labelsSelectors);
 
           DirectoryRequest request = new DirectoryRequest();
+          request.setSorted(mustSort);
           request.setClassSelectors(clsSels);
           request.setLabelsSelectors(lblsSels);
 

--- a/warp10/src/main/java/io/warp10/continuum/egress/EgressFindHandler.java
+++ b/warp10/src/main/java/io/warp10/continuum/egress/EgressFindHandler.java
@@ -86,8 +86,11 @@ public class EgressFindHandler extends AbstractHandler {
     long gskip = 0L;
     long gcount = Long.MAX_VALUE;
 
+    boolean mustSort = false;
+
     if (null != req.getParameter(Constants.HTTP_PARAM_GSKIP)) {
       gskip = Long.parseLong(req.getParameter(Constants.HTTP_PARAM_GSKIP));
+      mustSort = true;
     }
 
     // 'limit' predates 'gcount', it may be overriden if 'gcount' is set too
@@ -98,6 +101,7 @@ public class EgressFindHandler extends AbstractHandler {
     // 'gcount' overrides 'limit'
     if (null != req.getParameter(Constants.HTTP_PARAM_GCOUNT)) {
       gcount = Long.parseLong(req.getParameter(Constants.HTTP_PARAM_GCOUNT));
+      mustSort = true;
     }
 
     if (null == token) {
@@ -187,6 +191,7 @@ public class EgressFindHandler extends AbstractHandler {
           lblsSels.add(labelsSelector);
 
           DirectoryRequest request = new DirectoryRequest();
+          request.setSorted(mustSort);
           request.setClassSelectors(clsSels);
           request.setLabelsSelectors(lblsSels);
 

--- a/warp10/src/main/java/io/warp10/continuum/egress/EgressSplitsHandler.java
+++ b/warp10/src/main/java/io/warp10/continuum/egress/EgressSplitsHandler.java
@@ -98,13 +98,16 @@ public class EgressSplitsHandler extends AbstractHandler {
 
     long gskip = 0L;
     long gcount = Long.MAX_VALUE;
+    boolean mustSort = false;
 
     if (null != request.getParameter(Constants.HTTP_PARAM_GSKIP)) {
       gskip = Long.parseLong(request.getParameter(Constants.HTTP_PARAM_GSKIP));
+      mustSort = true;
     }
 
     if (null != request.getParameter(Constants.HTTP_PARAM_GCOUNT)) {
       gcount = Long.parseLong(request.getParameter(Constants.HTTP_PARAM_GCOUNT));
+      mustSort = true;
     }
 
     //
@@ -169,6 +172,7 @@ public class EgressSplitsHandler extends AbstractHandler {
     Transaction txn = null;
 
     DirectoryRequest drequest = new DirectoryRequest();
+    drequest.setSorted(mustSort);
     drequest.setClassSelectors(clsSels);
     drequest.setLabelsSelectors(lblsSels);
 

--- a/warp10/src/main/java/io/warp10/continuum/ingress/Ingress.java
+++ b/warp10/src/main/java/io/warp10/continuum/ingress/Ingress.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2022  SenX S.A.S.
+//   Copyright 2018-2023  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -1594,13 +1594,16 @@ public class Ingress extends AbstractHandler implements Runnable {
 
       long gskip = 0L;
       long gcount = Long.MAX_VALUE;
+      boolean mustSort = false;
 
       if (null != request.getParameter(Constants.HTTP_PARAM_GSKIP)) {
         gskip = Long.parseLong(request.getParameter(Constants.HTTP_PARAM_GSKIP));
+        mustSort = true;
       }
 
       if (null != request.getParameter(Constants.HTTP_PARAM_GCOUNT)) {
         gcount = Long.parseLong(request.getParameter(Constants.HTTP_PARAM_GCOUNT));
+        mustSort = true;
       }
 
       //
@@ -1675,6 +1678,7 @@ public class Ingress extends AbstractHandler implements Runnable {
         TSerializer serializer = new TSerializer(new TCompactProtocol.Factory());
 
         DirectoryRequest drequest = new DirectoryRequest();
+        drequest.setSorted(mustSort);
 
         Long activeAfter = null == request.getParameter(Constants.HTTP_PARAM_ACTIVEAFTER) ? null : Long.parseLong(request.getParameter(Constants.HTTP_PARAM_ACTIVEAFTER));
         Long quietAfter = null == request.getParameter(Constants.HTTP_PARAM_QUIETAFTER) ? null : Long.parseLong(request.getParameter(Constants.HTTP_PARAM_QUIETAFTER));
@@ -1897,6 +1901,7 @@ public class Ingress extends AbstractHandler implements Runnable {
       } else {
 
         DirectoryRequest drequest = new DirectoryRequest();
+        drequest.setSorted(mustSort);
         drequest.setClassSelectors(clsSels);
         drequest.setLabelsSelectors(lblsSels);
 

--- a/warp10/src/main/java/io/warp10/script/functions/FETCH.java
+++ b/warp10/src/main/java/io/warp10/script/functions/FETCH.java
@@ -318,13 +318,16 @@ public class FETCH extends NamedWarpScriptFunction implements WarpScriptStackFun
 
     long gskip = 0L;
     long gcount = Long.MAX_VALUE;
+    boolean mustSort = false;
 
     if (params.get(PARAM_GSKIP) instanceof Long) {
       gskip = ((Long) params.get(PARAM_GSKIP)).longValue();
+      mustSort = true;
     }
 
     if (params.get(PARAM_GCOUNT) instanceof Long) {
       gcount = ((Long) params.get(PARAM_GCOUNT)).longValue();
+      mustSort = true;
     }
 
     if (params.containsKey(PARAM_METASET)) {
@@ -495,6 +498,7 @@ public class FETCH extends NamedWarpScriptFunction implements WarpScriptStackFun
       }
 
       DirectoryRequest drequest = new DirectoryRequest();
+      drequest.setSorted(mustSort);
       drequest.setClassSelectors(clsSels);
       drequest.setLabelsSelectors(lblsSels);
 

--- a/warp10/src/main/java/io/warp10/script/functions/FIND.java
+++ b/warp10/src/main/java/io/warp10/script/functions/FIND.java
@@ -217,6 +217,16 @@ public class FIND extends NamedWarpScriptFunction implements WarpScriptStackFunc
       top = stack.pop();
       Map<String,Object> params = paramsFromMap((Map) top);
 
+      if (params.get(FETCH.PARAM_GSKIP) instanceof Long) {
+        gskip = ((Long) params.get(FETCH.PARAM_GSKIP)).longValue();
+        mustSort = true;
+      }
+
+      if (params.get(FETCH.PARAM_GCOUNT) instanceof Long) {
+        gcount = ((Long) params.get(FETCH.PARAM_GCOUNT)).longValue();
+        mustSort = true;
+      }
+
       if (params.containsKey(FETCH.PARAM_SELECTOR_PAIRS)) {
         List<Pair<Object, Object>> selectors = (List<Pair<Object, Object>>) params.get(FETCH.PARAM_SELECTOR_PAIRS);
         drequest = new DirectoryRequest();
@@ -241,16 +251,6 @@ public class FIND extends NamedWarpScriptFunction implements WarpScriptStackFunc
 
       if (params.containsKey(FETCH.PARAM_LABELS_PRIORITY)) {
         order = (List<String>) params.get(FETCH.PARAM_LABELS_PRIORITY);
-      }
-
-      if (params.get(FETCH.PARAM_GSKIP) instanceof Long) {
-        gskip = ((Long) params.get(FETCH.PARAM_GSKIP)).longValue();
-        mustSort = true;
-      }
-
-      if (params.get(FETCH.PARAM_GCOUNT) instanceof Long) {
-        gcount = ((Long) params.get(FETCH.PARAM_GCOUNT)).longValue();
-        mustSort = true;
       }
     } else {
       if (this.metaset) {
@@ -388,7 +388,6 @@ public class FIND extends NamedWarpScriptFunction implements WarpScriptStackFunc
     Iterator<Metadata> iter = null;
 
     try {
-
       if (null == drequest) {
         drequest = new DirectoryRequest();
         drequest.setSorted(mustSort);

--- a/warp10/src/main/java/io/warp10/script/functions/FIND.java
+++ b/warp10/src/main/java/io/warp10/script/functions/FIND.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2021  SenX S.A.S.
+//   Copyright 2018-2023  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -211,6 +211,7 @@ public class FIND extends NamedWarpScriptFunction implements WarpScriptStackFunc
 
     long gskip = 0L;
     long gcount = Long.MAX_VALUE;
+    boolean mustSort = false;
 
     if (mapparams) {
       top = stack.pop();
@@ -219,6 +220,7 @@ public class FIND extends NamedWarpScriptFunction implements WarpScriptStackFunc
       if (params.containsKey(FETCH.PARAM_SELECTOR_PAIRS)) {
         List<Pair<Object, Object>> selectors = (List<Pair<Object, Object>>) params.get(FETCH.PARAM_SELECTOR_PAIRS);
         drequest = new DirectoryRequest();
+        drequest.setSorted(mustSort);
         for (int i = 0; i < selectors.size(); i++) {
           String csel = (String) selectors.get(i).getLeft();
           Map<String,String> lsel = (Map<String,String>) selectors.get(i).getRight();
@@ -243,10 +245,12 @@ public class FIND extends NamedWarpScriptFunction implements WarpScriptStackFunc
 
       if (params.get(FETCH.PARAM_GSKIP) instanceof Long) {
         gskip = ((Long) params.get(FETCH.PARAM_GSKIP)).longValue();
+        mustSort = true;
       }
 
       if (params.get(FETCH.PARAM_GCOUNT) instanceof Long) {
         gcount = ((Long) params.get(FETCH.PARAM_GCOUNT)).longValue();
+        mustSort = true;
       }
     } else {
       if (this.metaset) {
@@ -387,6 +391,7 @@ public class FIND extends NamedWarpScriptFunction implements WarpScriptStackFunc
 
       if (null == drequest) {
         drequest = new DirectoryRequest();
+        drequest.setSorted(mustSort);
         drequest.setClassSelectors(clsSels);
         drequest.setLabelsSelectors(lblsSels);
       } else {

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneSplitsHandler.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneSplitsHandler.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2022  SenX S.A.S.
+//   Copyright 2018-2023  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -81,13 +81,18 @@ public class StandaloneSplitsHandler extends AbstractHandler {
 
     long gskip = 0L;
     long gcount = Long.MAX_VALUE;
+    // forcing sorting is not necessary with the current (2023-04-25) implementation of the standalone Directory, but we nevertheless
+    // set 'sorted' in the DirectoryRequest in case we change the Directory implementation in the future.
+    boolean mustSort = false;
 
     if (null != request.getParameter(Constants.HTTP_PARAM_GSKIP)) {
       gskip = Long.parseLong(request.getParameter(Constants.HTTP_PARAM_GSKIP));
+      mustSort = true;
     }
 
     if (null != request.getParameter(Constants.HTTP_PARAM_GCOUNT)) {
       gcount = Long.parseLong(request.getParameter(Constants.HTTP_PARAM_GCOUNT));
+      mustSort = true;
     }
 
     //
@@ -152,6 +157,7 @@ public class StandaloneSplitsHandler extends AbstractHandler {
     //
 
     DirectoryRequest dr = new DirectoryRequest();
+    dr.setSorted(mustSort);
     dr.setClassSelectors(clsSels);
     dr.setLabelsSelectors(lblsSels);
 


### PR DESCRIPTION
Ensure that GTS results from Directory requests are sorted when gskip/gcount are specified. This is of importance if there are several Directory instances.