### PR TITLE
Add foundationdb client busyness metric on egress

### DIFF
--- a/warp10/src/main/java/io/warp10/continuum/egress/EgressExecHandler.java
+++ b/warp10/src/main/java/io/warp10/continuum/egress/EgressExecHandler.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2024  SenX S.A.S.
+//   Copyright 2018-2025  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -56,6 +56,7 @@ import io.warp10.continuum.store.DirectoryClient;
 import io.warp10.continuum.store.StoreClient;
 import io.warp10.continuum.thrift.data.LoggingEvent;
 import io.warp10.crypto.KeyStore;
+import io.warp10.fdb.FDBStoreClient;
 import io.warp10.script.MemoryWarpScriptStack;
 import io.warp10.script.StackUtils;
 import io.warp10.script.WarpScriptException;
@@ -621,6 +622,15 @@ public class EgressExecHandler extends AbstractHandler {
       //
 
       Sensision.set(SensisionConstants.SENSISION_CLASS_WARPSCRIPT_JVM_FREEMEMORY, Sensision.EMPTY_LABELS, Runtime.getRuntime().freeMemory());
+
+      //
+      // Record FoundationDB network threads busyness
+      //
+
+      if (storeClient instanceof FDBStoreClient) {
+        FDBStoreClient fsc = (FDBStoreClient) storeClient;
+        fsc.getPool().updateDatabasesBusyness();
+      }
 
       LoggingEvent event = LogUtil.setLoggingEventAttribute(null, LogUtil.WARPSCRIPT_SCRIPT, scriptSB.toString());
 

--- a/warp10/src/main/java/io/warp10/continuum/sensision/SensisionConstants.java
+++ b/warp10/src/main/java/io/warp10/continuum/sensision/SensisionConstants.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2023  SenX S.A.S.
+//   Copyright 2018-2025  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -838,6 +838,11 @@ public class SensisionConstants {
    * Number of results of the 'find' method of Directory plugin
    */
   public static final String SENSISION_CLASS_CONTINUUM_DIRECTORY_PLUGIN_FIND_RESULTS = "warp.directory.plugin.find.results";
+
+  /**
+   * Saturation of FoundationDB network threads
+   */
+  public static final String SENSISION_CLASS_FDB_CLIENT_BUSYNESS = "fdb.client.busyness";
 
   /**
    * Number of times the WarpScript bootstrap code was loaded


### PR DESCRIPTION
:wave: 

This PR implements a metric that allow to understand how saturated are the network threads of the FoundationDB client, only on egresses. 

It's very convenient to have in order to have tune the number of network threads needed, scanners... 