### PR TITLE
Update fdb-java dependency version to 7.3.68

### DIFF
--- a/warp10/build.gradle
+++ b/warp10/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     api 'org.bouncycastle:bcpg-jdk18on:1.78.1'
 
     // https://mvnrepository.com/artifact/org.foundationdb/fdb-java
-    api 'org.foundationdb:fdb-java:7.1.37'
+    api 'org.foundationdb:fdb-java:7.3.68'
 
     api 'org.apache.hadoop:hadoop-common:3.3.6'
     api 'org.apache.hadoop:hadoop-mapreduce-client-core:3.3.6'


### PR DESCRIPTION
:wave: 

This PR allows to define FoundationDB `api_version` to `730`. The `fdb-java` dep is backward compatible, meaning `710` will still be a valid api version.