### PR TITLE
KVStore support

### DIFF
--- a/etc/conf.templates/standalone/00-warp.conf.template
+++ b/etc/conf.templates/standalone/00-warp.conf.template
@@ -1,5 +1,5 @@
 //
-//   Copyright 2019-2023  SenX S.A.S.
+//   Copyright 2019-2025  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -278,3 +278,21 @@ warp.token.read.attributes.default = { '.cap:limits' '' }
 // Set to true to allow Directory queries with missing label selectors (using empty exact match)
 //
 warp10.absent.label.support = true
+
+//
+// KVSTORE
+//
+
+//
+// Maximum key size (in bytes) for data stored via KVSTORE. Defaults to 128 bytes
+// Note, for standalone+ and distributed versions backed by FoundationDB, the value should not exceed 8192
+// Careful when forwarding KVSTORE events via Datalog to instances backed by FoundationDB, in that case 8192 is also a hard limit even for instances NOT backed by FoundationDB
+// 
+#warp.kvstore.maxk = 128
+
+//
+// Maximum value size (in bytes) for data stored via KVSTORE. Defaults to 1024 bytes
+// Note, for standalone+ and distributed versions backed by FoundationDB, the value should not exceed 98304 bytes
+// Careful when forwarding KVSTORE events via Datalog to instances backed by FoundationDB, in that case 98304 is also a hard limit even for instances NOT backed by FoundationDB
+// 
+#warp.kvstore.maxv = 1024

--- a/etc/conf.templates/standalone/20-datalog.conf.template
+++ b/etc/conf.templates/standalone/20-datalog.conf.template
@@ -1,5 +1,5 @@
 //
-//   Copyright 2019  SenX S.A.S.
+//   Copyright 2019-2025  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -51,3 +51,8 @@ datalog.register.all = false
 ## Values above 24 will induce sharding on class name only, not on labels.
 ##
 datalog.shardkey.shift = 0
+
+##
+## Set to true to log KVSTORE events for Datalog consumers
+##
+datalog.manager.logkvstores = false

--- a/etc/conf.templates/standalone/30-in-memory.conf.template
+++ b/etc/conf.templates/standalone/30-in-memory.conf.template
@@ -1,5 +1,5 @@
 //
-//   Copyright 2019-2023  SenX S.A.S.
+//   Copyright 2019-2025  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -131,3 +131,8 @@ in.memory.ephemeral = false
 // Maximum size (in bytes) of re-allocations performed during a gc cycle of the chunked in-memory store. 
 //
 #in.memory.gc.maxalloc =
+
+//
+// Maximum aggregate size (in bytes) of all store Key/Value pairs. Defaults to 10,000,000 bytes
+//
+#in.memory.maxkvsize = 10000000

--- a/warp10/src/main/java/io/warp10/continuum/Configuration.java
+++ b/warp10/src/main/java/io/warp10/continuum/Configuration.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2024  SenX S.A.S.
+//   Copyright 2018-2025  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -229,6 +229,16 @@ public class Configuration {
   public static final String WARPSCRIPT_MAX_SYMBOLS_HARD = "warpscript.maxsymbols.hard";
   public static final String WARPSCRIPT_MAX_PIXELS_HARD = "warpscript.maxpixels.hard";
   public static final String WARPSCRIPT_MAX_JSON_HARD = "warpscript.maxjson.hard";
+
+  /**
+   * Default maximum key size for KV stored via KVSTORE
+   */
+  public static final String WARP_KVSTORE_MAXK = "warp.kvstore.maxk";
+
+  /**
+   * Default maximum value size for KV stored via KVSTORE
+   */
+  public static final String WARP_KVSTORE_MAXV = "warp.kvstore.maxv";
 
   /**
    * When set to true, allow common comment block style. When false, keep the old strict comment block style within WarpScript
@@ -1761,6 +1771,11 @@ public class Configuration {
   public static final String IN_MEMORY_EPHEMERAL = "in.memory.ephemeral";
 
   /**
+   * Default maximum value size for all stored KV
+   */
+  public static final String IN_MEMORY_MAXKVSIZE = "in.memory.maxkvsize";
+
+  /**
    * Number of chunks per GTS to handle in memory (defaults to 3)
    */
   public static final String IN_MEMORY_CHUNK_COUNT = "in.memory.chunk.count";
@@ -1813,6 +1828,11 @@ public class Configuration {
    * FoundationDB tenant prefix to use for Egress data
    */
   public static final String EGRESS_FDB_TENANT_PREFIX = "egress.fdb.tenant.prefix";
+
+  /**
+   * Maximum number of retries for FoundationDB transactions
+   */
+  public static final String EGRESS_FDB_RETRYLIMIT = "egress.fdb.retrylimit";
 
   /**
    * Size of pooled FoundationDB databases instances

--- a/warp10/src/main/java/io/warp10/continuum/sensision/SensisionConstants.java
+++ b/warp10/src/main/java/io/warp10/continuum/sensision/SensisionConstants.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2023  SenX S.A.S.
+//   Copyright 2018-2025  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -29,6 +29,16 @@ public class SensisionConstants {
   //
   // Classes
   //
+
+  /**
+   * Number of FoundationDB sets committed in 'Egress'
+   */
+  public static final String SENSISION_CLASS_CONTINUUM_EGRESS_FDB_SETS_COMMITTED = "warp.egress.fdb.sets.committed";
+
+  /**
+   * Number of FoundationDB clears committed in 'Egress'
+   */
+  public static final String SENSISION_CLASS_CONTINUUM_EGRESS_FDB_CLEARS_COMMITTED = "warp.egress.fdb.clears.committed";
 
   /**
    * Number of times we have reached the maximum number of version attempts

--- a/warp10/src/main/java/io/warp10/continuum/store/StoreClient.java
+++ b/warp10/src/main/java/io/warp10/continuum/store/StoreClient.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2022  SenX S.A.S.
+//   Copyright 2018-2025  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -17,14 +17,21 @@
 package io.warp10.continuum.store;
 
 import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map.Entry;
 
 import io.warp10.continuum.gts.GTSEncoder;
 import io.warp10.continuum.store.thrift.data.FetchRequest;
+import io.warp10.continuum.store.thrift.data.KVFetchRequest;
+import io.warp10.continuum.store.thrift.data.KVStoreRequest;
 import io.warp10.continuum.store.thrift.data.Metadata;
 import io.warp10.quasar.token.thrift.data.WriteToken;
 import io.warp10.standalone.StandalonePlasmaHandlerInterface;
 
 public interface StoreClient {
+
+  public interface KVIterator<T> extends Iterator<T>, AutoCloseable {}
+
   public void store(GTSEncoder encoder) throws IOException;
   public long delete(WriteToken token, Metadata metadata, long start, long end) throws IOException;
   /**
@@ -43,4 +50,7 @@ public interface StoreClient {
    */
   public GTSDecoderIterator fetch(FetchRequest req) throws IOException;
   public void addPlasmaHandler(StandalonePlasmaHandlerInterface handler);
+
+  public void kvstore(KVStoreRequest request) throws IOException;
+  public KVIterator<Entry<byte[],byte[]>> kvfetch(KVFetchRequest request) throws IOException;
 }

--- a/warp10/src/main/java/io/warp10/fdb/FDBClear.java
+++ b/warp10/src/main/java/io/warp10/fdb/FDBClear.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2022  SenX S.A.S.
+//   Copyright 2022-2025  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -48,6 +48,6 @@ public class FDBClear implements FDBMutation {
 
   @Override
   public int size() {
-    return 103 + key.length + (null != this.tenant ? tenant.length : 0);
+    return 120 + key.length + (null != this.tenant ? tenant.length : 0);
   }
 }

--- a/warp10/src/main/java/io/warp10/fdb/FDBGetOp.java
+++ b/warp10/src/main/java/io/warp10/fdb/FDBGetOp.java
@@ -1,0 +1,83 @@
+//
+//   Copyright 2025  SenX S.A.S.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+package io.warp10.fdb;
+
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import com.apple.foundationdb.Transaction;
+
+public class FDBGetOp implements FDBMutation {
+
+  /**
+   * Tenant prefix
+   */
+  private final byte[] tenant;
+  private final byte[] key;
+
+  CompletableFuture<byte[]> future = null;
+
+  public FDBGetOp(byte[] key) {
+    this(null, key);
+  }
+
+  public FDBGetOp(byte[] tenant, byte[] key) {
+    this.tenant = tenant;
+    this.key = key;
+  }
+
+  @Override
+  public void apply(Transaction txn) {
+    synchronized (this.key) {
+      if (null != this.future) {
+        throw new IllegalStateException("Operation has already been applied.");
+      }
+      if (null != tenant) {
+        byte[] tkey = Arrays.copyOf(this.tenant, tenant.length + key.length);
+        System.arraycopy(this.key, 0, tkey, this.tenant.length, key.length);
+        this.future = txn.get(tkey);
+      } else {
+        this.future = txn.get(this.key);
+      }
+    }
+  }
+
+  @Override
+  public int size() {
+    return 103 + (null != tenant ? tenant.length : 0) + key.length;
+  }
+
+  public byte[] getKey() {
+    return this.key;
+  }
+
+  public byte[] getValue() {
+    if (null == future) {
+      throw new IllegalStateException("Operation has not been applied.");
+    }
+    try {
+      return this.future.get();
+    } catch (ExecutionException|InterruptedException e) {
+      throw new RuntimeException("Error retrieving value.", e);
+    }
+  }
+
+  public byte[] getTenant() {
+    return this.tenant;
+  }
+}

--- a/warp10/src/main/java/io/warp10/fdb/FDBStoreClient.java
+++ b/warp10/src/main/java/io/warp10/fdb/FDBStoreClient.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2022-2023  SenX S.A.S.
+//   Copyright 2022-2025  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -17,24 +17,45 @@
 package io.warp10.fdb;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.NoSuchElementException;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
 
+import org.bouncycastle.util.Arrays;
 import org.bouncycastle.util.encoders.Hex;
+
+import com.apple.foundationdb.Database;
+import com.apple.foundationdb.FDBException;
+import com.apple.foundationdb.StreamingMode;
+import com.apple.foundationdb.Transaction;
 
 import io.warp10.continuum.Configuration;
 import io.warp10.continuum.gts.GTSEncoder;
 import io.warp10.continuum.gts.MetadataIdComparator;
+import io.warp10.continuum.sensision.SensisionConstants;
+import io.warp10.continuum.store.Constants;
 import io.warp10.continuum.store.GTSDecoderIterator;
 import io.warp10.continuum.store.MultiScanGTSDecoderIterator;
 import io.warp10.continuum.store.ParallelGTSDecoderIteratorWrapper;
 import io.warp10.continuum.store.StoreClient;
 import io.warp10.continuum.store.thrift.data.FetchRequest;
+import io.warp10.continuum.store.thrift.data.KVFetchRequest;
+import io.warp10.continuum.store.thrift.data.KVStoreRequest;
 import io.warp10.continuum.store.thrift.data.Metadata;
 import io.warp10.crypto.KeyStore;
 import io.warp10.crypto.OrderPreservingBase64;
