### PR TITLE
Update of WarpScript parser

### DIFF
--- a/warp10/src/main/java/io/warp10/json/WarpScriptAuditStatementSerializer.java
+++ b/warp10/src/main/java/io/warp10/json/WarpScriptAuditStatementSerializer.java
@@ -35,7 +35,8 @@ public class WarpScriptAuditStatementSerializer extends StdSerializer<WarpScript
     gen.writeStartObject();
     gen.writeStringField(WarpScriptAuditStatement.KEY_TYPE,st.type.name());
     gen.writeNumberField(WarpScriptAuditStatement.KEY_LINE,st.lineNumber);
-    gen.writeNumberField(WarpScriptAuditStatement.KEY_POSITION,st.positionNumber);
+    gen.writeNumberField(WarpScriptAuditStatement.KEY_POSITION,st.inLinePositionStart);
+    gen.writeNumberField(WarpScriptAuditStatement.KEY_POSITION_END,st.inLinePositionEnd);
     gen.writeStringField(WarpScriptAuditStatement.KEY_STATEMENT,st.statement);
     gen.writeEndObject();
   }

--- a/warp10/src/main/java/io/warp10/script/MemoryWarpScriptStack.java
+++ b/warp10/src/main/java/io/warp10/script/MemoryWarpScriptStack.java
@@ -598,6 +598,8 @@ public class MemoryWarpScriptStack implements WarpScriptStack, Progressable {
           }
           multiline.append(rawline);
         }
