### PR TITLE
Selective MSTORE

### DIFF
--- a/warp10/src/main/java/io/warp10/script/functions/MSTORE.java
+++ b/warp10/src/main/java/io/warp10/script/functions/MSTORE.java
@@ -1,5 +1,5 @@
 //
-//   Copyright 2022  SenX S.A.S.
+//   Copyright 2022-2025  SenX S.A.S.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@ public class MSTORE extends NamedWarpScriptFunction implements WarpScriptStackFu
 
       Object symbol = itr.next();
 
-      if (null == symbol) {
+      if (null == symbol || !variables.containsKey(symbol)) {
         continue;
       }
 


### PR DESCRIPTION
Yes, it is a breaking change.
But this signature was never ever documented.

When combined with MCSTORE, this allows a easy way to store parameters, then default parameters :
```
<%
  [ 'a' 'b' ] MSTORE
  {
    'a' 0
    'b' 0
  } MCSTORE
  $a $b +
%> 'm' STORE

{ 'b' 4 } @m
```

