### PR TITLE
catch filesystem exception and ignore them while discovering runners

### DIFF
--- a/warp10/src/main/java/io/warp10/script/ScriptRunner.java
+++ b/warp10/src/main/java/io/warp10/script/ScriptRunner.java
@@ -29,6 +29,7 @@ import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
+import java.nio.file.FileSystemException;
 import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -956,6 +957,7 @@ public class ScriptRunner extends Thread {
       }
 
     } catch (IOException ioe) {
+    } catch (FileSystemException fse){
     }
 
 


### PR DESCRIPTION
Runner thread may crash during a rsync in runners directory.
