### PR TITLE
Pre computation hook

### DIFF
--- a/warp10/src/main/java/io/warp10/script/WarpScriptFunctionWithHook.java
+++ b/warp10/src/main/java/io/warp10/script/WarpScriptFunctionWithHook.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2020  SenX S.A.S.
+//   Copyright 2023  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -21,5 +21,7 @@ import io.warp10.continuum.gts.GeoTimeSerie;
 
 import java.util.Map;
 
-public interface WarpScriptMapperFunction extends WarpScriptAggregatorFunction {
+public interface WarpScriptFunctionWithHook {
+
+  public void preComputationHook(GeoTimeSerie gts, Map params) throws WarpScriptException;
 }

--- a/warp10/src/main/java/io/warp10/script/WarpScriptFunctionWithHook.java
+++ b/warp10/src/main/java/io/warp10/script/WarpScriptFunctionWithHook.java
@@ -23,5 +23,5 @@ import java.util.Map;
 
 public interface WarpScriptFunctionWithHook {
 
-  public void preComputationHook(GeoTimeSerie gts, Map params) throws WarpScriptException;
+  public Object preComputationHook(GeoTimeSerie gts, Map params) throws WarpScriptException;
 }

--- a/warp10/src/main/java/io/warp10/script/WarpScriptMapperFunction.java
+++ b/warp10/src/main/java/io/warp10/script/WarpScriptMapperFunction.java
@@ -17,9 +17,5 @@
 package io.warp10.script;
 
 
-import io.warp10.continuum.gts.GeoTimeSerie;
-
-import java.util.Map;
-
 public interface WarpScriptMapperFunction extends WarpScriptAggregatorFunction {
 }

--- a/warp10/src/main/java/io/warp10/script/WarpScriptMapperFunction.java
+++ b/warp10/src/main/java/io/warp10/script/WarpScriptMapperFunction.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2020  SenX S.A.S.
+//   Copyright 2018-2023  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.

--- a/warp10/src/main/java/io/warp10/script/WarpScriptMapperFunction.java
+++ b/warp10/src/main/java/io/warp10/script/WarpScriptMapperFunction.java
@@ -17,5 +17,11 @@
 package io.warp10.script;
 
 
+import io.warp10.continuum.gts.GeoTimeSerie;
+
+import java.util.Map;
+
 public interface WarpScriptMapperFunction extends WarpScriptAggregatorFunction {
+
+  default void preComputationHook(GeoTimeSerie gts, Map params) throws WarpScriptException {}
 }

--- a/warp10/src/main/java/io/warp10/script/functions/MAP.java
+++ b/warp10/src/main/java/io/warp10/script/functions/MAP.java
@@ -301,6 +301,7 @@ public class MAP extends NamedWarpScriptFunction implements WarpScriptStackFunct
     for (GeoTimeSerie gts: series) {
       List<GeoTimeSerie> res;
       try {
+        ((WarpScriptMapperFunction) mapper).preComputationHook(gts, params);
         res = GTSHelper.map(gts, mapper, prewindow, postwindow, Math.abs(occurrences), reversed, step, overrideTick, mapper instanceof Macro ? stack : null, (List<Long>) outputTicks);
       } catch (WarpScriptATCException wsatce) {
         // Do not handle WarpScriptATCException (STOP in MACROMAPPER for instance)

--- a/warp10/src/main/java/io/warp10/script/functions/MAP.java
+++ b/warp10/src/main/java/io/warp10/script/functions/MAP.java
@@ -20,6 +20,7 @@ import io.warp10.continuum.gts.GTSHelper;
 import io.warp10.continuum.gts.GeoTimeSerie;
 import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptATCException;
+import io.warp10.script.WarpScriptFunctionWithHook;
 import io.warp10.script.WarpScriptMapperFunction;
 import io.warp10.script.WarpScriptStack.Macro;
 import io.warp10.script.WarpScriptStackFunction;
@@ -301,7 +302,9 @@ public class MAP extends NamedWarpScriptFunction implements WarpScriptStackFunct
     for (GeoTimeSerie gts: series) {
       List<GeoTimeSerie> res;
       try {
-        ((WarpScriptMapperFunction) mapper).preComputationHook(gts, params);
+        if (mapper instanceof WarpScriptFunctionWithHook) {
+          ((WarpScriptFunctionWithHook) mapper).preComputationHook(gts, params);
+        }
         res = GTSHelper.map(gts, mapper, prewindow, postwindow, Math.abs(occurrences), reversed, step, overrideTick, mapper instanceof Macro ? stack : null, (List<Long>) outputTicks);
       } catch (WarpScriptATCException wsatce) {
         // Do not handle WarpScriptATCException (STOP in MACROMAPPER for instance)

--- a/warp10/src/main/java/io/warp10/script/functions/MAP.java
+++ b/warp10/src/main/java/io/warp10/script/functions/MAP.java
@@ -306,7 +306,7 @@ public class MAP extends NamedWarpScriptFunction implements WarpScriptStackFunct
         if (gtsMapper instanceof WarpScriptFunctionWithHook) {
           gtsMapper = ((WarpScriptFunctionWithHook) mapper).preComputationHook(gts, params);
         }
-        res = GTSHelper.map(gts, gtsMapper, prewindow, postwindow, Math.abs(occurrences), reversed, step, overrideTick, mapper instanceof Macro ? stack : null, (List<Long>) outputTicks);
+        res = GTSHelper.map(gts, gtsMapper, prewindow, postwindow, Math.abs(occurrences), reversed, step, overrideTick, gtsMapper instanceof Macro ? stack : null, (List<Long>) outputTicks);
       } catch (WarpScriptATCException wsatce) {
         // Do not handle WarpScriptATCException (STOP in MACROMAPPER for instance)
         throw wsatce;

--- a/warp10/src/main/java/io/warp10/script/functions/MAP.java
+++ b/warp10/src/main/java/io/warp10/script/functions/MAP.java
@@ -303,7 +303,7 @@ public class MAP extends NamedWarpScriptFunction implements WarpScriptStackFunct
       List<GeoTimeSerie> res;
       try {
         if (mapper instanceof WarpScriptFunctionWithHook) {
-          ((WarpScriptFunctionWithHook) mapper).preComputationHook(gts, params);
+          mapper = ((WarpScriptFunctionWithHook) mapper).preComputationHook(gts, params);
         }
         res = GTSHelper.map(gts, mapper, prewindow, postwindow, Math.abs(occurrences), reversed, step, overrideTick, mapper instanceof Macro ? stack : null, (List<Long>) outputTicks);
       } catch (WarpScriptATCException wsatce) {

--- a/warp10/src/main/java/io/warp10/script/functions/MAP.java
+++ b/warp10/src/main/java/io/warp10/script/functions/MAP.java
@@ -302,10 +302,11 @@ public class MAP extends NamedWarpScriptFunction implements WarpScriptStackFunct
     for (GeoTimeSerie gts: series) {
       List<GeoTimeSerie> res;
       try {
-        if (mapper instanceof WarpScriptFunctionWithHook) {
-          mapper = ((WarpScriptFunctionWithHook) mapper).preComputationHook(gts, params);
+        Object gtsMapper = mapper;
+        if (gtsMapper instanceof WarpScriptFunctionWithHook) {
+          gtsMapper = ((WarpScriptFunctionWithHook) mapper).preComputationHook(gts, params);
         }
-        res = GTSHelper.map(gts, mapper, prewindow, postwindow, Math.abs(occurrences), reversed, step, overrideTick, mapper instanceof Macro ? stack : null, (List<Long>) outputTicks);
+        res = GTSHelper.map(gts, gtsMapper, prewindow, postwindow, Math.abs(occurrences), reversed, step, overrideTick, mapper instanceof Macro ? stack : null, (List<Long>) outputTicks);
       } catch (WarpScriptATCException wsatce) {
         // Do not handle WarpScriptATCException (STOP in MACROMAPPER for instance)
         throw wsatce;


### PR DESCRIPTION
A hook to particularize an aggregator on the full data of a gts before applying the framework.
The interface is meant to be implemented by mappers that need to initialize their parameters before MAP computation.