+        handleSignal();
+        progress();
         return;
       } else if (inComment.get()) {
         int end = line.indexOf(COMMENT_END);
@@ -624,7 +626,7 @@ public class MemoryWarpScriptStack implements WarpScriptStack, Progressable {
           //
           // Start of comment block /*
           //
-          if (line.length() - pos > 1 && line.charAt(pos) == '/' && line.charAt(pos + 1) == '*') {
+          if (pos < line.length() - 1 && line.charAt(pos) == '/' && line.charAt(pos + 1) == '*') {
             inComment.set(true);
             end = line.indexOf(COMMENT_END, pos + 2); // Look at the end of the comment block on the same line
             if (-1 != end) {
@@ -637,7 +639,7 @@ public class MemoryWarpScriptStack implements WarpScriptStack, Progressable {
           //
           // End of comment block */
           //
-          if (line.length() - pos > 1 && line.charAt(pos) == '*' && line.charAt(pos + 1) == '/') {
+          if (pos < line.length() - 1 && line.charAt(pos) == '*' && line.charAt(pos + 1) == '/') {
             if (!inComment.get()) {
               if (auditMode && !(macros.isEmpty() || macros.size() == forcedMacro)) {
                 WarpScriptAuditStatement err = new WarpScriptAuditStatement(WarpScriptAuditStatement.STATEMENT_TYPE.WS_EXCEPTION, null, "Not inside a comment.", lineNumber, pos, pos + 1);
@@ -694,6 +696,9 @@ public class MemoryWarpScriptStack implements WarpScriptStack, Progressable {
             trimmedLength--;
           }
           trimmedLength++;
+          if (0 == trimmedLength) {
+            break; // empty line
+          }
           if (line.charAt(pos) == '"' || line.charAt(pos) == '\'') {
             char sep = line.charAt(pos);
             boolean warnSepInclusion = false;

--- a/warp10/src/main/java/io/warp10/script/MemoryWarpScriptStack.java
+++ b/warp10/src/main/java/io/warp10/script/MemoryWarpScriptStack.java
@@ -702,7 +702,7 @@ public class MemoryWarpScriptStack implements WarpScriptStack, Progressable {
               while (strEnd < trimmedLength) {
                 if (line.charAt(strEnd) == sep) {
                   if (strEnd == trimmedLength - 1 || line.charAt(strEnd + 1) == ' ') {
-                    // End of line, or followed by a separator
+                    // End of trimmed line, or followed by a whitespace
                     end = strEnd;
                     break;
                   } else {

--- a/warp10/src/main/java/io/warp10/script/MemoryWarpScriptStack.java
+++ b/warp10/src/main/java/io/warp10/script/MemoryWarpScriptStack.java
@@ -646,7 +646,7 @@ public class MemoryWarpScriptStack implements WarpScriptStack, Progressable {
                 throw new WarpScriptException("Not inside a comment.");
               }
             }
-            // is it followed by a space, or by end of line ?
+            // is it followed by a space, or by end of line?
             if (pos == line.length() - 2 || line.charAt(pos + 2) == ' ') {
               inComment.set(false);
               pos = pos + 2;
@@ -679,19 +679,29 @@ public class MemoryWarpScriptStack implements WarpScriptStack, Progressable {
           handleSignal();
           progress();
 
-          // Detect strings, "xx" or 'xx'
-          // If the separator is at the end of the line or
+          //
+          // Trim end of line to comply with string detection of the previous parser
+          // "a"%09a" is a valid single string (separator not followed by a space)
+          // "a" followed by a tabulation then end of line should also be valid (previous parser trimmed the line)
+          //
+          // Then detect strings, "xx" or 'xx' if the separator is at the end of the line or
           // followed by a whitespace then we consider we exited the string, otherwise
           // it is just part of the string, but we store a warning flag.
+          //
+          int trimmedLength = line.length() - 1;
+          while (trimmedLength > 0 && line.charAt(trimmedLength) <= ' ') {
+            trimmedLength--;
+          }
+          trimmedLength++;
           if (line.charAt(pos) == '"' || line.charAt(pos) == '\'') {
             char sep = line.charAt(pos);
             boolean warnSepInclusion = false;
             end = -1;
-            if (pos != line.length() - 1) { // Do not look for string end if it starts at line end
+            if (pos != trimmedLength - 1) { // Do not look for string end if it starts at line end
               int strEnd = pos + 1;
-              while (strEnd < line.length()) {
+              while (strEnd < trimmedLength) {
                 if (line.charAt(strEnd) == sep) {
-                  if (strEnd == line.length() - 1 || line.charAt(strEnd + 1) <= ' ') {
+                  if (strEnd == trimmedLength - 1 || line.charAt(strEnd + 1) == ' ') {
                     // End of line, or followed by a separator
                     end = strEnd;
                     break;

--- a/warp10/src/main/java/io/warp10/script/MemoryWarpScriptStack.java
+++ b/warp10/src/main/java/io/warp10/script/MemoryWarpScriptStack.java
@@ -643,27 +643,28 @@ public class MemoryWarpScriptStack implements WarpScriptStack, Progressable {
               } else {
                 throw new WarpScriptException("Not inside a multiline.");
               }
-            }
-            inMultiline.set(false);
-
-            String mlcontent = multiline.toString();
-
-            if (null != secureScript) {
-              secureScript.append(" ");
-              secureScript.append("'");
-              try {
-                secureScript.append(WarpURLEncoder.encode(mlcontent, StandardCharsets.UTF_8));
-              } catch (UnsupportedEncodingException uee) {
-              }
-              secureScript.append("'");
             } else {
-              if (macros.isEmpty()) {
-                this.push(mlcontent);
+              inMultiline.set(false);
+
+              String mlcontent = multiline.toString();
+
+              if (null != secureScript) {
+                secureScript.append(" ");
+                secureScript.append("'");
+                try {
+                  secureScript.append(WarpURLEncoder.encode(mlcontent, StandardCharsets.UTF_8));
+                } catch (UnsupportedEncodingException uee) {
+                }
+                secureScript.append("'");
               } else {
-                macros.get(0).add(mlcontent);
+                if (macros.isEmpty()) {
+                  this.push(mlcontent);
+                } else {
+                  macros.get(0).add(mlcontent);
+                }
               }
+              multiline.setLength(0);
             }
-            multiline.setLength(0);
             continue;
           } else if (inMultiline.get()) {
             if (multiline.length() > 0) {

--- a/warp10/src/main/java/io/warp10/script/MemoryWarpScriptStack.java
+++ b/warp10/src/main/java/io/warp10/script/MemoryWarpScriptStack.java
@@ -604,6 +604,8 @@ public class MemoryWarpScriptStack implements WarpScriptStack, Progressable {
       } else if (inComment.get()) {
         int end = line.indexOf(COMMENT_END);
         if (-1 == end) {
+          handleSignal();
+          progress();
           return; // No end of comment in this line, skip it
         } else {
           start = end; // Skip the beginning of the line, before */

--- a/warp10/src/main/java/io/warp10/script/WarpScriptAuditStatement.java
+++ b/warp10/src/main/java/io/warp10/script/WarpScriptAuditStatement.java
@@ -29,6 +29,7 @@ public class WarpScriptAuditStatement implements WarpScriptStackFunction {
   public static final String KEY_TYPE = "type";
   public static final String KEY_LINE = "line";
   public static final String KEY_POSITION = "position";
+  public static final String KEY_POSITION_END = "position.end";
   public static final String KEY_STATEMENT = "statement";
 
   public enum STATEMENT_TYPE {
@@ -44,17 +45,27 @@ public class WarpScriptAuditStatement implements WarpScriptStackFunction {
   public STATEMENT_TYPE type;
   public String statement;
   public long lineNumber;      // first line is numbered 1
-  public int positionNumber;   // first statement in line is numbered 0
+  public int inLinePositionStart;   // first character of the line is numbered 0
+  public int inLinePositionEnd;     // end of the statement or audit issue 
   public Object statementObject;
 
-  public WarpScriptAuditStatement(STATEMENT_TYPE type, Object statementObject, String statement, Long lineNumber, int statementNumber) {
+  public WarpScriptAuditStatement(STATEMENT_TYPE type, Object statementObject, String statement, Long lineNumber, int start) {
     this.type = type;
     this.statement = statement;
     this.lineNumber = lineNumber;
-    this.positionNumber = statementNumber;
+    this.inLinePositionStart = start;
+    this.inLinePositionEnd = statement == null ? start : start + statement.length();
     this.statementObject = statementObject;
   }
 
+  public WarpScriptAuditStatement(STATEMENT_TYPE type, Object statementObject, String statement, Long lineNumber, int start, int end) {
+    this.type = type;
+    this.statement = statement;
+    this.lineNumber = lineNumber;
+    this.inLinePositionStart = start;
+    this.inLinePositionEnd = end;
+    this.statementObject = statementObject;
+  }
   @Override
   public Object apply(WarpScriptStack stack) throws WarpScriptException {
     switch (type) {
@@ -101,7 +112,7 @@ public class WarpScriptAuditStatement implements WarpScriptStackFunction {
    * @return " (line x, position y)", where x and y are numbers.
    */
   public String formatPosition() {
-    return " (line " + lineNumber + ", position " + positionNumber + ")";
+    return " (line " + lineNumber + ", position " + inLinePositionStart + ")";
   }
 
   /**
@@ -112,7 +123,8 @@ public class WarpScriptAuditStatement implements WarpScriptStackFunction {
     Map m = new LinkedHashMap();
     m.put(KEY_TYPE,type.name());
     m.put(KEY_LINE,lineNumber);
-    m.put(KEY_POSITION,((Integer)positionNumber).longValue()); // WarpScript knows LONG 
+    m.put(KEY_POSITION,((Integer) inLinePositionStart).longValue()); // WarpScript knows LONG 
+    m.put(KEY_POSITION_END,((Integer) inLinePositionEnd).longValue()); // WarpScript knows LONG 
     m.put(KEY_STATEMENT,statement);
     return m;
   } 

--- a/warp10/src/main/java/io/warp10/script/WarpScriptAuditStatement.java
+++ b/warp10/src/main/java/io/warp10/script/WarpScriptAuditStatement.java
@@ -37,6 +37,7 @@ public class WarpScriptAuditStatement implements WarpScriptStackFunction {
     WS_EARLY_BINDING, // managed as a simple load for the moment
     WS_LOAD,          // load action is stored as one statement, to store the right statement position
     WS_RUN,           // run action is stored as one statement, to store the right statement position
+    WS_WARNING,       // something legal in WarpScript, but than can be misleading
     UNKNOWN           // syntax error (missing space, [5 is not a function), function call to a REDEF function, or unknown extension.
   }
 


### PR DESCRIPTION
- when not in multiline, `multiline.toString(); ` previously lead to a npe
- `/* "x": true, */ 42` was previously failing
- tab characters were previously tolerated at the beginning and end of each line (side effect of trim()). Now all control characters are valid separator
- statement number is replaced by position in line, easier for any debugging extension or code audit.

