### PR TITLE
fix(ingress): prevent null pointer on delete

### DIFF
--- a/warp10/src/main/java/io/warp10/continuum/ingress/Ingress.java
+++ b/warp10/src/main/java/io/warp10/continuum/ingress/Ingress.java
@@ -1622,8 +1622,8 @@ public class Ingress extends AbstractHandler implements Runnable {
 
       String selector = request.getParameter(Constants.HTTP_PARAM_SELECTOR);
 
-    if (null == selector) {
-      response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid '" + Constants.HTTP_PARAM_SELECTOR +"' query parameter, should not be empty.");
+    if (null == selector || selector.isEmpty) {
+      response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid '" + Constants.HTTP_PARAM_SELECTOR +"' query parameter, should not be missing or empty.");
       return;
     }
 

--- a/warp10/src/main/java/io/warp10/continuum/ingress/Ingress.java
+++ b/warp10/src/main/java/io/warp10/continuum/ingress/Ingress.java
@@ -1622,9 +1622,10 @@ public class Ingress extends AbstractHandler implements Runnable {
 
       String selector = request.getParameter(Constants.HTTP_PARAM_SELECTOR);
 
-      if (null == selector) {
-          throw new IOException("Invalid selector query parameter, should not be empty.");
-      }
+    if (null == selector) {
+      response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid '" + Constants.HTTP_PARAM_SELECTOR +"' query parameter, should not be empty.");
+      return;
+    }
 
       //
       // Extract the class and labels selectors

--- a/warp10/src/main/java/io/warp10/continuum/ingress/Ingress.java
+++ b/warp10/src/main/java/io/warp10/continuum/ingress/Ingress.java
@@ -1622,6 +1622,10 @@ public class Ingress extends AbstractHandler implements Runnable {
 
       String selector = request.getParameter(Constants.HTTP_PARAM_SELECTOR);
 
+      if (null == selector) {
+          throw new IOException("Invalid selector query parameter, should not be empty.");
+      }
+
       //
       // Extract the class and labels selectors
       // The class selector and label selectors are supposed to have

--- a/warp10/src/main/java/io/warp10/continuum/ingress/Ingress.java
+++ b/warp10/src/main/java/io/warp10/continuum/ingress/Ingress.java
@@ -1622,7 +1622,7 @@ public class Ingress extends AbstractHandler implements Runnable {
 
       String selector = request.getParameter(Constants.HTTP_PARAM_SELECTOR);
 
-    if (null == selector || selector.isEmpty) {
+    if (null == selector || selector.isEmpty()) {
       response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid '" + Constants.HTTP_PARAM_SELECTOR +"' query parameter, should not be missing or empty.");
       return;
     }

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneDeleteHandler.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneDeleteHandler.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2023  SenX S.A.S.
+//   Copyright 2018-2024  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneDeleteHandler.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneDeleteHandler.java
@@ -214,8 +214,8 @@ public class StandaloneDeleteHandler extends AbstractHandler {
 
     String selector = request.getParameter(Constants.HTTP_PARAM_SELECTOR);
 
-    if (null == selector) {
-      response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid '" + Constants.HTTP_PARAM_SELECTOR +"' query parameter, should not be empty.");
+    if (null == selector || selector.isEmpty) {
+      response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid '" + Constants.HTTP_PARAM_SELECTOR +"' query parameter, should not be missing or empty.");
       return;
     }
 

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneDeleteHandler.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneDeleteHandler.java
@@ -214,6 +214,11 @@ public class StandaloneDeleteHandler extends AbstractHandler {
 
     String selector = request.getParameter(Constants.HTTP_PARAM_SELECTOR);
 
+    if (null == selector) {
+      response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid '" + Constants.HTTP_PARAM_SELECTOR +"' query parameter, should not be empty.");
+      return;
+    }
+
     String minage = request.getParameter(Constants.HTTP_PARAM_MINAGE);
 
     if (null != minage) {

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneDeleteHandler.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneDeleteHandler.java
@@ -214,7 +214,7 @@ public class StandaloneDeleteHandler extends AbstractHandler {
 
     String selector = request.getParameter(Constants.HTTP_PARAM_SELECTOR);
 
-    if (null == selector || selector.isEmpty) {
+    if (null == selector || selector.isEmpty()) {
       response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid '" + Constants.HTTP_PARAM_SELECTOR +"' query parameter, should not be missing or empty.");
       return;
     }


### PR DESCRIPTION
Delete fails with null pointer exception if `selector` query param is not set.