### PR TITLE
Make calls to setRawAccess conditonal

### DIFF
--- a/warp10/src/main/java/io/warp10/continuum/store/Directory.java
+++ b/warp10/src/main/java/io/warp10/continuum/store/Directory.java
@@ -1372,7 +1372,9 @@ public class Directory extends AbstractHandler implements Runnable {
                 retry = false;
                 txn = db.createTransaction();
                 // Allow RAW access because we may manually force a tenant key prefix without actually setting a tenant
-                txn.options().setRawAccess();
+                if (fdbContext.hasTenant()) {
+                  txn.options().setRawAccess();
+                }
 
                 for (FDBMutation mutation: mutations) {
                   mutation.apply(txn);

--- a/warp10/src/main/java/io/warp10/continuum/store/Store.java
+++ b/warp10/src/main/java/io/warp10/continuum/store/Store.java
@@ -805,7 +805,9 @@ public class Store extends Thread {
                 retry = false;
                 txn = db.createTransaction();
                 // Allow RAW access because we may manually force a tenant key prefix without actually setting a tenant
-                txn.options().setRawAccess();
+                if (store.fdbContext.hasTenant() || store.FDBUseTenantPrefix) {
+                  txn.options().setRawAccess();
+                }
                 int sets = 0;
                 int clearranges = 0;
 

--- a/warp10/src/main/java/io/warp10/fdb/FDBContext.java
+++ b/warp10/src/main/java/io/warp10/fdb/FDBContext.java
@@ -83,6 +83,10 @@ public class FDBContext {
     return this.tenantPrefix;
   }
 
+  public boolean hasTenant() {
+    return null != this.tenantPrefix;
+  }
+
   public byte[] getTenantName() {
     return this.tenantName;
   }

--- a/warp10/src/main/java/io/warp10/fdb/FDBKVScanner.java
+++ b/warp10/src/main/java/io/warp10/fdb/FDBKVScanner.java
@@ -101,7 +101,9 @@ public class FDBKVScanner implements Iterator<FDBKeyValue> {
       if (null == txn) {
         this.txn = db.createTransaction();
         // Allow RAW access because we may manually force a tenant key prefix without actually setting a tenant
-        this.txn.options().setRawAccess();
+        if (this.context.hasTenant() || null != scan.getTenantPrefix()) {
+          this.txn.options().setRawAccess();
+        }
         this.txn.options().setCausalReadRisky();
         this.txn.options().setReadYourWritesDisable();
         this.txn.options().setSnapshotRywDisable();

--- a/warp10/src/main/java/io/warp10/fdb/FDBUtils.java
+++ b/warp10/src/main/java/io/warp10/fdb/FDBUtils.java
@@ -122,6 +122,7 @@ public class FDBUtils {
 
   public static byte[] getKey(Database db, byte[] key) {
     Transaction txn = db.createTransaction();
+    // setRawAccess is called unconditionally because we do not know if a tenant was set or not
     txn.options().setRawAccess();
     txn.options().setAccessSystemKeys();
 
@@ -146,6 +147,7 @@ public class FDBUtils {
 
   public static Map<String,Object> getTenantInfo(Database db, String tenant) {
     Transaction txn = db.createTransaction();
+    // setRawAccess is called unconditionally because we are accessing a system key without tenant
     txn.options().setRawAccess();
     txn.options().setAccessSystemKeys();
 
@@ -179,6 +181,7 @@ public class FDBUtils {
       while(attempts > 0) {
         try {
           txn = db.createTransaction();
+          // setRawAccess is called unconditionally because we are accessing a system key without tenant
           txn.options().setRawAccess();
           txn.options().setAccessSystemKeys();
 
@@ -229,6 +232,7 @@ public class FDBUtils {
     long size = 0L;
 
     try {
+      // setRawAccess is called unconditionally because we do not know if a tenant was set or not for the key range
       txn.options().setRawAccess();
       size = txn.getEstimatedRangeSizeBytes(from, to).get().longValue();
     } catch (Throwable t) {

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneDirectoryClient.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneDirectoryClient.java
@@ -873,7 +873,9 @@ public class StandaloneDirectoryClient implements DirectoryClient {
           retry = false;
           txn = this.fdb.createTransaction();
           // Allow RAW access because we may manually force a tenant key prefix without actually setting a tenant
-          txn.options().setRawAccess();
+          if (fdbContext.hasTenant()) {
+            txn.options().setRawAccess();
+          }
 
           FDBMutation delete = new FDBClear(this.fdbContext.getTenantPrefix(), bytes);
           delete.apply(txn);
@@ -973,7 +975,9 @@ public class StandaloneDirectoryClient implements DirectoryClient {
               if (!mutations.isEmpty()) {
                 txn = this.fdb.createTransaction();
                 // Allow RAW access because we may manually force a tenant key prefix without actually setting a tenant
-                txn.options().setRawAccess();
+                if (fdbContext.hasTenant()) {
+                  txn.options().setRawAccess();
+                }
 
                 for (FDBMutation mutation: mutations) {
                   mutation.apply(txn);

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneFDBStoreClient.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneFDBStoreClient.java
@@ -247,7 +247,9 @@ public class StandaloneFDBStoreClient extends FDBStoreClient {
           retry = false;
           txn = this.fdb.createTransaction();
           // Allow RAW access because we may manually force a tenant key prefix without actually setting a tenant
-          txn.options().setRawAccess();
+          if (fdbContext.hasTenant() || FDBUseTenantPrefix) {
+            txn.options().setRawAccess();
+          }
           int sets = 0;
           int clearranges = 0;
 


### PR DESCRIPTION
If an FDB cluster was configured with required tenants, we must ensure that on the Warp 10 side of things we do not override this configuration by calling setRawAccess if no tenant was specified in the Warp 10 config or tokens, otherwise the FDB instance could be polluted with tenantless keys.