### PR TITLE
Fixes to labels id computation

### DIFF
--- a/crypto/src/main/java/io/warp10/crypto/SipHashInline.java
+++ b/crypto/src/main/java/io/warp10/crypto/SipHashInline.java
@@ -33,22 +33,6 @@ import java.nio.ByteOrder;
  */
 public class SipHashInline {
 
-  private static final sun.misc.Unsafe UNSAFE;
-
-  static {
-    sun.misc.Unsafe unsafe = null;
-    try {
-      java.lang.reflect.Field field = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
-      field.setAccessible(true);
-      unsafe = (sun.misc.Unsafe) field.get(null);
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
-    UNSAFE = unsafe;
-  }
-
-  private static final long base = UNSAFE.arrayBaseOffset(new byte[0].getClass());
-
   /**
    * Hash 24 long.
    *
@@ -130,22 +114,11 @@ public class SipHashInline {
     // processing 8 bytes blocks in data
     while (i < last) {
       // pack a block to long, as LE 8 bytes
-      /*
-      m = (data[!reversed ? offset + i++ : offset + (len - 1) - i++] & 0xffL)
-          | (data[!reversed ? offset + i++ : offset + (len - 1) - i++] & 0xffL) << 8
-          | (data[!reversed ? offset + i++ : offset + (len - 1) - i++] & 0xffL) << 16
-          | (data[!reversed ? offset + i++ : offset + (len - 1) - i++] & 0xffL) << 24
-          | (data[!reversed ? offset + i++ : offset + (len - 1) - i++] & 0xffL) << 32
-          | (data[!reversed ? offset + i++ : offset + (len - 1) - i++] & 0xffL) << 40
-          | (data[!reversed ? offset + i++ : offset + (len - 1) - i++] & 0xffL) << 48
-          | (data[!reversed ? offset + i++ : offset + (len - 1) - i++] & 0xffL) << 56;
-      */
 
       if (!reversed) {
-        m = UNSAFE.getLong(data, base + offset + i);
-        //m = Long.reverseBytes(m);
+        m = getLong(data, offset + i);
       } else {
-        m = UNSAFE.getLong(data, base + offset + len - 1 - (i + 7));
+        m = getLong(data, offset + len - 1 - (i + 7));
         m = Long.reverseBytes(m);
       }
 
@@ -380,26 +353,8 @@ public class SipHashInline {
 
     if (last > 0) {
       while (idx < len8) {
-        /*
-        m = (data[offset + idx] & 0xffL);
-        idx++;
-        m |= (data[offset + idx] & 0xffL) << 8;
-        idx++;
-        m |= (data[offset + idx] & 0xffL) << 16;
-        idx++;
-        m |= (data[offset + idx] & 0xffL) << 24;
-        idx++;
-        m |= (data[offset + idx] & 0xffL) << 32;
-        idx++;
-        m |= (data[offset + idx] & 0xffL) << 40;
-        idx++;
-        m |= (data[offset + idx] & 0xffL) << 48;
-        idx++;
-        m |= (data[offset + idx] & 0xffL) << 56;
-        idx++;        
-        */
+        m = getLong(data, offset + idx);
 
-        m = UNSAFE.getLong(data, base + offset + idx);
         idx += 8;
 
         // MSGROUND {
@@ -482,7 +437,7 @@ public class SipHashInline {
         v2 = (v2 << 32) | v2 >>> 32;
         // }
         v0 ^= m;
-        // }      
+        // }
       }
 
       {
@@ -591,26 +546,7 @@ public class SipHashInline {
       }
 
       while (idx < last) {
-        /*
-        m = (data[offset2 - idx] & 0xffL);
-        idx++;
-        m |= (data[offset2 - idx] & 0xffL) << 8;
-        idx++;
-        m |= (data[offset2 - idx] & 0xffL) << 16;
-        idx++;
-        m |= (data[offset2 - idx] & 0xffL) << 24;
-        idx++;
-        m |= (data[offset2 - idx] & 0xffL) << 32;
-        idx++;
-        m |= (data[offset2 - idx] & 0xffL) << 40;
-        idx++;
-        m |= (data[offset2 - idx] & 0xffL) << 48;
-        idx++;
-        m |= (data[offset2 - idx] & 0xffL) << 56;
-        idx++;        
-        */
-
-        m = Long.reverseBytes(UNSAFE.getLong(data, base + offset2 - (idx + 7)));
+        m = Long.reverseBytes(getLong(data, offset2 - (idx + 7)));
         idx += 8;
 
         // MSGROUND {
@@ -885,5 +821,27 @@ public class SipHashInline {
     sipkey[1] = bb.getLong();
 
     return sipkey;
+  }
+
+  private static long getLong(byte[] data, int offset) {
+    long l = 0L;
+
+    l = data[offset + 7] & 0xFFL;
+    l <<= 8;
+    l |= data[offset + 6] & 0xFFL;
+    l <<= 8;
+    l |= data[offset + 5] & 0xFFL;
+    l <<= 8;
+    l |= data[offset + 4] & 0xFFL;
+    l <<= 8;
+    l |= data[offset + 3] & 0xFFL;
+    l <<= 8;
+    l |= data[offset + 2] & 0xFFL;
+    l <<= 8;
+    l |= data[offset + 1] & 0xFFL;
+    l <<= 8;
+    l |= data[offset] & 0xFFL;
+
+    return l;
   }
 }

--- a/warp10/src/main/java/io/warp10/continuum/Configuration.java
+++ b/warp10/src/main/java/io/warp10/continuum/Configuration.java
@@ -74,6 +74,11 @@ public class Configuration {
   public static final String WARP_DEFAULT_AES_LOGGING = "hex:3cf5cee9eadddba796f2cce0762f308ad9df36f4883841e167dab2889bcf215b";
 
   /**
+   * Set to true to ignore inconsistencies detected when loading GTS.
+   */
+  public static final String WARP_IGNORE_ID_INCONSISTENCIES = "warp.ignore.id.inconsistencies";
+
+  /**
    * Some libraries (like Processing), expect the Java version to be 1.y.z, as this has changed
    * with JDK9+, those libraries may fail to parse the java version. This configuration key
    * can be used to force the "java.version" property to the given value.

--- a/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
+++ b/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
@@ -42,8 +42,8 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.PriorityQueue;
 import java.util.Map.Entry;
+import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -58,12 +58,12 @@ import org.apache.commons.math3.fitting.PolynomialCurveFitter;
 import org.apache.commons.math3.fitting.WeightedObservedPoint;
 import org.apache.thrift.TSerializer;
 import org.apache.thrift.protocol.TCompactProtocol;
-import org.bouncycastle.util.encoders.Hex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.geoxp.GeoXPLib;
 import com.geoxp.GeoXPLib.GeoXPShape;
+
 import io.warp10.CapacityExtractorOutputStream;
 import io.warp10.WarpHexDecoder;
 import io.warp10.WarpURLDecoder;
@@ -93,40 +93,6 @@ import io.warp10.script.WarpScriptStack;
 import io.warp10.script.WarpScriptStack.Macro;
 import io.warp10.script.functions.MACROMAPPER;
 import io.warp10.script.functions.TOQUATERNION;
-
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.UnsupportedEncodingException;
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.net.URLDecoder;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.charset.CharsetEncoder;
-import java.nio.charset.CodingErrorAction;
-import java.nio.charset.StandardCharsets;
-import java.text.ParseException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.BitSet;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.PriorityQueue;
-import java.util.Set;
-import java.util.TreeMap;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 
 /**
@@ -3687,9 +3653,6 @@ public class GTSHelper {
     //
 
     int calen = 64;
-    byte[] ba = new byte[(int) ((double) ce.maxBytesPerChar() * calen)];
-    //char[] ca = new char[64];
-
 
     //
     // Allocate an array to hold both name and value hashes
@@ -3706,6 +3669,8 @@ public class GTSHelper {
     CharBuffer cb = CharBuffer.allocate(calen);
     ByteBuffer bb = ByteBuffer.allocate((int) ((double) ce.maxBytesPerChar() * calen));
 
+    boolean error = false;
+
     for (Entry<String, String> entry: labels.entrySet()) {
       String ekey = entry.getKey();
       String eval = entry.getValue();
@@ -3713,15 +3678,17 @@ public class GTSHelper {
       int klen = ekey.length();
       int vlen = eval.length();
 
+      //
+      // Grow the buffers if needed
+      //
+
       if (klen > calen || vlen > calen) {
         calen = Math.max(klen, vlen);
         cb = CharBuffer.allocate(calen);
         bb = ByteBuffer.allocate((int) ((double) ce.maxBytesPerChar() * calen));
       }
 
-      ce.onMalformedInput(CodingErrorAction.REPLACE)
-      .onUnmappableCharacter(CodingErrorAction.REPLACE)
-      .reset();
+      ce = ce.reset().onMalformedInput(CodingErrorAction.REPLACE).onUnmappableCharacter(CodingErrorAction.REPLACE);
 
       cb.clear();
       cb.put(ekey);
@@ -3729,12 +3696,13 @@ public class GTSHelper {
       bb.clear();
 
       CoderResult res = ce.encode(cb, bb, true);
+      error = error || !res.isUnderflow();
+      res = ce.flush(bb);
+      error = error || !res.isUnderflow();
       bb.flip();
-
       hashes[idx] = SipHashInline.hash24_palindromic(sipkey0, sipkey1, bb.array(), 0, bb.limit());
-      ce.onMalformedInput(CodingErrorAction.REPLACE)
-      .onUnmappableCharacter(CodingErrorAction.REPLACE)
-      .reset();
+
+      ce = ce.reset().onMalformedInput(CodingErrorAction.REPLACE).onUnmappableCharacter(CodingErrorAction.REPLACE);
 
       cb.clear();
       cb.put(eval);
@@ -3742,10 +3710,16 @@ public class GTSHelper {
       bb.clear();
 
       res = ce.encode(cb, bb, true);
+      error = error || !res.isUnderflow();
+      res = ce.flush(bb);
+      error = error || !res.isUnderflow();
       bb.flip();
-
       hashes[idx+1] = SipHashInline.hash24_palindromic(sipkey0, sipkey1, bb.array(), 0, bb.limit());
       idx+=2;
+    }
+
+    if (error) {
+      throw new RuntimeException("Error computing labels id.");
     }
 
     //
@@ -3784,7 +3758,10 @@ public class GTSHelper {
     // Now compute the SipHash of all the longs in the order we just determined
     //
 
-    byte[] buf = new byte[hashes.length * 8];
+    int hasheslen = hashes.length * 8;
+
+    // If the array backing bb is large enough, use it, otherwise allocate a new array
+    byte[] buf = bb.capacity() >= hasheslen ? bb.array() : new byte[hasheslen];
 
     idx = 0;
 
@@ -3800,7 +3777,7 @@ public class GTSHelper {
     }
 
     //return SipHashInline.hash24(sipkey[0], sipkey[1], buf, 0, buf.length);
-    long id = SipHashInline.hash24_palindromic(sipkey0, sipkey1, buf, 0, buf.length);
+    long id = SipHashInline.hash24_palindromic(sipkey0, sipkey1, buf, 0, hasheslen);
     return id;
     //return SipHashInline.hash24_palindromic(sipkey0, sipkey1, buf, 0, buf.length);
   }

--- a/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
+++ b/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
@@ -3776,10 +3776,8 @@ public class GTSHelper {
       buf[idx++] = (byte) (hash & 0xffL);
     }
 
-    //return SipHashInline.hash24(sipkey[0], sipkey[1], buf, 0, buf.length);
     long id = SipHashInline.hash24_palindromic(sipkey0, sipkey1, buf, 0, hasheslen);
     return id;
-    //return SipHashInline.hash24_palindromic(sipkey0, sipkey1, buf, 0, buf.length);
   }
 
   public static final long labelsId_slow(byte[] key, Map<String,String> labels) {


### PR DESCRIPTION
Under JDK17, Incorrect array content was sometimes encountered, leading to incorrect labels id computation. This PR aims at adding robustness to the labels id computation and at improving its overall performance by reducing the amount of allocations.