### PR TITLE
update SHRINK behavior

### DIFF
--- a/warp10/src/main/java/io/warp10/script/functions/SHRINK.java
+++ b/warp10/src/main/java/io/warp10/script/functions/SHRINK.java
@@ -49,13 +49,12 @@ public class SHRINK extends ListRecursiveStackFunction {
         if (element instanceof GeoTimeSerie) {
           GeoTimeSerie gts = (GeoTimeSerie) element;
 
-          if (shrinkto < 0) {
-            GTSHelper.sort(gts, true);
-          } else {
-            GTSHelper.sort(gts, false);
-          }
-
           if (GTSHelper.nvalues(gts) > Math.abs(shrinkto)) {
+            if (shrinkto < 0) {
+              GTSHelper.sort(gts, true);
+            } else {
+              GTSHelper.sort(gts, false);
+            }
             GTSHelper.shrinkTo(gts, (int) Math.abs(shrinkto));
           }
           return gts;


### PR DESCRIPTION
Fix `SHRINK` function.
Previously:
- when size was less than requested size, exception
- when size was equal, do nothing (no sort)
- when size was bigger than requested size, sort (or reverse sort), then shrink.

Now:
- when size greater than requested size : sort (or reverse sort) then shrink
- when size is less than requested size : let gts untouched
- can be applied on list of gts.

Documentation updated.