+import io.warp10.quasar.token.thrift.data.ReadToken;
 import io.warp10.quasar.token.thrift.data.WriteToken;
+import io.warp10.script.functions.KVSTORE;
+import io.warp10.sensision.Sensision;
 import io.warp10.standalone.StandalonePlasmaHandlerInterface;
 
 public class FDBStoreClient implements StoreClient {
@@ -43,12 +64,16 @@ public class FDBStoreClient implements StoreClient {
 
   public final KeyStore keystore;
   public final boolean FDBUseTenantPrefix;
+  private final long fdbRetryLimit;
 
   private static final String EGRESS_FDB_POOLSIZE_DEFAULT = Integer.toString(1);
+
+  public static final String DEFAULT_FDB_RETRYLIMIT = Long.toString(4);
 
   public FDBStoreClient(KeyStore keystore, Properties properties) throws IOException {
     this.keystore = keystore;
     this.FDBUseTenantPrefix = "true".equals(properties.getProperty(Configuration.FDB_USE_TENANT_PREFIX));
+    this.fdbRetryLimit = Long.parseLong(properties.getProperty(Configuration.EGRESS_FDB_RETRYLIMIT, DEFAULT_FDB_RETRYLIMIT));
 
     if (FDBUseTenantPrefix && (null != properties.getProperty(Configuration.EGRESS_FDB_TENANT) || null != properties.getProperty(Configuration.EGRESS_FDB_TENANT_PREFIX))) {
       throw new RuntimeException("Cannot set '" + Configuration.EGRESS_FDB_TENANT + "' or '" + Configuration.EGRESS_FDB_TENANT_PREFIX + "' when '" + Configuration.FDB_USE_TENANT_PREFIX + "' is true.");
@@ -175,5 +200,458 @@ public class FDBStoreClient implements StoreClient {
 
   public FDBPool getPool() {
     return this.pool;
+  }
+
+  @Override
+  public void kvstore(KVStoreRequest request) throws IOException {
+
+    if (null == request) {
+      return;
+    }
+
+    // Convert to FDBMutations, then batch those in tx of less than 10M
+
+    WriteToken token = request.getToken();
+
+    byte[] tenantPrefix = this.pool.getContext().getTenantPrefix();
+
+    if (this.FDBUseTenantPrefix) {
+      if (token.getAttributesSize() > 0 && token.getAttributes().containsKey(Constants.TOKEN_ATTR_FDB_TENANT_PREFIX)) {
+        tenantPrefix = OrderPreservingBase64.decode(token.getAttributes().get(Constants.TOKEN_ATTR_FDB_TENANT_PREFIX));
+        if (8 != tenantPrefix.length) {
+          throw new IOException("Invalid tenant prefix, length should be 8 bytes.");
+        }
+      } else {
+        throw new IOException("Configuration mandates a tenant and none was found in the provided token");
+      }
+    } else {
+      if (token.getAttributesSize() > 0 && token.getAttributes().containsKey(Constants.TOKEN_ATTR_FDB_TENANT_PREFIX)) {
+        throw new IOException("Configuration has no tenant support but provided token had a defined tenant.");
+      }
+    }
+
+    //
+    // Extract kvprefix from token attributes
+    //
+
+    byte[] kvprefix = KVSTORE.KVPREFIX;
+
+    if (token.getAttributesSize() > 0 && null != token.getAttributes().get(KVSTORE.ATTR_KVPREFIX)) {
+      if (!token.getAttributes().get(KVSTORE.ATTR_KVPREFIX).isEmpty()) {
+        byte[] tkvprefix = OrderPreservingBase64.decode(token.getAttributes().get(KVSTORE.ATTR_KVPREFIX));
+        kvprefix = Arrays.copyOf(KVSTORE.KVPREFIX, KVSTORE.KVPREFIX.length + tkvprefix.length);
+        System.arraycopy(tkvprefix, 0, kvprefix, KVSTORE.KVPREFIX.length, tkvprefix.length);
+      }
+    } else {
+      throw new IOException("Token is missing attribute '" + KVSTORE.ATTR_KVPREFIX + "'.");
+    }
+
+    List<List<FDBMutation>> batches = new ArrayList<List<FDBMutation>>();
+    List<FDBMutation> batch = new ArrayList<FDBMutation>();
+    batches.add(batch);
+    long batchsize = 0;
+
+    for (int i = 0; i < request.getKeysSize(); i++) {
+      ByteBuffer bb = request.getKeys().get(i);
+      bb.mark();
+      byte[] key = Arrays.copyOf(kvprefix, kvprefix.length + bb.remaining());
+
+      if (key.length + (null != tenantPrefix ? tenantPrefix.length : 0) >= FDBUtils.MAX_KEY_SIZE) {
+        throw new IOException("Key size (" + key.length + ") exceed maximum size.");
+      }
+
+      bb.get(key, kvprefix.length, bb.remaining());
+      bb.reset();
+
+      FDBMutation mutation = null;
+      if (i > request.getValuesSize() || 0 == request.getValues().get(i).remaining()) {
+        mutation = new FDBClear(tenantPrefix, key);
+      } else {
+        bb = request.getValues().get(i);
+        bb.mark();
+        if (bb.remaining() >= FDBUtils.MAX_VALUE_SIZE) {
+          throw new IOException("Value size (" + bb.remaining() + ") exceed maximum size.");
+        }
+
+        byte[] value = new byte[bb.remaining()];
+        bb.get(value);
+        bb.reset();
+        mutation = new FDBSet(tenantPrefix, key, value);
+      }
+
+      if (batchsize + mutation.size() > FDBUtils.MAX_TXN_SIZE * 0.95) {
+        batch = new ArrayList<FDBMutation>();
+        batches.add(batch);
+        batchsize = 0;
+      }
+
+      batch.add(mutation);
+      batchsize += mutation.size();
+    }
+
+    //
+    // Persist the batches via one tx per batch
+    //
+
+
+    for (List<FDBMutation> btch: batches) {
+      Database db = this.pool.getDatabase();
+      Transaction txn = null;
+      boolean retry = false;
+      long retries = fdbRetryLimit;
+
+      do {
+        try {
+          retry = false;
+          txn = db.createTransaction();
+          // Allow RAW access because we may manually force a tenant key prefix without actually setting a tenant
+          if (this.pool.getContext().hasTenant() || this.FDBUseTenantPrefix) {
+            txn.options().setRawAccess();
+          }
+
+          int sets = 0;
+          int clears = 0;
+
+          for (FDBMutation mutation: btch) {
+            if (mutation instanceof FDBSet) {
+              sets++;
+            } else if (mutation instanceof FDBClearRange) {
+              clears++;
+            }
+            mutation.apply(txn);
+          }
+          txn.commit().get();
+          Sensision.update(SensisionConstants.SENSISION_CLASS_CONTINUUM_EGRESS_FDB_SETS_COMMITTED, Sensision.EMPTY_LABELS, sets);
+          Sensision.update(SensisionConstants.SENSISION_CLASS_CONTINUUM_EGRESS_FDB_CLEARS_COMMITTED, Sensision.EMPTY_LABELS, clears);
+        } catch (Throwable t) {
+          FDBUtils.errorMetrics("egress", t.getCause());
+          if (t.getCause() instanceof FDBException && ((FDBException) t.getCause()).isRetryable() && retries-- > 0) {
+            retry = true;
+          } else {
+            throw new IOException("Error while commiting to FoundationDB.", t);
+          }
+        } finally {
+          if (null != txn) {
+            try { txn.close(); } catch (Throwable t) {}
+            txn = null;
+          }
+        }
+      } while(retry);
+    }
+  }
+
+  @Override
+  public KVIterator<Entry<byte[], byte[]>> kvfetch(KVFetchRequest request) throws IOException {
+
+    ReadToken token = request.getToken();
+
+    if (FDBUseTenantPrefix && (0 == token.getAttributesSize() || !token.getAttributes().containsKey(Constants.TOKEN_ATTR_FDB_TENANT_PREFIX))) {
+      throw new IOException("Invalid token, missing tenant prefix.");
+    } else if (!FDBUseTenantPrefix && (0 != token.getAttributesSize() && token.getAttributes().containsKey(Constants.TOKEN_ATTR_FDB_TENANT_PREFIX))) {
+      throw new IOException("Invalid token, no support for tenant prefix.");
+    }
+
+    byte[] tenantPrefix = null;
+
+    if (FDBUseTenantPrefix) {
+      tenantPrefix = OrderPreservingBase64.decode(token.getAttributes().get(Constants.TOKEN_ATTR_FDB_TENANT_PREFIX));
+      if (8 != tenantPrefix.length) {
+        throw new IOException("Invalid tenant prefix, length should be 8 bytes.");
+      }
+    } else {
+      tenantPrefix = pool.getContext().getTenantPrefix();
+    }
+
+    //
+    // Extract kvprefix from token attributes
+    //
+
+    byte[] kvprefix = KVSTORE.KVPREFIX;
+
+    if (token.getAttributesSize() > 0 && null != token.getAttributes().get(KVSTORE.ATTR_KVPREFIX)) {
+      if (!token.getAttributes().get(KVSTORE.ATTR_KVPREFIX).isEmpty()) {
+        byte[] tkvprefix = OrderPreservingBase64.decode(token.getAttributes().get(KVSTORE.ATTR_KVPREFIX));
+        kvprefix = Arrays.copyOf(KVSTORE.KVPREFIX, KVSTORE.KVPREFIX.length + tkvprefix.length);
+        System.arraycopy(tkvprefix, 0, kvprefix, KVSTORE.KVPREFIX.length, tkvprefix.length);
+      }
+    } else {
+      throw new IOException("Token is missing attribute '" + KVSTORE.ATTR_KVPREFIX + "'.");
+    }
+
+    if (request.isSetStart() && request.isSetStop()) {
+      FDBScan scan = new FDBScan();
+      scan.setReverse(false);
+      scan.setTenantPrefix(tenantPrefix);
+
+      byte[] start = Arrays.copyOf(kvprefix, kvprefix.length + request.getStart().length);
+      System.arraycopy(request.getStart(), 0, start, kvprefix.length, request.getStart().length);
+
+      byte[] stop = Arrays.copyOf(kvprefix, kvprefix.length + request.getStop().length);
+      System.arraycopy(request.getStop(), 0, stop, kvprefix.length, request.getStop().length);
+
+      scan.setStartKey(start);
+      scan.setEndKey(stop);
+
+      AtomicReference<Transaction> tx = new AtomicReference<Transaction>();
+
+      FDBKVScanner scanner = scan.getScanner(pool.getContext(), pool.getDatabase(), StreamingMode.ITERATOR, null);
+      Sensision.update(SensisionConstants.SENSISION_CLASS_CONTINUUM_FDB_CLIENT_SCANNERS, Sensision.EMPTY_LABELS, 1);
+
+      final byte[] fkvprefix = kvprefix;
+
+      return new KVIterator<Map.Entry<byte[],byte[]>>() {
+        Entry<byte[],byte[]> element = null;
+        boolean done = false;
+        @Override
+
+        public boolean hasNext() {
+          if (done) {
+            return false;
+          }
+          if (null != element) {
+            return true;
+          }
+
+          if (!scanner.hasNext()) {
+            done = true;
+            return false;
+          }
+
+          FDBKeyValue kv = scanner.next();
+
+          byte[] key = kv.getKey();
+
+          // Strip kvprefix from key
+          if (fkvprefix.length > 0) {
+            byte[] k = Arrays.copyOfRange(key, fkvprefix.length, key.length);
+            element = new AbstractMap.SimpleEntry<byte[],byte[]>(k, kv.getValue());
+          } else {
+            element = new AbstractMap.SimpleEntry<byte[],byte[]>(key, kv.getValue());
+          }
+
+          return null != element;
+        }
+
+        @Override
+        public Entry<byte[], byte[]> next() {
+          if (done) {
+            throw new IllegalStateException();
+          }
+          if (null == element && !hasNext()) {
+            throw new NoSuchElementException();
+          }
+          Entry<byte[],byte[]> elt = element;
+          element = null;
+          return elt;
+        }
+
+        @Override
+        public void close() throws Exception {
+          scanner.close();
+        }
+      };
+    } else {
+      // Keys
+
+      long txsize = 0L;
+
+      List<FDBGetOp> batch = new ArrayList<FDBGetOp>();
+
+      List<Entry<byte[],byte[]>> kvs = new ArrayList<Entry<byte[],byte[]>>();
+
+      for (int i = 0; i < request.getKeysSize(); i++) {
+        ByteBuffer kbb = request.getKeys().get(i);
+        byte[] key = Arrays.copyOf(kvprefix, kvprefix.length + kbb.remaining());
+        kbb.get(key, kvprefix.length, kbb.remaining());
+
+        FDBGetOp get = new FDBGetOp(tenantPrefix, key);
+
+        // We've reached the size limit for a transaction, issue it to FDB
+        if (txsize + get.size() >= FDBUtils.MAX_TXN_SIZE * 0.95) {
+          kvs.addAll(flushGetOps(batch));
+          batch.clear();
+          txsize = 0;
+        }
+        batch.add(get);
+        txsize += get.size();
+      }
+
+      if (!batch.isEmpty()) {
+        kvs.addAll(flushGetOps(batch));
+      }
+
+      //
+      // Return an iterator which will strip kvprefix from keys as elements are returned
+      //
+
+      Iterator<Entry<byte[],byte[]>> iter = kvs.iterator();
+
+      final byte[] fkvprefix = kvprefix;
+
+      return new KVIterator<Entry<byte[],byte[]>>() {
+        boolean done = false;
+        Entry<byte[],byte[]> element = null;
+        @Override
+        public void close() throws Exception {
+          done = true;
+        }
+        @Override
+        public boolean hasNext() {
+          if (done) {
+            return false;
+          }
+          if (null != element) {
+            return true;
+          }
+          if (!iter.hasNext()) {
+            done = true;
+            return false;
+          }
+          Entry<byte[],byte[]> entry = iter.next();
+
+          // Strip kvprefix from key
+          if (fkvprefix.length > 0) {
+            byte[] k = Arrays.copyOfRange(entry.getKey(), fkvprefix.length, entry.getKey().length);
+            element = new AbstractMap.SimpleEntry<byte[],byte[]>(k, entry.getValue());
+          } else {
+            element = entry;
+          }
+          return true;
+        }
+
+        @Override
+        public Entry<byte[], byte[]> next() {
+          if (done) {
+            throw new IllegalStateException();
+          }
+
+          if (null == element) {
+            if (!hasNext()) {
+              throw new IllegalStateException();
+            }
+          }
+
+          Entry<byte[],byte[]> elt = element;
+          element = null;
+          return elt;
+        }
+      };
+    }
+  }
+
+  private List<Entry<byte[],byte[]>> flushGetOps(List<FDBGetOp> batch) {
+    List<Entry<byte[],byte[]>> kvs = new ArrayList<Entry<byte[],byte[]>>(batch.size());
+
+    if (batch.isEmpty()) {
+      return kvs;
+    }
+
+    Transaction txn = null;
+
+    /**
+     * Number of attempts when cluster is lagging, 0 means no lag mitigation
+     */
+    int versionAttempts = 32;
+
+    /**
+     * Read version offset to apply when we need to go back in time (post error 1037). In microseconds.
+     * The offset will be modified along the attempts.
+     */
+    long offset = 1000000L;
+
+    Long forceReadVersion = null;
+
+    long count = 0L;
+
+    long attempts = this.fdbRetryLimit;
+
+    while(attempts-- > 0) {
+      try {
+        txn = this.pool.getDatabase().createTransaction();
+        // Allow RAW access because we may manually force a tenant key prefix without actually setting a tenant
+        if (this.pool.getContext().hasTenant() || null != batch.get(0).getTenant()) {
+          txn.options().setRawAccess();
+        }
+
+        txn.options().setCausalReadRisky();
+        txn.options().setReadYourWritesDisable();
+        txn.options().setSnapshotRywDisable();
+
+        for (FDBGetOp op: batch) {
+          op.apply(txn);
+        }
+
+        txn.commit();
+
+        for (FDBGetOp op: batch) {
+          kvs.add(new AbstractMap.SimpleEntry(op.getKey(), op.getValue()));
+        }
+
+        return kvs;
+      } catch (Throwable t) {
+        FDBUtils.errorMetrics("kvfetch", t.getCause());
+        if (t.getCause() instanceof FDBException) {
+          FDBException fdbe = (FDBException) t.getCause();
+          int code = fdbe.getCode();
+
+          // We support retrying after a 'transaction too old' error
+          if (1007 == code) { // Transaction too old
+            // If we were forcing a read version and read nothing then we probably set the read version
+            // too far in the past, adjust it 0.5s in the future
+            if (null != forceReadVersion && 0L == count) {
+              forceReadVersion += 500000;
+            }
+            // Update last seen read version
+            if (count > 0L) {
+              try { this.pool.getContext().setLastSeenReadVersion(txn.getReadVersion().get()); } catch (Throwable tt) {}
+              count = 0L;
+            }
+            try { txn.close(); } catch (Throwable tt) {}
+            txn = null;
+            continue; //return hasNext();
+          } else if (1009 == code        // 1009: request for future version, we were too aggressive when forcing the version.
+                     || 1037 == code) {  // 1037: process_behind, the cluster is lagging, attempt to force a known valid read version
+            long readVersion = 0L;
+            try {
+              // Call getReadVersion so version gets a chance to be initialized and we don't risk getting a transaction_too_old (1007)
+              // @see https://forums.foundationdb.org/t/use-of-setreadversion/3696/2
+              readVersion = txn.getReadVersion().get();
+            } catch (Throwable tt) {}
+            // We have reached the maximum number of forced version attempts
+            if (0 >= versionAttempts) {
+              Sensision.update(SensisionConstants.CLASS_WARP_FDB_MAXFORCEDVERSION, Sensision.EMPTY_LABELS, 1);
+              throw new RuntimeException("Maximum number of forced read version attempts reached", t);
+            }
+
+            if (null == forceReadVersion) {
+              forceReadVersion = this.pool.getContext().getLastSeenReadVersion();
+
+              if (forceReadVersion < readVersion) {
+                forceReadVersion = readVersion - offset;
+              }
+            } else {
+              // forced read version was already set but reading failed anyway, so attempt with a read version further in the past
+              forceReadVersion -= offset;
+            }
+            // Close the transaction since we cannot force the read version on a transaction which alread
+            try { txn.close(); } catch (Throwable tt) {}
+            txn = null;
+            continue; //return hasNext();
+          } else if (1039 == code) { // cluster_version_changed, may happen when using the multi-version client upon first connection
+            // Close the transaction
+            try { txn.close(); } catch (Throwable tt) {}
+            txn = null;
+            continue;
+          }
+        }
+        throw t;
+      } finally {
+        if (null != txn) {
+          try { txn.close(); } catch (Throwable tt) {}
+        }
+      }
+    }
+
+    throw new RuntimeException("Unable to retrieve Key/Value pairs from FoundationDB");
   }
 }

--- a/warp10/src/main/java/io/warp10/fdb/FDBUtils.java
+++ b/warp10/src/main/java/io/warp10/fdb/FDBUtils.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2022-2023  SenX S.A.S.
+//   Copyright 2022-2025  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -49,6 +49,7 @@ public class FDBUtils {
   public static final String KEY_ID = "id";
   public static final String KEY_PREFIX = "prefix";
 
+  public static final int MAX_KEY_SIZE = 10000;
   public static final int MAX_VALUE_SIZE = 100000;
   public static final long MAX_TXN_SIZE = 10000000;
 

--- a/warp10/src/main/java/io/warp10/leveldb/WarpDB.java
+++ b/warp10/src/main/java/io/warp10/leveldb/WarpDB.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2023  SenX S.A.S.
+//   Copyright 2018-2025  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -355,8 +355,7 @@ public class WarpDB extends Thread implements DB {
 
   @Override
   public byte[] get(byte[] key) throws DBException {
-    throw new RuntimeException("Unsupported operation get.");
-    //return this.db.get(key);
+    return this.db.get(key);
   }
 
   @Override

--- a/warp10/src/main/java/io/warp10/script/WarpScriptLib.java
+++ b/warp10/src/main/java/io/warp10/script/WarpScriptLib.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2019-2024  SenX S.A.S.
+//   Copyright 2019-2025  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -360,6 +360,8 @@ import io.warp10.script.functions.JSONSTRICT;
 import io.warp10.script.functions.JSONTO;
 import io.warp10.script.functions.KEYLIST;
 import io.warp10.script.functions.KURTOSIS;
+import io.warp10.script.functions.KVLOAD;
+import io.warp10.script.functions.KVSTORE;
 import io.warp10.script.functions.LABELS;
 import io.warp10.script.functions.LASTACTIVITY;
 import io.warp10.script.functions.LASTBUCKET;
@@ -1106,8 +1108,8 @@ public class WarpScriptLib {
   public static final String BDTESTBIT = "BDTESTBIT";
   public static final String BDXOR = "BDXOR";
 
-
-
+  public static final String KVLOAD = "KVLOAD";
+  public static final String KVSTORE = "KVSTORE";
 
   public static final String RSAPUBLIC = "RSAPUBLIC";
   public static final String RSAPRIVATE = "RSAPRIVATE";
@@ -2954,6 +2956,9 @@ public class WarpScriptLib {
     addNamedWarpScriptFunction(new BDRAND(SBDRAND, true));
     addNamedWarpScriptFunction(new BDPROBABLEPRIME(BDPROBABLEPRIME, false));
     addNamedWarpScriptFunction(new BDPROBABLEPRIME(SBDPROBABLEPRIME, true));
+
+    addNamedWarpScriptFunction(new KVSTORE(KVSTORE));
+    addNamedWarpScriptFunction(new KVLOAD(KVLOAD));
 
     //
     // Linear Algebra

--- a/warp10/src/main/java/io/warp10/script/functions/KVLOAD.java
+++ b/warp10/src/main/java/io/warp10/script/functions/KVLOAD.java
@@ -1,0 +1,170 @@
+//
+//   Copyright 2025  SenX S.A.S.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+package io.warp10.script.functions;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import io.warp10.BytesUtils;
+import io.warp10.continuum.Tokens;
+import io.warp10.continuum.store.StoreClient;
+import io.warp10.continuum.store.StoreClient.KVIterator;
+import io.warp10.continuum.store.thrift.data.KVFetchRequest;
+import io.warp10.quasar.token.thrift.data.ReadToken;
+import io.warp10.script.NamedWarpScriptFunction;
+import io.warp10.script.WarpScriptException;
+import io.warp10.script.WarpScriptStack;
+import io.warp10.script.WarpScriptStack.Macro;
+import io.warp10.script.WarpScriptStackFunction;
+
+public class KVLOAD extends NamedWarpScriptFunction implements WarpScriptStackFunction {
+
+  public static final String KEY_START = "start";
+  public static final String KEY_END = "end";
+  public static final String KEY_KEYS = "keys";
+  public static final String KEY_TOKEN = "token";
+  public static final String KEY_MACRO = "macro";
+
+  public KVLOAD(String name) {
+    super(name);
+  }
+
+  @Override
+  public Object apply(WarpScriptStack stack) throws WarpScriptException {
+    Object top = stack.pop();
+
+    if (!(top instanceof Map)) {
+      throw new WarpScriptException(getName() + " operates on a map.");
+    }
+
+    Map<Object,Object> params = (Map<Object,Object>) top;
+
+    if (!(params.get(KEY_TOKEN) instanceof String)) {
+      throw new WarpScriptException(getName() + " expects a token under '" + KEY_TOKEN + "'.");
+    }
+
+    //
+    // If the token has an attribute .kvprefix then the call can succeed. This attribute
+    // acts as a capability.
+    //
+
+    ReadToken rtoken = Tokens.extractReadToken((String) params.get(KEY_TOKEN));
+
+    KVFetchRequest kvfr = new KVFetchRequest();
+    kvfr.setToken(rtoken);
+
+    Macro macro = null;
+
+    if (params.get(KEY_MACRO) instanceof Macro) {
+      macro = (Macro) params.get(KEY_MACRO);
+    }
+
+    if (params.get(KEY_KEYS) instanceof List) {
+      List<Object> keys = (List<Object>) params.get(KEY_KEYS);
+      List<byte[]> bkeys = new ArrayList<byte[]>(keys.size());
+
+      for (Object key: keys) {
+        if (key instanceof byte[]) {
+          bkeys.add((byte[]) key);
+        } else if (key instanceof String) {
+          byte[] k = ((String) key).getBytes(StandardCharsets.UTF_8);
+          if (k.length != ((String) key).length()) {
+            throw new WarpScriptException(getName() + " STRING keys cannot contain non ISO-8859-1 characters.");
+          }
+          bkeys.add(k);
+        } else {
+          throw new WarpScriptException(getName() + " expects '" + KEY_KEYS + "' to contain a list of BYTES or STRING keys.");
+        }
+      }
+
+      // Sort the list in lexicographical order to speed up retrieval
+
+      bkeys.sort(new Comparator<byte[]>() {
+        @Override
+        public int compare(byte[] o1, byte[] o2) {
+          return BytesUtils.compareTo(o1, o2);
+        }
+      });
+
+      for (byte[] key: bkeys) {
+        kvfr.addToKeys(ByteBuffer.wrap(key));
+      }
+    } else {
+      byte[] start = null;
+      byte[] end = null;
+
+      if (params.get(KEY_START) instanceof byte[]) {
+        start = Arrays.copyOf((byte[]) params.get(KEY_START), ((byte[]) params.get(KEY_START)).length);
+      } else if (params.get(KEY_START) instanceof String) {
+        start = ((String) params.get(KEY_START)).getBytes(StandardCharsets.UTF_8);
+        if (start.length != ((String) params.get(KEY_START)).length()) {
+          throw new WarpScriptException(getName() + " STRING keys cannot contain non ISO-8859-1 characters.");
+        }
+      } else {
+        throw new WarpScriptException(getName() + " expects keys to be STRING or BYTES.");
+      }
+
+      if (params.get(KEY_END) instanceof byte[]) {
+        end = Arrays.copyOf((byte[]) params.get(KEY_END), ((byte[]) params.get(KEY_END)).length);
+      } else if (params.get(KEY_END) instanceof String) {
+        end = ((String) params.get(KEY_END)).getBytes(StandardCharsets.UTF_8);
+        if (end.length != ((String) params.get(KEY_END)).length()) {
+          throw new WarpScriptException(getName() + " STRING keys cannot contain non ISO-8859-1 characters.");
+        }
+      } else {
+        throw new WarpScriptException(getName() + " expects keys to be STRING or BYTES.");
+      }
+
+      kvfr.setStart(start);
+      kvfr.setStop(end);
+    }
+
+    StoreClient store = stack.getStoreClient();
+
+    Map<byte[],byte[]> kv = new LinkedHashMap<byte[],byte[]>();
+
+    try (KVIterator<Entry<byte[],byte[]>> iter = store.kvfetch(kvfr)) {
+      while(iter.hasNext()) {
+        Entry<byte[],byte[]> entry = iter.next();
+
+        if (null != macro) {
+          stack.push(entry.getKey());
+          stack.push(entry.getValue());
+          stack.exec(macro);
+          if (Boolean.TRUE.equals(stack.pop())) {
+            kv.put(entry.getKey(), entry.getValue());
+          }
+        } else {
+          kv.put(entry.getKey(), entry.getValue());
+        }
+      }
+    } catch (Exception e) {
+      throw new WarpScriptException(getName() + " encountered an error while reading Key/Value pairs.", e);
+    }
+
+    stack.push(kv);
+
+    return stack;
+  }
+}

--- a/warp10/src/main/java/io/warp10/script/functions/KVLOAD.java
+++ b/warp10/src/main/java/io/warp10/script/functions/KVLOAD.java
@@ -103,7 +103,7 @@ public class KVLOAD extends NamedWarpScriptFunction implements WarpScriptStackFu
         } else if (key instanceof String) {
           byte[] k = ((String) key).getBytes(StandardCharsets.UTF_8);
           if (k.length != ((String) key).length()) {
-            throw new WarpScriptException(getName() + " STRING keys cannot contain non ISO-8859-1 characters.");
+            throw new WarpScriptException(getName() + " STRING keys cannot contain non ASCII characters.");
           }
           bkeys.add(k);
         } else {
@@ -132,7 +132,7 @@ public class KVLOAD extends NamedWarpScriptFunction implements WarpScriptStackFu
       } else if (params.get(KEY_START) instanceof String) {
         start = ((String) params.get(KEY_START)).getBytes(StandardCharsets.UTF_8);
         if (start.length != ((String) params.get(KEY_START)).length()) {
-          throw new WarpScriptException(getName() + " STRING keys cannot contain non ISO-8859-1 characters.");
+          throw new WarpScriptException(getName() + " STRING keys cannot contain non ASCII characters.");
         }
       } else {
         throw new WarpScriptException(getName() + " expects keys to be STRING or BYTES.");
@@ -143,7 +143,7 @@ public class KVLOAD extends NamedWarpScriptFunction implements WarpScriptStackFu
       } else if (params.get(KEY_END) instanceof String) {
         end = ((String) params.get(KEY_END)).getBytes(StandardCharsets.UTF_8);
         if (end.length != ((String) params.get(KEY_END)).length()) {
-          throw new WarpScriptException(getName() + " STRING keys cannot contain non ISO-8859-1 characters.");
+          throw new WarpScriptException(getName() + " STRING keys cannot contain non ASCII characters.");
         }
       } else {
         throw new WarpScriptException(getName() + " expects keys to be STRING or BYTES.");

--- a/warp10/src/main/java/io/warp10/script/functions/KVSTORE.java
+++ b/warp10/src/main/java/io/warp10/script/functions/KVSTORE.java
@@ -1,0 +1,161 @@
+//
+//   Copyright 2025  SenX S.A.S.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+package io.warp10.script.functions;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import io.warp10.WarpConfig;
+import io.warp10.continuum.Configuration;
+import io.warp10.continuum.Tokens;
+import io.warp10.continuum.store.StoreClient;
+import io.warp10.continuum.store.thrift.data.KVStoreRequest;
+import io.warp10.quasar.token.thrift.data.WriteToken;
+import io.warp10.script.NamedWarpScriptFunction;
+import io.warp10.script.WarpScriptException;
+import io.warp10.script.WarpScriptStack;
+import io.warp10.script.WarpScriptStackFunction;
+
+public class KVSTORE extends NamedWarpScriptFunction implements WarpScriptStackFunction {
+
+  /**
+   * KV are stored with keys starting with 'X' (as Xtra data)
+   */
+  public static final byte[] KVPREFIX = "X".getBytes(StandardCharsets.UTF_8);
+
+  /**
+   * Token attribute for storing OPB64 encoded key prefix
+   */
+  public static final String ATTR_KVPREFIX = ".kvprefix";
+
+  /**
+   * Maximum key size
+   */
+  public static final String ATTR_KVMAXK = ".kvmaxk";
+
+  /**
+   * Maximum value size
+   */
+  public static final String ATTR_KVMAXV = ".kvmaxv";
+
+  private static final int DEFAULT_MAXK;
+  private static final int DEFAULT_MAXV;
+
+  static {
+    DEFAULT_MAXK = Integer.parseInt(WarpConfig.getProperty(Configuration.WARP_KVSTORE_MAXK, "128"));
+    DEFAULT_MAXV = Integer.parseInt(WarpConfig.getProperty(Configuration.WARP_KVSTORE_MAXV, "1024"));
+  }
+
+  public KVSTORE(String name) {
+    super(name);
+  }
+
+  @Override
+  public Object apply(WarpScriptStack stack) throws WarpScriptException {
+    Object top = stack.pop();
+
+    if (!(top instanceof String)) {
+      throw new WarpScriptException(getName() + " missing token.");
+    }
+
+    //
+    // If the token has an attribute .kvprefix then the call can succeed. This attribute
+    // acts as a capability.
+    //
+
+    WriteToken wtoken = Tokens.extractWriteToken((String) top);
+
+    top = stack.pop();
+
+    if (!(top instanceof Map)) {
+      throw new WarpScriptException(getName() + " operates on a map.");
+    }
+
+    Map<Object,Object> kv = (Map<Object,Object>) top;
+
+    KVStoreRequest kvsr = new KVStoreRequest();
+    kvsr.setToken(wtoken);
+
+    int kvmaxv = DEFAULT_MAXV;
+    int kvmaxk = DEFAULT_MAXK;
+
+    if (wtoken.getAttributesSize() > 0) {
+      if (null != wtoken.getAttributes().get(ATTR_KVMAXK)) {
+        kvmaxk = Integer.parseInt(wtoken.getAttributes().get(ATTR_KVMAXK));
+      }
+      if (null != wtoken.getAttributes().get(ATTR_KVMAXV)) {
+        kvmaxv = Integer.parseInt(wtoken.getAttributes().get(ATTR_KVMAXV));
+      }
+    }
+
+    for (Entry<Object,Object> entry: kv.entrySet()) {
+      byte[] key = null;
+      byte[] value = null;
+
+      if (entry.getKey() instanceof byte[]) {
+        key = (byte[]) entry.getKey();
+      } else if (entry.getKey() instanceof String) {
+        key = ((String) entry.getKey()).getBytes(StandardCharsets.UTF_8);
+        // Check that STRING keys do not contain Unicode characters
+        if (key.length != ((String) entry.getKey()).length()) {
+          throw new WarpScriptException(getName() + " STRING keys cannot contain non ISO-8859-1 characters.");
+        }
+      } else {
+        throw new WarpScriptException(getName() + " keys are expected to be BYTES or STRING.");
+      }
+
+      if (entry.getValue() instanceof byte[]) {
+        value = (byte[]) entry.getValue();
+      } else if (entry.getValue() instanceof String) {
+        value = ((String) entry.getValue()).getBytes(StandardCharsets.UTF_8);
+      } else if (null != entry.getValue()) {
+        throw new WarpScriptException(getName() + " values are expected to be BYTES or STRING.");
+      }
+
+      if (key.length > kvmaxk) {
+        throw new WarpScriptException(getName() + " maximum allowed key size is " + kvmaxk + " bytes.");
+      }
+
+      if (null != value && value.length > kvmaxv) {
+        throw new WarpScriptException(getName() + " maximum allowed value size is " + kvmaxv + " bytes.");
+      }
+
+      kvsr.addToKeys(ByteBuffer.wrap(key));
+
+      if (null == value) {
+        kvsr.addToValues(ByteBuffer.allocate(0));
+      } else {
+        kvsr.addToValues(ByteBuffer.wrap(value));
+      }
+    }
+
+    StoreClient store = stack.getStoreClient();
+
+    try {
+      store.kvstore(kvsr);
+      // We force writing a null to trigger a possible sync of a DatalogManager
+      store.kvstore(null);
+    } catch (IOException ioe) {
+      throw new WarpScriptException(getName() + " encountered an error while storing Key/Value pairs.", ioe);
+    }
+
+    return stack;
+  }
+}

--- a/warp10/src/main/java/io/warp10/script/functions/KVSTORE.java
+++ b/warp10/src/main/java/io/warp10/script/functions/KVSTORE.java
@@ -115,7 +115,7 @@ public class KVSTORE extends NamedWarpScriptFunction implements WarpScriptStackF
         key = ((String) entry.getKey()).getBytes(StandardCharsets.UTF_8);
         // Check that STRING keys do not contain Unicode characters
         if (key.length != ((String) entry.getKey()).length()) {
-          throw new WarpScriptException(getName() + " STRING keys cannot contain non ISO-8859-1 characters.");
+          throw new WarpScriptException(getName() + " STRING keys cannot contain non ASCII characters.");
         }
       } else {
         throw new WarpScriptException(getName() + " keys are expected to be BYTES or STRING.");

--- a/warp10/src/main/java/io/warp10/standalone/NullStoreClient.java
+++ b/warp10/src/main/java/io/warp10/standalone/NullStoreClient.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2024  SenX S.A.S.
+//   Copyright 2018-2025  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -17,6 +17,9 @@
 package io.warp10.standalone;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 
 import io.warp10.continuum.gts.GTSDecoder;
@@ -24,6 +27,8 @@ import io.warp10.continuum.gts.GTSEncoder;
 import io.warp10.continuum.store.GTSDecoderIterator;
 import io.warp10.continuum.store.StoreClient;
 import io.warp10.continuum.store.thrift.data.FetchRequest;
+import io.warp10.continuum.store.thrift.data.KVFetchRequest;
+import io.warp10.continuum.store.thrift.data.KVStoreRequest;
 import io.warp10.continuum.store.thrift.data.Metadata;
 import io.warp10.quasar.token.thrift.data.WriteToken;
 
@@ -49,4 +54,24 @@ public class NullStoreClient implements StoreClient {
 
   @Override
   public long delete(WriteToken token, Metadata metadata, long start, long end) throws IOException { return 0L; }
+
+  @Override
+  public void kvstore(KVStoreRequest request) throws IOException {}
+
+  @Override
+  public KVIterator<Entry<byte[], byte[]>> kvfetch(KVFetchRequest request) throws IOException {
+    return new KVIterator<Entry<byte[],byte[]>>() {
+      @Override
+      public boolean hasNext() {
+        return false;
+      }
+      @Override
+      public Entry<byte[], byte[]> next() {
+        return null;
+      }
+      @Override
+      public void close() throws Exception {
+      }
+    };
+  }
 }

--- a/warp10/src/main/java/io/warp10/standalone/PlasmaStoreClient.java
+++ b/warp10/src/main/java/io/warp10/standalone/PlasmaStoreClient.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2020  SenX S.A.S.
+//   Copyright 2018-2025  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -18,12 +18,16 @@ package io.warp10.standalone;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map.Entry;
 
 import io.warp10.continuum.gts.GTSEncoder;
 import io.warp10.continuum.store.GTSDecoderIterator;
 import io.warp10.continuum.store.StoreClient;
 import io.warp10.continuum.store.thrift.data.FetchRequest;
+import io.warp10.continuum.store.thrift.data.KVFetchRequest;
+import io.warp10.continuum.store.thrift.data.KVStoreRequest;
 import io.warp10.continuum.store.thrift.data.Metadata;
 import io.warp10.quasar.token.thrift.data.WriteToken;
 
@@ -44,7 +48,17 @@ public class PlasmaStoreClient implements StoreClient {
       }
     }
   }
-  
+
   @Override
   public long delete(WriteToken token, Metadata metadata, long start, long end) throws IOException { return 0L; }
+
+  @Override
+  public void kvstore(KVStoreRequest request) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public KVIterator<Entry<byte[], byte[]>> kvfetch(KVFetchRequest request) throws IOException {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneAcceleratedStoreClient.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneAcceleratedStoreClient.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2020-2021  SenX S.A.S.
+//   Copyright 2020-2025  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -19,8 +19,10 @@ package io.warp10.standalone;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -29,10 +31,10 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.LockSupport;
 
-import io.warp10.CustomThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.warp10.CustomThreadFactory;
 import io.warp10.WarpConfig;
 import io.warp10.continuum.Configuration;
 import io.warp10.continuum.TimeSource;
@@ -45,6 +47,8 @@ import io.warp10.continuum.store.MetadataIterator;
 import io.warp10.continuum.store.StoreClient;
 import io.warp10.continuum.store.thrift.data.DirectoryRequest;
 import io.warp10.continuum.store.thrift.data.FetchRequest;
+import io.warp10.continuum.store.thrift.data.KVFetchRequest;
+import io.warp10.continuum.store.thrift.data.KVStoreRequest;
 import io.warp10.continuum.store.thrift.data.Metadata;
 import io.warp10.quasar.token.thrift.data.WriteToken;
 
@@ -336,5 +340,15 @@ public class StandaloneAcceleratedStoreClient implements StoreClient {
     if (!AcceleratorConfig.nocache.get()) {
       cache.store(encoder);
     }
+  }
+
+  @Override
+  public void kvstore(KVStoreRequest request) throws IOException {
+    persistent.kvstore(request);
+  }
+
+  @Override
+  public KVIterator<Entry<byte[], byte[]>> kvfetch(KVFetchRequest request) throws IOException {
+    return persistent.kvfetch(request);
   }
 }

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneParallelStoreClientWrapper.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneParallelStoreClientWrapper.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2020  SenX S.A.S.
+//   Copyright 2018-2025  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -16,32 +16,36 @@
 package io.warp10.standalone;
 
 import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map.Entry;
 
 import io.warp10.continuum.gts.GTSEncoder;
 import io.warp10.continuum.store.GTSDecoderIterator;
 import io.warp10.continuum.store.ParallelGTSDecoderIteratorWrapper;
 import io.warp10.continuum.store.StoreClient;
 import io.warp10.continuum.store.thrift.data.FetchRequest;
+import io.warp10.continuum.store.thrift.data.KVFetchRequest;
+import io.warp10.continuum.store.thrift.data.KVStoreRequest;
 import io.warp10.continuum.store.thrift.data.Metadata;
 import io.warp10.quasar.token.thrift.data.WriteToken;
 
 public class StandaloneParallelStoreClientWrapper implements StoreClient {
   private final StoreClient parent;
-  
+
   public StandaloneParallelStoreClientWrapper(StoreClient parent) {
     this.parent = parent;
   }
-  
+
   @Override
   public void addPlasmaHandler(StandalonePlasmaHandlerInterface handler) {
     parent.addPlasmaHandler(handler);
   }
-  
+
   @Override
   public long delete(WriteToken token, Metadata metadata, long start, long end) throws IOException {
     return parent.delete(token, metadata, start, end);
   }
-  
+
   @Override
   public GTSDecoderIterator fetch(FetchRequest req) throws IOException {
     if (req.isParallelScanners() && ParallelGTSDecoderIteratorWrapper.useParallelScanners()) {
@@ -50,9 +54,19 @@ public class StandaloneParallelStoreClientWrapper implements StoreClient {
       return parent.fetch(req);
     }
   }
-  
+
   @Override
   public void store(GTSEncoder encoder) throws IOException {
     parent.store(encoder);
+  }
+
+  @Override
+  public void kvstore(KVStoreRequest request) throws IOException {
+    parent.kvstore(request);
+  }
+
+  @Override
+  public KVIterator<Entry<byte[], byte[]>> kvfetch(KVFetchRequest request) throws IOException {
+    return parent.kvfetch(request);
   }
 }

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneShardedStoreClientWrapper.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneShardedStoreClientWrapper.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2019-2023  SenX S.A.S.
+//   Copyright 2019-2025  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 package io.warp10.standalone;
 
 import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map.Entry;
 
 import io.warp10.WarpConfig;
 import io.warp10.continuum.Configuration;
@@ -25,6 +27,8 @@ import io.warp10.continuum.gts.GTSHelper;
 import io.warp10.continuum.store.GTSDecoderIterator;
 import io.warp10.continuum.store.StoreClient;
 import io.warp10.continuum.store.thrift.data.FetchRequest;
+import io.warp10.continuum.store.thrift.data.KVFetchRequest;
+import io.warp10.continuum.store.thrift.data.KVStoreRequest;
 import io.warp10.continuum.store.thrift.data.Metadata;
 import io.warp10.crypto.KeyStore;
 import io.warp10.crypto.SipHashInline;
@@ -130,5 +134,15 @@ public class StandaloneShardedStoreClientWrapper implements StoreClient {
     if (!skip) {
       this.client.store(encoder);
     }
+  }
+
+  @Override
+  public void kvstore(KVStoreRequest request) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public KVIterator<Entry<byte[], byte[]>> kvfetch(KVFetchRequest request) throws IOException {
+    throw new UnsupportedOperationException();
   }
 }

--- a/warp10/src/main/java/io/warp10/standalone/datalog/DatalogHelper.java
+++ b/warp10/src/main/java/io/warp10/standalone/datalog/DatalogHelper.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2020-2023  SenX S.A.S.
+//   Copyright 2020-2025  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -24,13 +24,13 @@ import org.apache.thrift.TBase;
 import org.apache.thrift.TDeserializer;
 import org.apache.thrift.TException;
 import org.apache.thrift.TSerializer;
-import org.apache.thrift.protocol.TCompactProtocol;
 
 import io.warp10.ThriftUtils;
 import io.warp10.WarpConfig;
 import io.warp10.continuum.gts.GTSEncoder;
 import io.warp10.continuum.store.thrift.data.DatalogRecord;
 import io.warp10.continuum.store.thrift.data.DatalogRecordType;
+import io.warp10.continuum.store.thrift.data.KVStoreRequest;
 import io.warp10.continuum.store.thrift.data.Metadata;
 import io.warp10.quasar.token.thrift.data.WriteToken;
 
@@ -86,6 +86,16 @@ public class DatalogHelper {
     record.setId(id);
     record.setTimestamp(System.currentTimeMillis());
     record.setMetadata(metadata);
+
+    return record;
+  }
+
+  public static DatalogRecord getKVStoreRecord(String id, KVStoreRequest request) throws IOException {
+    DatalogRecord record = new DatalogRecord();
+    record.setType(DatalogRecordType.KVSTORE);
+    record.setId(id);
+    record.setTimestamp(System.currentTimeMillis());
+    record.setKvstorerequest(request);
 
     return record;
   }

--- a/warp10/src/main/java/io/warp10/standalone/datalog/DatalogManager.java
+++ b/warp10/src/main/java/io/warp10/standalone/datalog/DatalogManager.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2020-2022  SenX S.A.S.
+//   Copyright 2020-2025  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.io.IOException;
 import io.warp10.continuum.gts.GTSEncoder;
 import io.warp10.continuum.store.StoreClient;
 import io.warp10.continuum.store.thrift.data.DatalogRecord;
+import io.warp10.continuum.store.thrift.data.KVStoreRequest;
 import io.warp10.continuum.store.thrift.data.Metadata;
 import io.warp10.quasar.token.thrift.data.WriteToken;
 import io.warp10.standalone.StandaloneDirectoryClient;
@@ -39,6 +40,7 @@ public abstract class DatalogManager {
   protected abstract void unregister(Metadata metadata) throws IOException;
   protected abstract void store(GTSEncoder encoder) throws IOException;
   protected abstract void delete(WriteToken token, Metadata metadata, long start, long end) throws IOException;
+  protected abstract void kvstore(KVStoreRequest request) throws IOException;
 
   /**
    * Method to process a record retrieved from a feeder. This is different from locally generated

--- a/warp10/src/main/java/io/warp10/standalone/datalog/DatalogStoreClient.java
+++ b/warp10/src/main/java/io/warp10/standalone/datalog/DatalogStoreClient.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2020  SenX S.A.S.
+//   Copyright 2020-2025  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -17,11 +17,15 @@
 package io.warp10.standalone.datalog;
 
 import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map.Entry;
 
 import io.warp10.continuum.gts.GTSEncoder;
 import io.warp10.continuum.store.GTSDecoderIterator;
 import io.warp10.continuum.store.StoreClient;
 import io.warp10.continuum.store.thrift.data.FetchRequest;
+import io.warp10.continuum.store.thrift.data.KVFetchRequest;
+import io.warp10.continuum.store.thrift.data.KVStoreRequest;
 import io.warp10.continuum.store.thrift.data.Metadata;
 import io.warp10.quasar.token.thrift.data.WriteToken;
 import io.warp10.standalone.StandalonePlasmaHandlerInterface;
@@ -30,12 +34,12 @@ public class DatalogStoreClient implements StoreClient {
 
   private final DatalogManager manager;
   private final StoreClient store;
-  
+
   public DatalogStoreClient(DatalogManager manager, StoreClient store) {
     this.manager = manager;
     this.store = store;
   }
-  
+
   @Override
   public GTSDecoderIterator fetch(FetchRequest req) throws IOException {
     return store.fetch(req);
@@ -63,8 +67,19 @@ public class DatalogStoreClient implements StoreClient {
   public void addPlasmaHandler(StandalonePlasmaHandlerInterface plasmaHandler) {
     store.addPlasmaHandler(plasmaHandler);
   }
-  
+
   public DatalogManager getDatalogManager() {
     return this.manager;
+  }
+
+  @Override
+  public void kvstore(KVStoreRequest request) throws IOException {
+    store.kvstore(request);
+    manager.kvstore(request);
+  }
+
+  @Override
+  public KVIterator<Entry<byte[], byte[]>> kvfetch(KVFetchRequest request) throws IOException {
+    return store.kvfetch(request);
   }
 }

--- a/warp10/src/main/java/io/warp10/standalone/datalog/FileBasedDatalogManager.java
+++ b/warp10/src/main/java/io/warp10/standalone/datalog/FileBasedDatalogManager.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2020-2023  SenX S.A.S.
+//   Copyright 2020-2025  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -52,6 +52,7 @@ import io.warp10.continuum.gts.GTSDecoder;
 import io.warp10.continuum.gts.GTSEncoder;
 import io.warp10.continuum.store.StoreClient;
 import io.warp10.continuum.store.thrift.data.DatalogRecord;
+import io.warp10.continuum.store.thrift.data.KVStoreRequest;
 import io.warp10.continuum.store.thrift.data.Metadata;
 import io.warp10.quasar.token.thrift.data.WriteToken;
 import io.warp10.standalone.StandaloneDirectoryClient;
@@ -77,6 +78,7 @@ public class FileBasedDatalogManager extends DatalogManager implements Runnable 
   public static final String CONFIG_DATALOG_MANAGER_FORWARD = "datalog.manager.forward";
   public static final String CONFIG_DATALOG_MANAGER_LOGUPDATES = "datalog.manager.logupdates";
   public static final String CONFIG_DATALOG_MANAGER_LOGDELETES = "datalog.manager.logdeletes";
+  public static final String CONFIG_DATALOG_MANAGER_LOGKVSTORES = "datalog.manager.logkvstores";
 
   public static final String CONFIG_DATALOG_FEEDER_ID = "datalog.feeder.id";
   public static final String CONFIG_DATALOG_FEEDER_HOST = "datalog.feeder.host";
@@ -166,6 +168,7 @@ public class FileBasedDatalogManager extends DatalogManager implements Runnable 
    */
   private final boolean logupdates;
   private final boolean logdeletes;
+  private final boolean logkvstores;
 
   private static final boolean REGISTER_UPDATES;
 
@@ -222,9 +225,10 @@ public class FileBasedDatalogManager extends DatalogManager implements Runnable 
       throw new RuntimeException("Missing Datalog id '" + CONFIG_DATALOG_MANAGER_ID + "'.");
     }
 
-    // Should we log UPDATE / DELETE records?
+    // Should we log UPDATE / DELETE / KVSTORE records?
     this.logupdates = "true".equals(WarpConfig.getProperty(CONFIG_DATALOG_MANAGER_LOGUPDATES, "true"));
     this.logdeletes = "true".equals(WarpConfig.getProperty(CONFIG_DATALOG_MANAGER_LOGDELETES, "true"));
+    this.logkvstores = "true".equals(WarpConfig.getProperty(CONFIG_DATALOG_MANAGER_LOGKVSTORES, "true"));
 
     if (null != WarpConfig.getProperty(CONFIG_DATALOG_MANAGER_FORWARD)) {
       String[] ids =  WarpConfig.getProperty(CONFIG_DATALOG_MANAGER_FORWARD).split(",");
@@ -349,8 +353,21 @@ public class FileBasedDatalogManager extends DatalogManager implements Runnable 
     if (null == metadata) {
       return;
     }
-    System.out.println("delete: " + token + " " + metadata + " " + start + " " + end);
+    //System.out.println("delete: " + token + " " + metadata + " " + start + " " + end);
     append(DatalogHelper.getDeleteRecord(id, token, metadata, start, end));
+  }
+
+  @Override
+  protected void kvstore(KVStoreRequest request) throws IOException {
+    if (!logkvstores) {
+      return;
+    }
+
+    if (null == request) {
+      append(null);
+    } else {
+      append(DatalogHelper.getKVStoreRecord(id, request));
+    }
   }
 
   @Override
@@ -360,6 +377,7 @@ public class FileBasedDatalogManager extends DatalogManager implements Runnable 
     if (null == record) {
       this.storeClient.store(null);
       this.storeClient.delete(null, null, Long.MAX_VALUE, Long.MAX_VALUE);
+      this.storeClient.kvstore(null);
       this.directoryClient.unregister(null);
       this.directoryClient.register(null);
       return;
@@ -408,6 +426,10 @@ public class FileBasedDatalogManager extends DatalogManager implements Runnable 
 
       case DELETE:
         this.storeClient.delete(record.getToken(), record.getMetadata(), record.getStart(), record.getStop());
+        break;
+
+      case KVSTORE:
+        this.storeClient.kvstore(record.getKvstorerequest());
         break;
     }
 
@@ -527,7 +549,7 @@ public class FileBasedDatalogManager extends DatalogManager implements Runnable 
         long count = 0L;
 
         while(reader.next(key, val)) {
-          System.out.println("VAL=" + DatalogHelper.getRecord(val.getBytes(), 0, val.getLength()));
+          //System.out.println("VAL=" + DatalogHelper.getRecord(val.getBytes(), 0, val.getLength()));
           count++;
         }
 
@@ -575,7 +597,7 @@ public class FileBasedDatalogManager extends DatalogManager implements Runnable 
         key[offset++] = (byte) ((l >>> 8) & 0xFFL);
         key[offset++] = (byte) (l & 0xFFL);
 
-        l = record.getMetadata().getClassId();
+        l = null == record.getMetadata() ? 0L : record.getMetadata().getClassId();
         key[offset++] = (byte) ((l >>> 56) & 0xFFL);
         key[offset++] = (byte) ((l >>> 48) & 0xFFL);
         key[offset++] = (byte) ((l >>> 40) & 0xFFL);
@@ -585,7 +607,7 @@ public class FileBasedDatalogManager extends DatalogManager implements Runnable 
         key[offset++] = (byte) ((l >>> 8) & 0xFFL);
         key[offset++] = (byte) (l & 0xFFL);
 
-        l = record.getMetadata().getLabelsId();
+        l = null == record.getMetadata() ? 0L : record.getMetadata().getLabelsId();
         key[offset++] = (byte) ((l >>> 56) & 0xFFL);
         key[offset++] = (byte) ((l >>> 48) & 0xFFL);
         key[offset++] = (byte) ((l >>> 40) & 0xFFL);
@@ -625,6 +647,7 @@ public class FileBasedDatalogManager extends DatalogManager implements Runnable 
       while(true) {
         // Should we close the current file and reopen a new one?
         if (done.get() || null == datalog || size.get() > MAXSIZE || System.currentTimeMillis() - start.get() > MAXTIME) {
+
           try {
             lock.lockInterruptibly();
 

--- a/warp10/src/main/java/io/warp10/standalone/datalog/TCPDatalogConsumer.java
+++ b/warp10/src/main/java/io/warp10/standalone/datalog/TCPDatalogConsumer.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2020-2023  SenX S.A.S.
+//   Copyright 2020-2025  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -540,7 +540,7 @@ public class TCPDatalogConsumer extends Thread implements DatalogConsumer {
           DatalogHelper.deserialize(msg.getRecord(), record);
 
           //
-          // If our id or an exluded one created this message, ignore it, it would otherwise create a loop
+          // If our id or an excluded one created this message, ignore it, it would otherwise create a loop
           //
 
           if (id.equals(record.getId()) || this.excluded.contains(record.getId())) {
@@ -550,219 +550,221 @@ public class TCPDatalogConsumer extends Thread implements DatalogConsumer {
             continue;
           }
 
-          //
-          // Recompute the class and labels id with our own keys
-          //
+          if (!DatalogRecordType.KVSTORE.equals(record.getType())) {
+            //
+            // Recompute the class and labels id with our own keys
+            //
 
-          long classid = GTSHelper.classId(CLASS_KEYS, record.getMetadata().getName());
-          long labelsid = GTSHelper.labelsId(LABELS_KEYS, record.getMetadata().getLabels());
+            long classid = GTSHelper.classId(CLASS_KEYS, record.getMetadata().getName());
+            long labelsid = GTSHelper.labelsId(LABELS_KEYS, record.getMetadata().getLabels());
 
-          record.getMetadata().setClassId(classid);
-          record.getMetadata().setLabelsId(labelsid);
+            record.getMetadata().setClassId(classid);
+            record.getMetadata().setLabelsId(labelsid);
 
-          //
-          // Check shards if needed
-          //
+            //
+            // Check shards if needed
+            //
 
-          if (hasShards) {
-            // compute shard id
-            long sid = DatalogHelper.getShardId(classid, labelsid, shardShift);
+            if (hasShards) {
+              // compute shard id
+              long sid = DatalogHelper.getShardId(classid, labelsid, shardShift);
 
-            boolean matched = false;
+              boolean matched = false;
 
-            for (int i = 0; i < modulus.length; i++) {
-              if (0 != modulus[i] && remainder[i] == sid % modulus[i]) {
-                matched = true;
-                break;
+              for (int i = 0; i < modulus.length; i++) {
+                if (0 != modulus[i] && remainder[i] == sid % modulus[i]) {
+                  matched = true;
+                  break;
+                }
               }
-            }
 
-            if (!matched) {
-              continue;
-            }
-          }
-
-          //
-          // Execute the filtering macro if set.
-          // If 'datalog.consumer.macro.data' is false, the macro is
-          // expected to return a boolean which, if true, will
-          // accept the message.
-          // The macro is fed with a GTS Encoder with the metadata
-          // of the GTS subject of the message and a STRING with
-          // the type of message (From DatalogRecordType, UPDATE, DELETE, REGISTER, UNREGISTER).
-          // If 'datalog.consumer.macro.data' is true, the macro
-          // is fed with an encoder as above but with the actual data included for UPDATE messages.
-          // The macro will then have the ability to alter the encoder to update metadata
-          // and/or data. It is then expected to return a boolean or an encoder.
-          //
-          // The macro is called in the consumer thread, not in the worker threads so metadata alterations
-          // are reflected in the choice of the worker to respect the sequence of messages per GTS
-          //
-
-          if (null != macro) {
-            stack.show();
-            stack.clear();
-            Map<String,Object> tokenMap = null;
-
-            if (macroToken && null != record.getToken()) {
-              tokenMap = TOKENDUMP.mapFromToken(record.getToken());
-            }
-
-            if (!macroData) {
-              GTSEncoder encoder = new GTSEncoder(0L);
-              encoder.setMetadata(record.getMetadata());
-
-              stack.push(tokenMap);
-              stack.push(encoder);
-              stack.push(record.getType().name());
-              stack.push(macro);
-              RUN.apply(stack);
-              if (0 == stack.depth() || !Boolean.TRUE.equals(stack.peek())) {
-                stack.show();
-                stack.clear();
-                Sensision.update(SensisionConstants.SENSISION_CLASS_DATALOG_SKIPPED, labels, 1);
+              if (!matched) {
                 continue;
               }
-            } else {
-              GTSEncoder encoder;
+            }
 
-              if (DatalogRecordType.UPDATE.equals(record.getType())) {
-                GTSDecoder decoder = new GTSDecoder(record.getBaseTimestamp(), record.bufferForEncoder());
-                decoder.next();
-                encoder = decoder.getEncoder();
-              } else {
-                encoder = new GTSEncoder(0L);
+            //
+            // Execute the filtering macro if set.
+            // If 'datalog.consumer.macro.data' is false, the macro is
+            // expected to return a boolean which, if true, will
+            // accept the message.
+            // The macro is fed with a GTS Encoder with the metadata
+            // of the GTS subject of the message and a STRING with
+            // the type of message (From DatalogRecordType, UPDATE, DELETE, REGISTER, UNREGISTER).
+            // If 'datalog.consumer.macro.data' is true, the macro
+            // is fed with an encoder as above but with the actual data included for UPDATE messages.
+            // The macro will then have the ability to alter the encoder to update metadata
+            // and/or data. It is then expected to return a boolean or an encoder.
+            //
+            // The macro is called in the consumer thread, not in the worker threads so metadata alterations
+            // are reflected in the choice of the worker to respect the sequence of messages per GTS
+            //
+
+            if (null != macro) {
+              stack.show();
+              stack.clear();
+              Map<String,Object> tokenMap = null;
+
+              if (macroToken && null != record.getToken()) {
+                tokenMap = TOKENDUMP.mapFromToken(record.getToken());
               }
-              encoder.setMetadata(record.getMetadata());
 
-              // Call the macro with the token, the encoder and the record type
-              stack.push(tokenMap);
-              stack.push(encoder);
-              stack.push(record.getType().name());
-              stack.push(macro);
-              RUN.apply(stack);
+              if (!macroData) {
+                GTSEncoder encoder = new GTSEncoder(0L);
+                encoder.setMetadata(record.getMetadata());
 
-              // Skip if the macro did not return a boolean TRUE
-              boolean skip = !(stack.depth() >= 1 && Boolean.TRUE.equals(stack.peek()));
+                stack.push(tokenMap);
+                stack.push(encoder);
+                stack.push(record.getType().name());
+                stack.push(macro);
+                RUN.apply(stack);
+                if (0 == stack.depth() || !Boolean.TRUE.equals(stack.peek())) {
+                  stack.show();
+                  stack.clear();
+                  Sensision.update(SensisionConstants.SENSISION_CLASS_DATALOG_SKIPPED, labels, 1);
+                  continue;
+                }
+              } else {
+                GTSEncoder encoder;
 
-              boolean updateIds = false;
+                if (DatalogRecordType.UPDATE.equals(record.getType())) {
+                  GTSDecoder decoder = new GTSDecoder(record.getBaseTimestamp(), record.bufferForEncoder());
+                  decoder.next();
+                  encoder = decoder.getEncoder();
+                } else {
+                  encoder = new GTSEncoder(0L);
+                }
+                encoder.setMetadata(record.getMetadata());
 
-              if (!skip) {
-                // Discard the boolean
-                stack.pop();
+                // Call the macro with the token, the encoder and the record type
+                stack.push(tokenMap);
+                stack.push(encoder);
+                stack.push(record.getType().name());
+                stack.push(macro);
+                RUN.apply(stack);
 
-                // The macro returned a GTS or an ENCODER, update the record with the
-                // metadata and the content (for UPDATE records)
-                GTSEncoder forwardEncoder = null;
-                if (stack.depth() > 0) {
-                  if (stack.peek() instanceof GeoTimeSerie) {
-                    GeoTimeSerie gts = (GeoTimeSerie) stack.pop();
-                    encoder = new GTSEncoder(0L);
-                    encoder.setMetadata(gts.getMetadata());
-                    encoder.encode(gts);
-                    updateIds = true;
-                  } else if (stack.peek() instanceof GTSEncoder) {
-                    encoder = (GTSEncoder) stack.pop();
-                    updateIds = true;
-                  } else if (stack.peek() instanceof List) {
-                    // The macro returned a list of two elements, either GTS or ENCODER. The first one is the
-                    // content to use for the action (UPDATE/REGISTER/UNREGISTER/DELETE), the second one is
-                    // the content to forward.
-                    List<Object> l = (List<Object>) stack.pop();
-                    if (2 == l.size()) {
-                      Object update = l.get(0);
-                      Object forward = l.get(1);
+                // Skip if the macro did not return a boolean TRUE
+                boolean skip = !(stack.depth() >= 1 && Boolean.TRUE.equals(stack.peek()));
 
-                      if (update instanceof GeoTimeSerie) {
-                        GeoTimeSerie gts = (GeoTimeSerie) update;
-                        encoder = new GTSEncoder(0L);
-                        encoder.setMetadata(gts.getMetadata());
-                        encoder.encode(gts);
-                        updateIds = true;
-                      } else if (update instanceof GTSEncoder) {
-                        encoder = (GTSEncoder) update;
-                        updateIds = true;
+                boolean updateIds = false;
+
+                if (!skip) {
+                  // Discard the boolean
+                  stack.pop();
+
+                  // The macro returned a GTS or an ENCODER, update the record with the
+                  // metadata and the content (for UPDATE records)
+                  GTSEncoder forwardEncoder = null;
+                  if (stack.depth() > 0) {
+                    if (stack.peek() instanceof GeoTimeSerie) {
+                      GeoTimeSerie gts = (GeoTimeSerie) stack.pop();
+                      encoder = new GTSEncoder(0L);
+                      encoder.setMetadata(gts.getMetadata());
+                      encoder.encode(gts);
+                      updateIds = true;
+                    } else if (stack.peek() instanceof GTSEncoder) {
+                      encoder = (GTSEncoder) stack.pop();
+                      updateIds = true;
+                    } else if (stack.peek() instanceof List) {
+                      // The macro returned a list of two elements, either GTS or ENCODER. The first one is the
+                      // content to use for the action (UPDATE/REGISTER/UNREGISTER/DELETE), the second one is
+                      // the content to forward.
+                      List<Object> l = (List<Object>) stack.pop();
+                      if (2 == l.size()) {
+                        Object update = l.get(0);
+                        Object forward = l.get(1);
+
+                        if (update instanceof GeoTimeSerie) {
+                          GeoTimeSerie gts = (GeoTimeSerie) update;
+                          encoder = new GTSEncoder(0L);
+                          encoder.setMetadata(gts.getMetadata());
+                          encoder.encode(gts);
+                          updateIds = true;
+                        } else if (update instanceof GTSEncoder) {
+                          encoder = (GTSEncoder) update;
+                          updateIds = true;
+                        } else {
+                          skip = true;
+                        }
+
+                        // Create 'forward' wrapper
+                        if (forward instanceof GeoTimeSerie) {
+                          GeoTimeSerie gts = (GeoTimeSerie) forward;
+                          forwardEncoder = new GTSEncoder(0L);
+                          forwardEncoder.setMetadata(gts.getMetadata());
+                          forwardEncoder.encode(gts);
+                          updateIds = true;
+                        } else if (forward instanceof GTSEncoder) {
+                          forwardEncoder = (GTSEncoder) forward;
+                          updateIds = true;
+                        } else {
+                          skip = true;
+                        }
                       } else {
                         skip = true;
                       }
 
-                      // Create 'forward' wrapper
-                      if (forward instanceof GeoTimeSerie) {
-                        GeoTimeSerie gts = (GeoTimeSerie) forward;
-                        forwardEncoder = new GTSEncoder(0L);
-                        forwardEncoder.setMetadata(gts.getMetadata());
-                        forwardEncoder.encode(gts);
-                        updateIds = true;
-                      } else if (forward instanceof GTSEncoder) {
-                        forwardEncoder = (GTSEncoder) forward;
-                        updateIds = true;
-                      } else {
-                        skip = true;
+                      // Copy the forwardEncoder as a wrapper in the record. This will trigger the storing of this
+                      // encoder instead of the one in 'encoder' but will forward the latter if forwarding should happen.
+                      if (null != forwardEncoder) {
+                        GTSWrapper wrapper = GTSWrapperHelper.fromGTSEncoderToGTSWrapper(forwardEncoder, false);
+                        record.setForward(wrapper);
                       }
                     } else {
                       skip = true;
                     }
 
-                    // Copy the forwardEncoder as a wrapper in the record. This will trigger the storing of this
-                    // encoder instead of the one in 'encoder' but will forward the latter if forwarding should happen.
-                    if (null != forwardEncoder) {
-                      GTSWrapper wrapper = GTSWrapperHelper.fromGTSEncoderToGTSWrapper(forwardEncoder, false);
-                      record.setForward(wrapper);
+                    if (!skip) {
+                      // Copy the encoder
+                      record.setMetadata(encoder.getMetadata());
+                      if (DatalogRecordType.UPDATE.equals(record.getType())) {
+                        record.setBaseTimestamp(encoder.getBaseTimestamp());
+                        record.setEncoder(encoder.getBytes());
+                      }
+
+                      // If there is a map left on the stack, update the token
+                      if (stack.depth() > 0 && stack.peek() instanceof Map) {
+                        tokenMap = (Map<String,Object>) stack.pop();
+                        // force token type
+                        tokenMap.put(TOKENGEN.KEY_TYPE, TokenType.WRITE.toString());
+                        record.setToken((WriteToken) TOKENGEN.tokenFromMap(tokenMap, "Datalog", Long.MAX_VALUE));
+                      }
+                      updateIds = true;
                     }
-                  } else {
-                    skip = true;
                   }
+                }
 
-                  if (!skip) {
-                    // Copy the encoder
-                    record.setMetadata(encoder.getMetadata());
-                    if (DatalogRecordType.UPDATE.equals(record.getType())) {
-                      record.setBaseTimestamp(encoder.getBaseTimestamp());
-                      record.setEncoder(encoder.getBytes());
-                    }
+                if (skip) {
+                  stack.show();
+                  stack.clear();
+                  Sensision.update(SensisionConstants.SENSISION_CLASS_DATALOG_SKIPPED, labels, 1);
+                  continue;
+                }
 
-                    // If there is a map left on the stack, update the token
-                    if (stack.depth() > 0 && stack.peek() instanceof Map) {
-                      tokenMap = (Map<String,Object>) stack.pop();
-                      // force token type
-                      tokenMap.put(TOKENGEN.KEY_TYPE, TokenType.WRITE.toString());
-                      record.setToken((WriteToken) TOKENGEN.tokenFromMap(tokenMap, "Datalog", Long.MAX_VALUE));
-                    }
-                    updateIds = true;
+                //
+                // Update the class and label ids if metadata were possibly changed.
+                // This is so the feeders later have a valid set of ids to use for sharding.
+                //
+
+                if (updateIds) {
+                  long cid = GTSHelper.classId(CLASS_KEYS, record.getMetadata().getName());
+                  long lid = GTSHelper.labelsId(LABELS_KEYS, record.getMetadata().getLabels());
+
+                  record.getMetadata().setClassId(cid);
+                  record.getMetadata().setLabelsId(lid);
+
+                  if (record.isSetForward()) {
+                    cid = GTSHelper.classId(CLASS_KEYS, record.getForward().getMetadata().getName());
+                    lid = GTSHelper.labelsId(LABELS_KEYS, record.getForward().getMetadata().getLabels());
+
+                    record.getForward().getMetadata().setClassId(cid);
+                    record.getForward().getMetadata().setLabelsId(lid);
                   }
                 }
               }
-
-              if (skip) {
-                stack.show();
-                stack.clear();
-                Sensision.update(SensisionConstants.SENSISION_CLASS_DATALOG_SKIPPED, labels, 1);
-                continue;
-              }
-
-              //
-              // Update the class and label ids if metadata were possibly changed.
-              // This is so the feeders later have a valid set of ids to use for sharding.
-              //
-
-              if (updateIds) {
-                long cid = GTSHelper.classId(CLASS_KEYS, record.getMetadata().getName());
-                long lid = GTSHelper.labelsId(LABELS_KEYS, record.getMetadata().getLabels());
-
-                record.getMetadata().setClassId(cid);
-                record.getMetadata().setLabelsId(lid);
-
-                if (record.isSetForward()) {
-                  cid = GTSHelper.classId(CLASS_KEYS, record.getForward().getMetadata().getName());
-                  lid = GTSHelper.labelsId(LABELS_KEYS, record.getForward().getMetadata().getLabels());
-
-                  record.getForward().getMetadata().setClassId(cid);
-                  record.getForward().getMetadata().setLabelsId(lid);
-                }
-              }
+              stack.show();
+              stack.clear();
             }
-            stack.show();
-            stack.clear();
           }
 
           //

--- a/warp10/src/main/java/io/warp10/standalone/datalog/TCPDatalogFeeder.java
+++ b/warp10/src/main/java/io/warp10/standalone/datalog/TCPDatalogFeeder.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2020-2022  SenX S.A.S.
+//   Copyright 2020-2025  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ public class TCPDatalogFeeder extends Thread {
   private static final Logger LOG = LoggerFactory.getLogger(TCPDatalogFeeder.class);
 
   public static final String DEFAULT_HOST = "127.0.0.1";
-  public static final String DEFAULT_PORT = "3564"; // speeds 'DLNG', DataLog Next Generation
+  public static final String DEFAULT_PORT = "3564"; // spells 'DLNG', DataLog Next Generation
   private static final String DEFAULT_MAXCLIENTS = "2";
   private static final String DEFAULT_BACKLOG = "2";
 

--- a/warp10/src/main/java/io/warp10/standalone/datalog/TCPDatalogFeederWorker.java
+++ b/warp10/src/main/java/io/warp10/standalone/datalog/TCPDatalogFeederWorker.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2020-2023  SenX S.A.S.
+//   Copyright 2020-2025  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -63,7 +63,6 @@ import io.warp10.script.WarpScriptStack;
 import io.warp10.script.binary.ADD;
 import io.warp10.script.functions.ECDH;
 import io.warp10.script.functions.ECPRIVATE;
-import io.warp10.script.functions.ECPUBLIC;
 import io.warp10.script.functions.ECSIGN;
 import io.warp10.script.functions.HASH;
 import io.warp10.script.functions.REVERSE;
@@ -141,7 +140,6 @@ public class TCPDatalogFeederWorker extends Thread {
       //
 
       ECPrivateKey eccPrivate = null;
-      ECPublicKey eccPublic = null;
 
       String eccpri = WarpConfig.getProperty(FileBasedDatalogManager.CONFIG_DATALOG_FEEDER_ECC_PRIVATE);
 
@@ -701,7 +699,7 @@ public class TCPDatalogFeederWorker extends Thread {
 
           if (!currentFile.equals(next)) {
             len = fs.getFileStatus(path).getLen();
-            System.out.println("FILE=" + currentFile + " POS=" + position + " LEN=" + len + " NEXT=" + next);
+            //System.out.println("FILE=" + currentFile + " POS=" + position + " LEN=" + len + " NEXT=" + next);
             if (len == position + SEQFILE_SYNC_MARKER_LEN) {
               previousFile = currentFile;
               currentFile = next;

--- a/warp10/src/main/thrift/io_warp10_continuum_store_thrift_data.thrift
+++ b/warp10/src/main/thrift/io_warp10_continuum_store_thrift_data.thrift
@@ -1,5 +1,5 @@
 //
-//   Copyright 2018-2024  SenX S.A.S.
+//   Copyright 2018-2025  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -448,6 +448,7 @@ enum DatalogRecordType {
   DELETE = 2,
   REGISTER = 3,
   UNREGISTER = 4,
+  KVSTORE = 5,
 }
 
 struct DatalogRecord {
@@ -506,9 +507,14 @@ struct DatalogRecord {
   10: optional GTSWrapper forward,
   
   /**
-   * Write token associated with the request. This is needed when using FDB with tenant prefixes.
+   * Write token associated with the request. This is needed when using FDB with tenant prefixes of KVPrefixes
    */
   11: optional io_warp10_quasar_token_thrift_data.WriteToken token,
+  
+  /**
+   * KVStoreRequest instance when message is containing a KVStore mutation
+   */
+  12: optional KVStoreRequest kvstorerequest,
 }
 
 enum DatalogMessageType {
@@ -563,4 +569,38 @@ struct DatalogMessage {
    * Reference to use in the commit message
    */
   52: optional string commitref,
+}
+
+//
+// KVStore related structures
+//
+
+struct KVStoreRequest {
+  1: list<binary> keys,
+  2: list<binary> values,
+    /**
+   * Write token associated with the request. This is needed to add/strip prefixes such as the FDB tenant prefix.
+   */
+  3: io_warp10_quasar_token_thrift_data.WriteToken token,  
+}
+
+struct KVFetchRequest {
+  /**
+   * Start key (inclusive)
+   */
+  1: optional binary start,
+  /**
+   * End key (exclusive)
+   */
+  2: optional binary stop,
+  
+  /**
+   * Explicit list of keys
+   */
+  3: optional list<binary> keys,
+  
+      /**
+   * Read token associated with the request. This is needed to add/strip prefixes.
+   */
+  4: io_warp10_quasar_token_thrift_data.ReadToken token,  
 }


### PR DESCRIPTION
This PR adds a Key/Value store feature to Warp 10, enabling the storage of arbitrary Key/Value pairs for the following storage engines:

- LevelDB
- in memory
- FoundationDB for both standalone+ and distributed versions

Additionally, stored K/V pairs can be replicated via the Datalog mechanism.

WarpLib functions `KVSTORE` and `KVLOAD` allow to store and retrieved stored K/V pairs.

Retrieval is either range or key based, allowing to scan the key space or access specific keys explicitely.

Tenant prefixes are supported for FoundationDB based versions.

Optional custom prefix can be added to keys prior to storage to allow for user segregation by key spaces.