### PR TITLE
recursive macro clone, CLONENODUP variation

### DIFF
--- a/warp10/src/main/java/io/warp10/script/WarpScriptLib.java
+++ b/warp10/src/main/java/io/warp10/script/WarpScriptLib.java
@@ -1478,6 +1478,7 @@ public class WarpScriptLib {
   public static final String ATTICK = "ATTICK";
   public static final String ATBUCKET = "ATBUCKET";
   public static final String CLONE = "CLONE";
+  public static final String CLONENODUP = "CLONENODUP";
   public static final String DURATION = "DURATION";
   public static final String HUMANDURATION = "HUMANDURATION";
   public static final String ISODURATION = "ISODURATION";
@@ -2502,6 +2503,7 @@ public class WarpScriptLib {
     addNamedWarpScriptFunction(new ATBUCKET(ATBUCKET));
 
     addNamedWarpScriptFunction(new CLONE(CLONE));
+    addNamedWarpScriptFunction(new CLONE(CLONENODUP,false));
     addNamedWarpScriptFunction(new DURATION(DURATION));
     addNamedWarpScriptFunction(new HUMANDURATION(HUMANDURATION));
     addNamedWarpScriptFunction(new ISODURATION(ISODURATION));

--- a/warp10/src/main/java/io/warp10/script/WarpScriptStack.java
+++ b/warp10/src/main/java/io/warp10/script/WarpScriptStack.java
@@ -380,6 +380,25 @@ public interface WarpScriptStack {
       size += n;
     }
 
+    public Macro cloneRecursive(int maxRecursion) throws WarpScriptException {
+      return cloneRecursive(maxRecursion, 0);
+    }
+
+    private Macro cloneRecursive(int maxRecursion, int currentRecursionLevel) throws WarpScriptException {
+      Macro m = new Macro();
+      m.addAll(this);
+      m.setSecure(this.isSecure());
+      if (currentRecursionLevel > maxRecursion) {
+        throw new WarpScriptException("Maximum recursion level reached during macro cloning");
+      }
+      for (int i = 0; i < m.statements.length; i++) {
+        if (m.statements[i] instanceof Macro) {
+          m.statements[i] = ((Macro) statements[i]).cloneRecursive(maxRecursion, currentRecursionLevel + 1);
+        }
+      }
+      return m;
+    }
+    
     public void setSecure(boolean secure) {
       this.secure = secure;
     }


### PR DESCRIPTION
-  Introduce recursive macro cloning, to easily DEREF imbricated macros.
```
0 2 
<%
  'a' STORE 
  <%
    DUP $a > <% $a * %> <% $a + %> IFT 
  %> CLONE SWAP DROP 
  {
    'a' $a
  } DEREF 
%> FOR 
```

-  Introduce `CLONENODUP` (name to discuss) to avoid CLONE SWAP DROP (new name to avoid signature variation up to type like `CONTAINS`)

